### PR TITLE
Some minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ IDO_IGNORE_WARNINGS = -woff 838,649,624
 ASFLAGS = -mtune=vr4300 -march=vr4300 -mabi=32 $(foreach d,$(DEFINES),--defsym $(d))
 INCLUDE_CFLAGS := -I include -I $(BUILD_DIR) -I src -I . -I include/libc
 CFLAGS = -c -Wab,-r4300_mul -non_shared -G 0 -Xcpluscomm -DNDEBUG $(OPT_FLAGS) $(MIPSISET) $(INCLUDE_CFLAGS) $(DEF_INC_CFLAGS) $(IDO_IGNORE_WARNINGS)
-LDFLAGS = undefined_syms.txt -T $(LD_SCRIPT) -Map $(BUILD_DIR)/dkr.map
+LDFLAGS = undefined_syms.txt -T $(BUILD_DIR)/$(LD_SCRIPT) -Map $(BUILD_DIR)/dkr.map
 
 ####################### Other Tools #########################
 

--- a/tools/python/calc_func_checksums.py
+++ b/tools/python/calc_func_checksums.py
@@ -65,7 +65,7 @@ def calculate_checksum_for_function(funcLabel, varLabel, funcSizeLabel):
 
 def calculate_matches():
     global mapFile, RAM_TO_ROM
-    REGEX_MAP_GET_LABEL = r"[ ]*?0x[0-9A-Fa-f]{8}([0-9A-Fa-f]{8})[ ]*?([_A-Za-z0-9]+)"
+    REGEX_MAP_GET_LABEL = r"[ ]*?(?:0x[0-9A-Fa-f]{8})?([0-9A-Fa-f]{8})[ ]*?([_A-Za-z0-9]+)"
     mapText = FileUtil.get_text_from_file(MAP_FILEPATH)
     mapMatches = getMatches(mapText, REGEX_MAP_GET_LABEL)
     for i in range(0, len(mapMatches) - 1):

--- a/tools/python/generate_ld.py
+++ b/tools/python/generate_ld.py
@@ -205,7 +205,7 @@ class GenerateLD:
 
     def append_files(self, files, extensions, directory, outputDir):
         filenames = FileUtil.get_filenames_from_directory_recursive(directory, extensions)
-        regex = r'[\/][*]+\s*RAM_POS:\s*0x([0-9a-fA-F]+)\s*[*]+[\/]'
+        regex = r'[\/][*]+\s*RAM_POS:\s*((?:0x)[0-9a-fA-F]+|(?:[Aa][Uu][Tt][Oo]))\s*[*]+[\/]'
         for filename in filenames:
             with open(directory + '/' + filename, 'r') as inFile:
                 notDone = True
@@ -216,7 +216,10 @@ class GenerateLD:
                         line = inFile.readline()
                         continue
                     matchedGroups = matches.groups()
-                    files.append((outputDir + filename[:-2] + '.o', '', matchedGroups[0], 0))
+                    ramPos = matchedGroups[0]
+                    if ramPos.lower() == 'auto':
+                        ramPos = '800FFFF0'
+                    files.append((outputDir + filename[:-2] + '.o', '', ramPos, 0))
                     break
 
     def get_code_files(self):


### PR DESCRIPTION
* We were using the c preprocessor on dkr.ld and outputting it to the build folder, then proceeded to use the original anyway. Fixed the makefile so that we now use the one in the build folder.
* Apparently Ubuntu 23.04 makes the dkr.map file use 8-digit addresses/offsets instead of 16 like before. I fixed a regex so that both 8 digit and 16 digit addresses should work.
* For modded repos, you can now use `/* RAM_POS: auto */` at the top of a source file. This lets generate_ld.sh still pick up the file, even if you don't care where in RAM it should be.