### PR TITLE
add update score to verifyBuild

### DIFF
--- a/.github/workflows/VerifyBuild.yml
+++ b/.github/workflows/VerifyBuild.yml
@@ -51,6 +51,16 @@ jobs:
     - name: Verify Build
       run: if [[ $(sha1sum -c --quiet sha1/dkr.us_1.0.sha1) = "" ]]; then echo "Signature OK"; else echo "Failed"; exit 1; fi
 
+    - name: Update Score
+      run: ./update-score.sh
+
+    - name: Commit Score Update
+      uses: test-room-7/action-update-file@v1
+      with:
+          file-path: README.md
+          commit-msg: Update score
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Clean Build
       run: make clean
 


### PR DESCRIPTION
- On VerifyBuild (runs on commits on master), will run `./update-score.sh` and commit the changes made to `README.md`
- `secrets.GITHUB_TOKEN` shouldn't need to be explicitly added, as long as `Repository Settings > Actions > General > Workflow Permissions > Read and Write permissions` is enabled for the repo.
- If there are no changes to `README.md` after running `./update-score.sh`, it just wont commit anything (but if date changes, it will)

Tested it on my fork https://github.com/tonyspumoni/Diddy-Kong-Racing (latest commit just shows it updating the date, but thats only because I force pushed and overwrote the one that did it automatically)

