### PR TITLE
Define NON_MATCHING when building with NON_EQUIVALENT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ ifeq ($(NON_MATCHING),1)
 endif
 ifeq ($(NON_EQUIVALENT),1)
   DEFINES += NON_EQUIVALENT=1
+  DEFINES += NON_MATCHING=1
+  NON_MATCHING = 1
 endif
 
 # Whether to hide commands or not


### PR DESCRIPTION
Make NON_EQUIVALENT builds define NON_MATCHING by default, which will automatically fix build errors for NON_EQUIVALENT.