### PR TITLE
fix trailing spaces in generated score

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,13 @@ s32 is_drumstick_unlocked(void) {
 ```
 
 <!-- README_SCORE_BEGIN -->
-As of October 24th, 2022, this is our current score:
+As of October 28, 2022, this is our current score:
 ```
  =======================================================
          ADVENTURE ONE (ASM -> C Decompilation)
- ------------------- 34.02% Complete -------------------
-              # Decompiled functions: 1301
-               # GLOBAL_ASM remaining: 532
+ ------------------- 34.09% Complete -------------------
+              # Decompiled functions: 1306
+               # GLOBAL_ASM remaining: 527
               # NON_MATCHING functions: 12
            # NON_EQUIVALENT WIP functions: 92
  --------------------- Game Status ---------------------

--- a/tools/python/score_display.py
+++ b/tools/python/score_display.py
@@ -75,7 +75,7 @@ class ScoreDisplay:
         
     def makeLine(self, char, length, title=None):
         if title == None:
-            return ' ' + (char * length) + ' \n'
+            return ' ' + (char * length) + '\n'
         else:
             lineSideLength = (length - len(title) - 2) // 2
             leftLength = lineSideLength
@@ -84,11 +84,12 @@ class ScoreDisplay:
                 rightLength += 1
             if leftLength + rightLength <= 0:
                 if leftLength + rightLength == 0:
-                    return '  ' + title + ' \n'
+                    return '  ' + title + '\n'
                 else:
-                    return ' ' + title + ' \n'
+                    return ' ' + title + '\n'
             else:
-                return ' ' + (char * leftLength) + ' ' + title + ' ' + (char * rightLength) + ' \n'
+                return ' ' + (char * leftLength) + ' ' + title + \
+                        (' ' + char * rightLength if char != ' ' else '') + '\n'
         
     def getGameStatusDisplay(self, status, dashLen):
         out = ''

--- a/update-score.sh
+++ b/update-score.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-export NEW_SCORE=$(python3 ./tools/python/score.py)
+export NEW_SCORE="$(python3 ./tools/python/score.py)"
 python3 - <<'EOF' > README.md.tmp
 import sys
 import os


### PR DESCRIPTION
`tools/python/score_display.py` added trailing whitespace to the score which was annoying when pasting it into the README as it made git mad