### PR TITLE
Verify NON_MATCHING and NON_EQUIVALENT builds

### DIFF
--- a/.github/workflows/VerifyBuild.yml
+++ b/.github/workflows/VerifyBuild.yml
@@ -3,8 +3,8 @@ name: Verify Build
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  # pull_request:
+  #   branches: [ master ]
 
 jobs:
   build:
@@ -52,3 +52,15 @@ jobs:
       
     - name: Verify Build
       run: if [[ $(sha1sum -c --quiet sha1/dkr.us_1.0.sha1) = "" ]]; then echo "Signature OK"; else echo "Failed"; exit 1; fi
+
+    - name: Clean Build
+      run: make clean
+
+    - name: Verify NON_MATCHING
+      run: make NON_MATCHING=1
+
+    - name: Clean Again
+      run: make clean
+
+    - name: Verify NON_EQUIVALENT
+      run: make NON_EQUIVALENT=1

--- a/.github/workflows/VerifyPR.yml
+++ b/.github/workflows/VerifyPR.yml
@@ -52,3 +52,15 @@ jobs:
 
     - name: Verify Build
       run: if [[ $(sha1sum -c --quiet sha1/dkr.us_1.0.sha1) = "" ]]; then echo "Signature OK"; else echo "Failed"; exit 1; fi
+
+    - name: Clean Build
+      run: make clean
+
+    - name: Verify NON_MATCHING
+      run: make NON_MATCHING=1
+
+    - name: Clean Again
+      run: make clean
+
+    - name: Verify NON_EQUIVALENT
+      run: make NON_EQUIVALENT=1


### PR DESCRIPTION
Make the workflows verify that NON_MATCHING and NON_EQUIVALENT builds are good as well, and only run VerifyBuild on pushes so it keeps PR's clean