### PR TITLE
Added __d_to_ull, __f_to_ull, __ll_to_d, __ull_to_d, and __ull_to_f

### DIFF
--- a/lib/asm/non_matchings/unknown_0CA730/__f_to_ll.s
+++ b/lib/asm/non_matchings/unknown_0CA730/__f_to_ll.s
@@ -14,6 +14,7 @@ glabel __f_to_ll
 /* 0CA760 800C9B60 03E00008 */  jr    $ra
 /* 0CA764 800C9B64 0002103F */   dsra32 $v0, $v0, 0
 
+glabel __d_to_ull
 /* 0CA768 800C9B68 444EF800 */  cfc1  $t6, $31
 /* 0CA76C 800C9B6C 24020001 */  li    $v0, 1
 /* 0CA770 800C9B70 44C2F800 */  ctc1  $v0, $31
@@ -58,6 +59,7 @@ glabel __f_to_ll
 /* 0CA800 800C9C00 03E00008 */  jr    $ra
 /* 0CA804 800C9C04 0002103F */   dsra32 $v0, $v0, 0
 
+glabel __f_to_ull
 /* 0CA808 800C9C08 444EF800 */  cfc1  $t6, $31
 /* 0CA80C 800C9C0C 24020001 */  li    $v0, 1
 /* 0CA810 800C9C10 44C2F800 */  ctc1  $v0, $31
@@ -101,6 +103,7 @@ glabel __f_to_ll
 /* 0CA89C 800C9C9C 03E00008 */  jr    $ra
 /* 0CA8A0 800C9CA0 0002103F */   dsra32 $v0, $v0, 0
 
+glabel __ll_to_d
 /* 0CA8A4 800C9CA4 AFA40000 */  sw    $a0, ($sp)
 /* 0CA8A8 800C9CA8 AFA50004 */  sw    $a1, 4($sp)
 /* 0CA8AC 800C9CAC DFAE0000 */  ld    $t6, ($sp)

--- a/lib/asm/non_matchings/unknown_0CA730/__ll_to_f.s
+++ b/lib/asm/non_matchings/unknown_0CA730/__ll_to_f.s
@@ -6,6 +6,7 @@ glabel __ll_to_f
 /* 0CA8CC 800C9CCC 03E00008 */  jr    $ra
 /* 0CA8D0 800C9CD0 46A02020 */   cvt.s.l $f0, $f4
 
+glabel __ull_to_d
 /* 0CA8D4 800C9CD4 AFA40000 */  sw    $a0, ($sp)
 /* 0CA8D8 800C9CD8 AFA50004 */  sw    $a1, 4($sp)
 /* 0CA8DC 800C9CDC DFAE0000 */  ld    $t6, ($sp)
@@ -21,6 +22,7 @@ glabel __ll_to_f
 /* 0CA900 800C9D00 03E00008 */  jr    $ra
 /* 0CA904 800C9D04 00000000 */   nop   
 
+glabel __ull_to_f
 /* 0CA908 800C9D08 AFA40000 */  sw    $a0, ($sp)
 /* 0CA90C 800C9D0C AFA50004 */  sw    $a1, 4($sp)
 /* 0CA910 800C9D10 DFAE0000 */  ld    $t6, ($sp)


### PR DESCRIPTION
While these weren't used in the vanilla game, they are very useful for modding purposes.