### PR TITLE
Updated generate_ctx script

### DIFF
--- a/include/macros.h
+++ b/include/macros.h
@@ -62,4 +62,7 @@
 
 #define ABSF(x) (x < 0.f ? -x : x)
 
+// Used to suppress warnings in the ./generate_ctx.sh script.
+#define INCONSISTENT 
+
 #endif

--- a/src/object_functions.h
+++ b/src/object_functions.h
@@ -1,6 +1,7 @@
 #ifndef _OBJECT_FUNCTIONS_H_
 #define _OBJECT_FUNCTIONS_H_
 
+#include "macros.h"
 #include "types.h"
 #include "structs.h"
 #include "level_object_entries.h"
@@ -428,10 +429,10 @@ void obj_loop_exit(Object *obj, s32 updateRate);
 void obj_loop_fish(Object *obj, s32 updateRate);
 void obj_loop_scenery(Object *obj, s32 updateRate);
 void obj_init_midifade(Object *obj, LevelObjectEntry_MidiFade *entry);
-void obj_init_butterfly();
+INCONSISTENT void obj_init_butterfly();
 void obj_init_trigger(Object *obj, LevelObjectEntry_Trigger *entry);
-void obj_init_animation();
-void obj_init_lensflareswitch();
+INCONSISTENT void obj_init_animation();
+INCONSISTENT void obj_init_lensflareswitch();
 void obj_init_lensflare(Object *obj, LevelObjectEntry_LensFlare *entry);
 void obj_init_weaponballoon(Object *obj, LevelObjectEntry_WeaponBalloon *entry);
 void obj_init_door(Object *obj, LevelObjectEntry_Door *entry);

--- a/src/objects.h
+++ b/src/objects.h
@@ -343,7 +343,7 @@ Object **func_8000E988(s32 *arg0, s32 *cnt);
 s32 getObjectCount(void);
 s32 func_8000E9C0(void);
 void func_8000E9D0(Object *arg0);
-void gParticlePtrList_addObject();
+void gParticlePtrList_addObject(Object*);
 s32 func_80010018(void);
 s32 func_80010028(s32 arg0);
 void func_80011390(void);

--- a/src/objects.h
+++ b/src/objects.h
@@ -343,7 +343,7 @@ Object **func_8000E988(s32 *arg0, s32 *cnt);
 s32 getObjectCount(void);
 s32 func_8000E9C0(void);
 void func_8000E9D0(Object *arg0);
-void gParticlePtrList_addObject(Object*);
+void gParticlePtrList_addObject(Object *);
 s32 func_80010018(void);
 s32 func_80010028(s32 arg0);
 void func_80011390(void);

--- a/src/particles.c
+++ b/src/particles.c
@@ -1325,7 +1325,7 @@ void func_800B22FC(Particle2 *arg0, s32 arg1) {
         }
         arg0->unk38.half.unk3A -= D_80127C80;
         if (arg0->unk38.half.unk3A <= 0) {
-            gParticlePtrList_addObject(arg0);
+            gParticlePtrList_addObject((Object*) arg0);
         } else {
             if (arg0->unk60_halfs.unk60 == 0) {
                 arg0->unk5C_halfs.unk5C += D_80127C80 * arg0->unk5C_halfs.unk5E;

--- a/src/unknown_003260.h
+++ b/src/unknown_003260.h
@@ -118,7 +118,7 @@ void alSndPNew(audioMgrConfig *c);
 void func_80004604(u8 *arg0, u8 arg1);
 u8 func_8000461C(u8 *arg0);
 void func_80004638(ALBank *bnk, s16 sndIndx, s32 arg2);
-void func_8000488C();
+INCONSISTENT void func_8000488C();
 void func_800049D8(void);
 void func_800049F8(s32 soundMask, s16 type, u32 volume);
 u16 get_sound_channel_volume(u8 arg0);

--- a/tools/python/m2ctx.py
+++ b/tools/python/m2ctx.py
@@ -86,7 +86,7 @@ def collect_func_from_regex(filename, filetext, regex, data):
     for match in defs:
         typeAndName = cleanup_string(match.group(1)).split()
         funcType = cleanup_string(' '.join(typeAndName[0:-1]))
-        if funcType == 'return' or funcType == "else":
+        if funcType == 'return' or funcType == "else" or funcType.startswith('INCONSISTENT'):
             continue; # Skip false matches
         funcName = cleanup_string(typeAndName[-1])
         args = get_cleaned_args(match.group(2))
@@ -149,7 +149,7 @@ def collect_typedefs(filename, filetext, data):
         }
 
 # This regex extracts the type from a member.
-structMemTypeRegex = r"^[ \t]*(?:/[*][^*]*?[*]/)?[ \t]*?((?:[A-Za-z0-9_]+[ *\t]+)+)[ \t*]*(?:(?:(?:[A-Za-z0-9_*]+)(?:[ \t*]*[\[][^]]*[\]])?[ \t]*)|(?:[^\n;]*));"
+structMemTypeRegex = r"[ \t]*(?:/[*][^*]*?[*]/)?[ \t]*?((?:[A-Za-z0-9_]+[ *\t]+(?=[^{ ]))+)[ \t*]*(?:(?:(?:[A-Za-z0-9_*]+)(?:[ \t*]*[\[][^]]*[\]])?[ \t]*)|(?:[^\n;]*));"
 # Get all the types that are in the struct
 def get_struct_types(structText):
     defs = regex_get_matches(structText, structMemTypeRegex)


### PR DESCRIPTION
Fixed an issue where types in structs were not being extracted if it was a single line. Also added the `INCONSISTENT` define to suppress the inconsistent function signature warning from `./generate_ctx.sh`