### PR TITLE
Renamed a lot of symbols in menu.c

### DIFF
--- a/asm/non_matchings/menu/draw_menu_elements.s
+++ b/asm/non_matchings/menu/draw_menu_elements.s
@@ -34,14 +34,14 @@ glabel draw_menu_elements
 /* 082E58 80082258 8E110014 */  lw    $s1, 0x14($s0)
 /* 082E5C 8008225C 3C013B80 */  li    $at, 0x3B800000 # 0.003906
 /* 082E60 80082260 12200175 */  beqz  $s1, .L80082838
-/* 082E64 80082264 3C17800E */   lui   $s7, %hi(D_800DF7A0) # $s7, 0x800e
-/* 082E68 80082268 3C1E800E */  lui   $fp, %hi(D_800DF79C) # $fp, 0x800e
+/* 082E64 80082264 3C17800E */   lui   $s7, %hi(gDrawMenuElementsYOffset2) # $s7, 0x800e
+/* 082E68 80082268 3C1E800E */  lui   $fp, %hi(gDrawMenuElementsYOffset) # $fp, 0x800e
 /* 082E6C 8008226C 3C14800E */  lui   $s4, %hi(gMenuImageStack) # $s4, 0x800e
 /* 082E70 80082270 4481B000 */  mtc1  $at, $f22
 /* 082E74 80082274 8FA40070 */  lw    $a0, 0x70($sp)
 /* 082E78 80082278 2694F75C */  addiu $s4, %lo(gMenuImageStack) # addiu $s4, $s4, -0x8a4
-/* 082E7C 8008227C 27DEF79C */  addiu $fp, %lo(D_800DF79C) # addiu $fp, $fp, -0x864
-/* 082E80 80082280 26F7F7A0 */  addiu $s7, %lo(D_800DF7A0) # addiu $s7, $s7, -0x860
+/* 082E7C 8008227C 27DEF79C */  addiu $fp, %lo(gDrawMenuElementsYOffset) # addiu $fp, $fp, -0x864
+/* 082E80 80082280 26F7F7A0 */  addiu $s7, %lo(gDrawMenuElementsYOffset2) # addiu $s7, $s7, -0x860
 .L80082284:
 /* 082E84 80082284 3C0F8012 */  lui   $t7, %hi(D_80126850) # $t7, 0x8012
 /* 082E88 80082288 25EF6850 */  addiu $t7, %lo(D_80126850) # addiu $t7, $t7, 0x6850
@@ -352,8 +352,8 @@ glabel L80082608
 /* 083318 80082718 3C01800E */  lui   $at, %hi(sMenuGuiColourB) # $at, 0x800e
 /* 08331C 8008271C A028F4AC */  sb    $t0, %lo(sMenuGuiColourB)($at)
 /* 083320 80082720 9209000F */  lbu   $t1, 0xf($s0)
-/* 083324 80082724 3C01800E */  lui   $at, %hi(D_800DF4B0) # $at, 0x800e
-/* 083328 80082728 A029F4B0 */  sb    $t1, %lo(D_800DF4B0)($at)
+/* 083324 80082724 3C01800E */  lui   $at, %hi(sMenuGuiColourA) # $at, 0x800e
+/* 083328 80082728 A029F4B0 */  sb    $t1, %lo(sMenuGuiColourA)($at)
 /* 08332C 8008272C 920A0010 */  lbu   $t2, 0x10($s0)
 /* 083330 80082730 3C01800E */  lui   $at, %hi(sMenuGuiOpacity) # $at, 0x800e
 /* 083334 80082734 AC2AF764 */  sw    $t2, %lo(sMenuGuiOpacity)($at)
@@ -438,8 +438,8 @@ glabel L800827C0
 /* 083458 80082858 A022F4A8 */  sb    $v0, %lo(sMenuGuiColourG)($at)
 /* 08345C 8008285C 3C01800E */  lui   $at, %hi(sMenuGuiColourB) # $at, 0x800e
 /* 083460 80082860 A022F4AC */  sb    $v0, %lo(sMenuGuiColourB)($at)
-/* 083464 80082864 3C01800E */  lui   $at, %hi(D_800DF4B0) # $at, 0x800e
-/* 083468 80082868 A020F4B0 */  sb    $zero, %lo(D_800DF4B0)($at)
+/* 083464 80082864 3C01800E */  lui   $at, %hi(sMenuGuiColourA) # $at, 0x800e
+/* 083468 80082868 A020F4B0 */  sb    $zero, %lo(sMenuGuiColourA)($at)
 /* 08346C 8008286C 3C01800E */  lui   $at, %hi(sMenuGuiOpacity) # $at, 0x800e
 /* 083470 80082870 240D00FF */  li    $t5, 255
 /* 083474 80082874 AC2DF764 */  sw    $t5, %lo(sMenuGuiOpacity)($at)

--- a/asm/non_matchings/menu/draw_menu_elements.s
+++ b/asm/non_matchings/menu/draw_menu_elements.s
@@ -34,14 +34,14 @@ glabel draw_menu_elements
 /* 082E58 80082258 8E110014 */  lw    $s1, 0x14($s0)
 /* 082E5C 8008225C 3C013B80 */  li    $at, 0x3B800000 # 0.003906
 /* 082E60 80082260 12200175 */  beqz  $s1, .L80082838
-/* 082E64 80082264 3C17800E */   lui   $s7, %hi(gDrawMenuElementsYOffset2) # $s7, 0x800e
-/* 082E68 80082268 3C1E800E */  lui   $fp, %hi(gDrawMenuElementsYOffset) # $fp, 0x800e
+/* 082E64 80082264 3C17800E */   lui   $s7, %hi(gDrawElementsYOffset) # $s7, 0x800e
+/* 082E68 80082268 3C1E800E */  lui   $fp, %hi(gDrawElementsRegionYOffset) # $fp, 0x800e
 /* 082E6C 8008226C 3C14800E */  lui   $s4, %hi(gMenuImageStack) # $s4, 0x800e
 /* 082E70 80082270 4481B000 */  mtc1  $at, $f22
 /* 082E74 80082274 8FA40070 */  lw    $a0, 0x70($sp)
 /* 082E78 80082278 2694F75C */  addiu $s4, %lo(gMenuImageStack) # addiu $s4, $s4, -0x8a4
-/* 082E7C 8008227C 27DEF79C */  addiu $fp, %lo(gDrawMenuElementsYOffset) # addiu $fp, $fp, -0x864
-/* 082E80 80082280 26F7F7A0 */  addiu $s7, %lo(gDrawMenuElementsYOffset2) # addiu $s7, $s7, -0x860
+/* 082E7C 8008227C 27DEF79C */  addiu $fp, %lo(gDrawElementsRegionYOffset) # addiu $fp, $fp, -0x864
+/* 082E80 80082280 26F7F7A0 */  addiu $s7, %lo(gDrawElementsYOffset) # addiu $s7, $s7, -0x860
 .L80082284:
 /* 082E84 80082284 3C0F8012 */  lui   $t7, %hi(D_80126850) # $t7, 0x8012
 /* 082E88 80082288 25EF6850 */  addiu $t7, %lo(D_80126850) # addiu $t7, $t7, 0x6850

--- a/asm/non_matchings/menu/func_8007FFEC.s
+++ b/asm/non_matchings/menu/func_8007FFEC.s
@@ -334,9 +334,9 @@ glabel func_8007FFEC
 /* 0810F4 800804F4 AC201DB4 */  sw    $zero, %lo(D_800E1DB4)($at)
 /* 0810F8 800804F8 3C01800E */  lui   $at, %hi(gWoodPanelCount) # $at, 0x800e
 /* 0810FC 800804FC AC201DB8 */  sw    $zero, %lo(gWoodPanelCount)($at)
-/* 081100 80080500 3C01800E */  lui   $at, %hi(D_800E1DBC) # $at, 0x800e
+/* 081100 80080500 3C01800E */  lui   $at, %hi(gWoodPanelAllocCount) # $at, 0x800e
 /* 081104 80080504 8FBF001C */  lw    $ra, 0x1c($sp)
-/* 081108 80080508 AC301DBC */  sw    $s0, %lo(D_800E1DBC)($at)
+/* 081108 80080508 AC301DBC */  sw    $s0, %lo(gWoodPanelAllocCount)($at)
 /* 08110C 8008050C 8FB00018 */  lw    $s0, 0x18($sp)
 /* 081110 80080510 03E00008 */  jr    $ra
 /* 081114 80080514 27BD0050 */   addiu $sp, $sp, 0x50

--- a/asm/non_matchings/menu/func_8007FFEC.s
+++ b/asm/non_matchings/menu/func_8007FFEC.s
@@ -18,16 +18,16 @@ glabel func_8007FFEC
 /* 080C28 80080028 000D7880 */  sll   $t7, $t5, 2
 /* 080C2C 8008002C 01ED7821 */  addu  $t7, $t7, $t5
 /* 080C30 80080030 24020020 */  li    $v0, 32
-/* 080C34 80080034 3C01800E */  lui   $at, %hi(D_800E1DC0) # $at, 0x800e
+/* 080C34 80080034 3C01800E */  lui   $at, %hi(gWoodPanelTexScaleU) # $at, 0x800e
 /* 080C38 80080038 000F6840 */  sll   $t5, $t7, 1
-/* 080C3C 8008003C AC221DC0 */  sw    $v0, %lo(D_800E1DC0)($at)
-/* 080C40 80080040 3C01800E */  lui   $at, %hi(D_800E1DC4) # $at, 0x800e
+/* 080C3C 8008003C AC221DC0 */  sw    $v0, %lo(gWoodPanelTexScaleU)($at)
+/* 080C40 80080040 3C01800E */  lui   $at, %hi(gWoodPanelTexScaleV) # $at, 0x800e
 /* 080C44 80080044 00106140 */  sll   $t4, $s0, 5
 /* 080C48 80080048 00001812 */  mflo  $v1
 /* 080C4C 8008004C 0003C100 */  sll   $t8, $v1, 4
 /* 080C50 80080050 01B8C821 */  addu  $t9, $t5, $t8
 /* 080C54 80080054 00197040 */  sll   $t6, $t9, 1
-/* 080C58 80080058 AC221DC4 */  sw    $v0, %lo(D_800E1DC4)($at)
+/* 080C58 80080058 AC221DC4 */  sw    $v0, %lo(gWoodPanelTexScaleV)($at)
 /* 080C5C 8008005C 01CC2021 */  addu  $a0, $t6, $t4
 /* 080C60 80080060 03001825 */  move  $v1, $t8
 /* 080C64 80080064 AFB80020 */  sw    $t8, 0x20($sp)
@@ -36,12 +36,12 @@ glabel func_8007FFEC
 /* 080C70 80080070 0C01C327 */  jal   allocate_from_main_pool_safe
 /* 080C74 80080074 2405FFFF */   li    $a1, -1
 /* 080C78 80080078 8FA30020 */  lw    $v1, 0x20($sp)
-/* 080C7C 8008007C 3C07800E */  lui   $a3, %hi(D_800E1DAC) # $a3, 0x800e
-/* 080C80 80080080 24E71DAC */  addiu $a3, %lo(D_800E1DAC) # addiu $a3, $a3, 0x1dac
+/* 080C7C 8008007C 3C07800E */  lui   $a3, %hi(gWoodPanelTriangles) # $a3, 0x800e
+/* 080C80 80080080 24E71DAC */  addiu $a3, %lo(gWoodPanelTriangles) # addiu $a3, $a3, 0x1dac
 /* 080C84 80080084 ACE20000 */  sw    $v0, ($a3)
-/* 080C88 80080088 3C01800E */  lui   $at, %hi(D_800E1DAC+4) # $at, 0x800e
+/* 080C88 80080088 3C01800E */  lui   $at, %hi(gWoodPanelTriangles+4) # $at, 0x800e
 /* 080C8C 8008008C 0043C021 */  addu  $t8, $v0, $v1
-/* 080C90 80080090 AC381DB0 */  sw    $t8, %lo(D_800E1DAC+4)($at)
+/* 080C90 80080090 AC381DB0 */  sw    $t8, %lo(gWoodPanelTriangles+4)($at)
 /* 080C94 80080094 8CF90004 */  lw    $t9, 4($a3)
 /* 080C98 80080098 3C068012 */  lui   $a2, %hi(D_80126C2C) # $a2, 0x8012
 /* 080C9C 8008009C 3C018012 */  lui   $at, %hi(D_80126C2C) # $at, 0x8012
@@ -50,16 +50,16 @@ glabel func_8007FFEC
 /* 080CA8 800800A8 AC2E6C2C */  sw    $t6, %lo(D_80126C2C)($at)
 /* 080CAC 800800AC 8FAC0028 */  lw    $t4, 0x28($sp)
 /* 080CB0 800800B0 8CCF0000 */  lw    $t7, ($a2)
-/* 080CB4 800800B4 3C08800E */  lui   $t0, %hi(D_800E1DA4) # $t0, 0x800e
-/* 080CB8 800800B8 3C01800E */  lui   $at, %hi(D_800E1DA4+4) # $at, 0x800e
+/* 080CB4 800800B4 3C08800E */  lui   $t0, %hi(gWoodPanelVertices) # $t0, 0x800e
+/* 080CB8 800800B8 3C01800E */  lui   $at, %hi(gWoodPanelVertices+4) # $at, 0x800e
 /* 080CBC 800800BC 01ECC021 */  addu  $t8, $t7, $t4
-/* 080CC0 800800C0 25081DA4 */  addiu $t0, %lo(D_800E1DA4) # addiu $t0, $t0, 0x1da4
-/* 080CC4 800800C4 AC381DA4 */  sw    $t8, %lo(D_800E1DA4)($at)
+/* 080CC0 800800C0 25081DA4 */  addiu $t0, %lo(gWoodPanelVertices) # addiu $t0, $t0, 0x1da4
+/* 080CC4 800800C4 AC381DA4 */  sw    $t8, %lo(gWoodPanelVertices)($at)
 /* 080CC8 800800C8 8FAD0024 */  lw    $t5, 0x24($sp)
 /* 080CCC 800800CC 8D190000 */  lw    $t9, ($t0)
 /* 080CD0 800800D0 2409000A */  li    $t1, 10
 /* 080CD4 800800D4 032D7021 */  addu  $t6, $t9, $t5
-/* 080CD8 800800D8 AC2E1DA8 */  sw    $t6, %lo(D_800E1DA4+4)($at)
+/* 080CD8 800800D8 AC2E1DA8 */  sw    $t6, %lo(gWoodPanelVertices+4)($at)
 /* 080CDC 800800DC 00005025 */  move  $t2, $zero
 /* 080CE0 800800E0 00002825 */  move  $a1, $zero
 /* 080CE4 800800E4 1A0000C8 */  blez  $s0, .L80080408
@@ -275,12 +275,12 @@ glabel func_8007FFEC
 /* 081018 80080418 00001825 */  move  $v1, $zero
 /* 08101C 8008041C 24050040 */  li    $a1, 64
 .L80080420:
-/* 081020 80080420 3C04800E */  lui   $a0, %hi(D_800E1CD0) # $a0, 0x800e
-/* 081024 80080424 24841CD0 */  addiu $a0, %lo(D_800E1CD0) # addiu $a0, $a0, 0x1cd0
+/* 081020 80080420 3C04800E */  lui   $a0, %hi(gWoodPanelsIndices) # $a0, 0x800e
+/* 081024 80080424 24841CD0 */  addiu $a0, %lo(gWoodPanelsIndices) # addiu $a0, $a0, 0x1cd0
 /* 081028 80080428 00003825 */  move  $a3, $zero
 .L8008042C:
-/* 08102C 8008042C 3C02800E */  lui   $v0, %hi(D_800E1DAC) # $v0, 0x800e
-/* 081030 80080430 24421DAC */  addiu $v0, %lo(D_800E1DAC) # addiu $v0, $v0, 0x1dac
+/* 08102C 8008042C 3C02800E */  lui   $v0, %hi(gWoodPanelTriangles) # $v0, 0x800e
+/* 081030 80080430 24421DAC */  addiu $v0, %lo(gWoodPanelTriangles) # addiu $v0, $v0, 0x1dac
 .L80080434:
 /* 081034 80080434 8C4F0000 */  lw    $t7, ($v0)
 /* 081038 80080438 24420004 */  addiu $v0, $v0, 4
@@ -332,8 +332,8 @@ glabel func_8007FFEC
 /* 0810F0 800804F0 00000000 */   nop   
 .L800804F4:
 /* 0810F4 800804F4 AC201DB4 */  sw    $zero, %lo(D_800E1DB4)($at)
-/* 0810F8 800804F8 3C01800E */  lui   $at, %hi(D_800E1DB8) # $at, 0x800e
-/* 0810FC 800804FC AC201DB8 */  sw    $zero, %lo(D_800E1DB8)($at)
+/* 0810F8 800804F8 3C01800E */  lui   $at, %hi(gWoodPanelCount) # $at, 0x800e
+/* 0810FC 800804FC AC201DB8 */  sw    $zero, %lo(gWoodPanelCount)($at)
 /* 081100 80080500 3C01800E */  lui   $at, %hi(D_800E1DBC) # $at, 0x800e
 /* 081104 80080504 8FBF001C */  lw    $ra, 0x1c($sp)
 /* 081108 80080508 AC301DBC */  sw    $s0, %lo(D_800E1DBC)($at)

--- a/asm/non_matchings/menu/func_80080580.s
+++ b/asm/non_matchings/menu/func_80080580.s
@@ -1,8 +1,8 @@
 glabel func_80080580
 /* 081180 80080580 27BDFF40 */  addiu $sp, $sp, -0xc0
 /* 081184 80080584 AFBE0038 */  sw    $fp, 0x38($sp)
-/* 081188 80080588 3C1E800E */  lui   $fp, %hi(D_800E1DB8) # $fp, 0x800e
-/* 08118C 8008058C 27DE1DB8 */  addiu $fp, %lo(D_800E1DB8) # addiu $fp, $fp, 0x1db8
+/* 081188 80080588 3C1E800E */  lui   $fp, %hi(gWoodPanelCount) # $fp, 0x800e
+/* 08118C 8008058C 27DE1DB8 */  addiu $fp, %lo(gWoodPanelCount) # addiu $fp, $fp, 0x1db8
 /* 081190 80080590 8FCF0000 */  lw    $t7, ($fp)
 /* 081194 80080594 3C0E8012 */  lui   $t6, %hi(D_80126C2C) # $t6, 0x8012
 /* 081198 80080598 000FC140 */  sll   $t8, $t7, 5
@@ -28,19 +28,19 @@ glabel func_80080580
 /* 0811E8 800805E8 0080B825 */  move  $s7, $a0
 /* 0811EC 800805EC 12600086 */  beqz  $s3, .L80080808
 /* 0811F0 800805F0 AF130010 */   sw    $s3, 0x10($t8)
-/* 0811F4 800805F4 3C05800E */  lui   $a1, %hi(D_800E1DC0) # $a1, 0x800e
+/* 0811F4 800805F4 3C05800E */  lui   $a1, %hi(gWoodPanelTexScaleU) # $a1, 0x800e
 /* 0811F8 800805F8 8FAB00D4 */  lw    $t3, 0xd4($sp)
-/* 0811FC 800805FC 8CA51DC0 */  lw    $a1, %lo(D_800E1DC0)($a1)
+/* 0811FC 800805FC 8CA51DC0 */  lw    $a1, %lo(gWoodPanelTexScaleU)($a1)
 /* 081200 80080600 00EBC823 */  subu  $t9, $a3, $t3
 /* 081204 80080604 00AB0019 */  multu $a1, $t3
-/* 081208 80080608 3C06800E */  lui   $a2, %hi(D_800E1DC4) # $a2, 0x800e
+/* 081208 80080608 3C06800E */  lui   $a2, %hi(gWoodPanelTexScaleV) # $a2, 0x800e
 /* 08120C 8008060C 8FAC00D8 */  lw    $t4, 0xd8($sp)
-/* 081210 80080610 8CC61DC4 */  lw    $a2, %lo(D_800E1DC4)($a2)
+/* 081210 80080610 8CC61DC4 */  lw    $a2, %lo(gWoodPanelTexScaleV)($a2)
 /* 081214 80080614 8FAD00D0 */  lw    $t5, 0xd0($sp)
 /* 081218 80080618 AFA000B0 */  sw    $zero, 0xb0($sp)
 /* 08121C 8008061C AFA000A0 */  sw    $zero, 0xa0($sp)
-/* 081220 80080620 3C02800E */  lui   $v0, %hi(D_800E1CF0) # $v0, 0x800e
-/* 081224 80080624 24421CF0 */  addiu $v0, %lo(D_800E1CF0) # addiu $v0, $v0, 0x1cf0
+/* 081220 80080620 3C02800E */  lui   $v0, %hi(gWoodPanelTexCoords) # $v0, 0x800e
+/* 081224 80080624 24421CF0 */  addiu $v0, %lo(gWoodPanelTexCoords) # addiu $v0, $v0, 0x1cf0
 /* 081228 80080628 0000F825 */  move  $ra, $zero
 /* 08122C 8008062C 27A400B0 */  addiu $a0, $sp, 0xb0
 /* 081230 80080630 00007812 */  mflo  $t7
@@ -182,14 +182,14 @@ glabel func_80080580
 /* 081448 80080848 01D87821 */  addu  $t7, $t6, $t8
 /* 08144C 8008084C 00197080 */  sll   $t6, $t9, 2
 /* 081450 80080850 01EEC021 */  addu  $t8, $t7, $t6
-/* 081454 80080854 3C0A800E */  lui   $t2, %hi(D_800E1D7C) # $t2, 0x800e
-/* 081458 80080858 3C03800E */  lui   $v1, %hi(D_800E1D2C) # $v1, 0x800e
+/* 081454 80080854 3C0A800E */  lui   $t2, %hi(gWoodPanelVertColours) # $t2, 0x800e
+/* 081458 80080858 3C03800E */  lui   $v1, %hi(gWoodPanelVertCoords) # $v1, 0x800e
 /* 08145C 8008085C 8FAB00D4 */  lw    $t3, 0xd4($sp)
 /* 081460 80080860 8FAC00D8 */  lw    $t4, 0xd8($sp)
 /* 081464 80080864 8FAD00D0 */  lw    $t5, 0xd0($sp)
 /* 081468 80080868 8F020000 */  lw    $v0, ($t8)
-/* 08146C 8008086C 24631D2C */  addiu $v1, %lo(D_800E1D2C) # addiu $v1, $v1, 0x1d2c
-/* 081470 80080870 254A1D7C */  addiu $t2, %lo(D_800E1D7C) # addiu $t2, $t2, 0x1d7c
+/* 08146C 8008086C 24631D2C */  addiu $v1, %lo(gWoodPanelVertCoords) # addiu $v1, $v1, 0x1d2c
+/* 081470 80080870 254A1D7C */  addiu $t2, %lo(gWoodPanelVertColours) # addiu $t2, $t2, 0x1d7c
 /* 081474 80080874 0000F825 */  move  $ra, $zero
 /* 081478 80080878 24090004 */  li    $t1, 4
 /* 08147C 8008087C 309600FF */  andi  $s6, $a0, 0xff

--- a/asm/non_matchings/menu/func_80080BC8.s
+++ b/asm/non_matchings/menu/func_80080BC8.s
@@ -14,10 +14,10 @@ glabel func_80080BC8
 /* 0817F8 80080BF8 AC8E0000 */  sw    $t6, ($a0)
 /* 0817FC 80080BFC 27181C70 */  addiu $t8, %lo(dMenuHudSettings) # addiu $t8, $t8, 0x1c70
 /* 081800 80080C00 3C0F0600 */  lui   $t7, 0x600
-/* 081804 80080C04 3C09800E */  lui   $t1, %hi(D_800E1DB8) # $t1, 0x800e
+/* 081804 80080C04 3C09800E */  lui   $t1, %hi(gWoodPanelCount) # $t1, 0x800e
 /* 081808 80080C08 AC4F0000 */  sw    $t7, ($v0)
 /* 08180C 80080C0C AC580004 */  sw    $t8, 4($v0)
-/* 081810 80080C10 8D291DB8 */  lw    $t1, %lo(D_800E1DB8)($t1)
+/* 081810 80080C10 8D291DB8 */  lw    $t1, %lo(gWoodPanelCount)($t1)
 /* 081814 80080C14 00803025 */  move  $a2, $a0
 /* 081818 80080C18 2408FFFF */  li    $t0, -1
 /* 08181C 80080C1C 00006825 */  move  $t5, $zero
@@ -104,7 +104,7 @@ glabel func_80080BC8
 /* 081940 80080D40 AC400004 */  sw    $zero, 4($v0)
 /* 081944 80080D44 AC530000 */  sw    $s3, ($v0)
 /* 081948 80080D48 8CC20000 */  lw    $v0, ($a2)
-/* 08194C 80080D4C 3C09800E */  lui   $t1, %hi(D_800E1DB8) # $t1, 0x800e
+/* 08194C 80080D4C 3C09800E */  lui   $t1, %hi(gWoodPanelCount) # $t1, 0x800e
 /* 081950 80080D50 244F0008 */  addiu $t7, $v0, 8
 /* 081954 80080D54 ACCF0000 */  sw    $t7, ($a2)
 /* 081958 80080D58 8D780000 */  lw    $t8, ($t3)
@@ -150,7 +150,7 @@ glabel func_80080BC8
 /* 0819F8 80080DF8 00000000 */  nop   
 /* 0819FC 80080DFC 01CC7821 */  addu  $t7, $t6, $t4
 /* 081A00 80080E00 AC4F0004 */  sw    $t7, 4($v0)
-/* 081A04 80080E04 8D291DB8 */  lw    $t1, %lo(D_800E1DB8)($t1)
+/* 081A04 80080E04 8D291DB8 */  lw    $t1, %lo(gWoodPanelCount)($t1)
 /* 081A08 80080E08 00000000 */  nop   
 .L80080E0C:
 /* 081A0C 80080E0C 24E70001 */  addiu $a3, $a3, 1
@@ -159,9 +159,9 @@ glabel func_80080BC8
 /* 081A18 80080E18 00000000 */   nop   
 .L80080E1C:
 /* 081A1C 80080E1C 3C0A800E */  lui   $t2, %hi(D_800E1DB4) # $t2, 0x800e
-/* 081A20 80080E20 3C01800E */  lui   $at, %hi(D_800E1DB8) # $at, 0x800e
+/* 081A20 80080E20 3C01800E */  lui   $at, %hi(gWoodPanelCount) # $at, 0x800e
 /* 081A24 80080E24 254A1DB4 */  addiu $t2, %lo(D_800E1DB4) # addiu $t2, $t2, 0x1db4
-/* 081A28 80080E28 AC201DB8 */  sw    $zero, %lo(D_800E1DB8)($at)
+/* 081A28 80080E28 AC201DB8 */  sw    $zero, %lo(gWoodPanelCount)($at)
 /* 081A2C 80080E2C 8D590000 */  lw    $t9, ($t2)
 /* 081A30 80080E30 24100001 */  li    $s0, 1
 /* 081A34 80080E34 0219C023 */  subu  $t8, $s0, $t9

--- a/asm/non_matchings/menu/func_80081218.s
+++ b/asm/non_matchings/menu/func_80081218.s
@@ -91,10 +91,10 @@ glabel func_80081218
 /* 081F7C 8008137C AC22F4A0 */  sw    $v0, %lo(gMenuText)($at)
 /* 081F80 80081380 0C01FE40 */  jal   load_menu_text
 /* 081F84 80081384 00002025 */   move  $a0, $zero
-/* 081F88 80081388 3C028012 */  lui   $v0, %hi(gMenuTextures) # $v0, 0x8012
+/* 081F88 80081388 3C028012 */  lui   $v0, %hi(gMenuObjects) # $v0, 0x8012
 /* 081F8C 8008138C 3C038012 */  lui   $v1, %hi(D_80126750) # $v1, 0x8012
 /* 081F90 80081390 24636750 */  addiu $v1, %lo(D_80126750) # addiu $v1, $v1, 0x6750
-/* 081F94 80081394 24426550 */  addiu $v0, %lo(gMenuTextures) # addiu $v0, $v0, 0x6550
+/* 081F94 80081394 24426550 */  addiu $v0, %lo(gMenuObjects) # addiu $v0, $v0, 0x6550
 .L80081398:
 /* 081F98 80081398 24420010 */  addiu $v0, $v0, 0x10
 /* 081F9C 8008139C AC40FFF0 */  sw    $zero, -0x10($v0)

--- a/asm/non_matchings/menu/func_80083098.s
+++ b/asm/non_matchings/menu/func_80083098.s
@@ -23,9 +23,9 @@ glabel func_80083098
 /* 083CEC 800830EC C4640000 */  lwc1  $f4, ($v1)
 /* 083CF0 800830F0 000E7080 */  sll   $t6, $t6, 2
 /* 083CF4 800830F4 01C27023 */  subu  $t6, $t6, $v0
-/* 083CF8 800830F8 3C0F800E */  lui   $t7, %hi(D_800DF83C) # $t7, 0x800e
+/* 083CF8 800830F8 3C0F800E */  lui   $t7, %hi(gTitleCinematicText) # $t7, 0x800e
 /* 083CFC 800830FC 460C2180 */  add.s $f6, $f4, $f12
-/* 083D00 80083100 25EFF83C */  addiu $t7, %lo(D_800DF83C) # addiu $t7, $t7, -0x7c4
+/* 083D00 80083100 25EFF83C */  addiu $t7, %lo(gTitleCinematicText) # addiu $t7, $t7, -0x7c4
 /* 083D04 80083104 000E7080 */  sll   $t6, $t6, 2
 /* 083D08 80083108 01CF9821 */  addu  $s3, $t6, $t7
 /* 083D0C 8008310C E4660000 */  swc1  $f6, ($v1)
@@ -36,15 +36,15 @@ glabel func_80083098
 /* 083D20 80083120 00003025 */  move  $a2, $zero
 /* 083D24 80083124 0C0310F3 */  jal   set_text_background_colour
 /* 083D28 80083128 00003825 */   move  $a3, $zero
-/* 083D2C 8008312C 3C12800E */  lui   $s2, %hi(D_800DF9F4) # $s2, 0x800e
-/* 083D30 80083130 2652F9F4 */  addiu $s2, %lo(D_800DF9F4) # addiu $s2, $s2, -0x60c
+/* 083D2C 8008312C 3C12800E */  lui   $s2, %hi(gTitleCinematicTextColourCount) # $s2, 0x800e
+/* 083D30 80083130 2652F9F4 */  addiu $s2, %lo(gTitleCinematicTextColourCount) # addiu $s2, $s2, -0x60c
 /* 083D34 80083134 8E440000 */  lw    $a0, ($s2)
 /* 083D38 80083138 00008825 */  move  $s1, $zero
 /* 083D3C 8008313C 18800044 */  blez  $a0, .L80083250
 /* 083D40 80083140 3C108012 */   lui   $s0, %hi(D_80126878) # $s0, 0x8012
 /* 083D44 80083144 3C168012 */  lui   $s6, %hi(sMenuCurrDisplayList) # $s6, 0x8012
-/* 083D48 80083148 3C15800E */  lui   $s5, %hi(D_800DF9F8) # $s5, 0x800e
-/* 083D4C 8008314C 26B5F9F8 */  addiu $s5, %lo(D_800DF9F8) # addiu $s5, $s5, -0x608
+/* 083D48 80083148 3C15800E */  lui   $s5, %hi(gTitleCinematicTextColours) # $s5, 0x800e
+/* 083D4C 8008314C 26B5F9F8 */  addiu $s5, %lo(gTitleCinematicTextColours) # addiu $s5, $s5, -0x608
 /* 083D50 80083150 26D663A0 */  addiu $s6, %lo(sMenuCurrDisplayList) # addiu $s6, $s6, 0x63a0
 /* 083D54 80083154 26106878 */  addiu $s0, %lo(D_80126878) # addiu $s0, $s0, 0x6878
 /* 083D58 80083158 24140005 */  li    $s4, 5

--- a/asm/non_matchings/menu/func_80084854.s
+++ b/asm/non_matchings/menu/func_80084854.s
@@ -10,8 +10,8 @@ glabel func_80084854
 /* 085474 80084874 AFB0002C */  sw    $s0, 0x2c($sp)
 /* 085478 80084878 AFA40058 */  sw    $a0, 0x58($sp)
 /* 08547C 8008487C 906E0000 */  lbu   $t6, ($v1)
-/* 085480 80084880 3C13800E */  lui   $s3, %hi(D_800DFABC) # $s3, 0x800e
-/* 085484 80084884 8E73FABC */  lw    $s3, %lo(D_800DFABC)($s3)
+/* 085480 80084880 3C13800E */  lui   $s3, %hi(gMusicTestSongIndex) # $s3, 0x800e
+/* 085484 80084884 8E73FABC */  lw    $s3, %lo(gMusicTestSongIndex)($s3)
 /* 085488 80084888 29C10030 */  slti  $at, $t6, 0x30
 /* 08548C 8008488C 14200006 */  bnez  $at, .L800848A8
 /* 085490 80084890 00008825 */   move  $s1, $zero
@@ -49,7 +49,7 @@ glabel func_80084854
 /* 085500 80084900 26310001 */  addiu $s1, $s1, 1
 /* 085504 80084904 3C128012 */  lui   $s2, %hi(sMenuCurrDisplayList) # $s2, 0x8012
 /* 085508 80084908 265263A0 */  addiu $s2, %lo(sMenuCurrDisplayList) # addiu $s2, $s2, 0x63a0
-/* 08550C 8008490C 3C0F800E */  lui   $t7, %hi(D_800DFAC8) # $t7, 0x800e
+/* 08550C 8008490C 3C0F800E */  lui   $t7, %hi(gAudioOutputType) # $t7, 0x800e
 /* 085510 80084910 00001012 */  mflo  $v0
 /* 085514 80084914 24590030 */  addiu $t9, $v0, 0x30
 /* 085518 80084918 A1190000 */  sb    $t9, ($t0)
@@ -74,7 +74,7 @@ glabel func_80084854
 /* 085564 80084964 240E01FF */  li    $t6, 511
 /* 085568 80084968 01CD9823 */  subu  $s3, $t6, $t5
 .L8008496C:
-/* 08556C 8008496C 8DEFFAC8 */  lw    $t7, %lo(D_800DFAC8)($t7)
+/* 08556C 8008496C 8DEFFAC8 */  lw    $t7, %lo(gAudioOutputType)($t7)
 /* 085570 80084970 3C01800E */  lui   $at, %hi(gAudioMenuStrings+12) # $at, 0x800e
 /* 085574 80084974 000FC080 */  sll   $t8, $t7, 2
 /* 085578 80084978 0338C821 */  addu  $t9, $t9, $t8
@@ -91,8 +91,8 @@ glabel func_80084854
 .L800849A4:
 /* 0855A4 800849A4 24100071 */  li    $s0, 113
 .L800849A8:
-/* 0855A8 800849A8 3C0D8012 */  lui   $t5, %hi(gMenuTextures) # $t5, 0x8012
-/* 0855AC 800849AC 8DAD6660 */  lw    $t5, %lo(gMenuTextures + 0x110)($t5)
+/* 0855A8 800849A8 3C0D8012 */  lui   $t5, %hi(gMenuObjects) # $t5, 0x8012
+/* 0855AC 800849AC 8DAD6660 */  lw    $t5, %lo(gMenuObjects + 0x110)($t5)
 /* 0855B0 800849B0 24090078 */  li    $t1, 120
 /* 0855B4 800849B4 240B000E */  li    $t3, 14
 /* 0855B8 800849B8 240A0006 */  li    $t2, 6
@@ -107,8 +107,8 @@ glabel func_80084854
 /* 0855DC 800849DC AFB1001C */  sw    $s1, 0x1c($sp)
 /* 0855E0 800849E0 0C020160 */  jal   func_80080580
 /* 0855E4 800849E4 AFAD0020 */   sw    $t5, 0x20($sp)
-/* 0855E8 800849E8 3C088012 */  lui   $t0, %hi(gMenuTextures) # $t0, 0x8012
-/* 0855EC 800849EC 8D086660 */  lw    $t0, %lo(gMenuTextures + 0x110)($t0)
+/* 0855E8 800849E8 3C088012 */  lui   $t0, %hi(gMenuObjects) # $t0, 0x8012
+/* 0855EC 800849EC 8D086660 */  lw    $t0, %lo(gMenuObjects + 0x110)($t0)
 /* 0855F0 800849F0 240E0050 */  li    $t6, 80
 /* 0855F4 800849F4 240F000E */  li    $t7, 14
 /* 0855F8 800849F8 24180006 */  li    $t8, 6

--- a/asm/non_matchings/menu/func_800871D8.s
+++ b/asm/non_matchings/menu/func_800871D8.s
@@ -9,11 +9,11 @@ glabel func_800871D8
 /* 087DF4 800871F4 26B5FAE0 */  addiu $s5, %lo(D_800DFAE0) # addiu $s5, $s5, -0x520
 /* 087DF8 800871F8 31CF0003 */  andi  $t7, $t6, 3
 /* 087DFC 800871FC 0018C880 */  sll   $t9, $t8, 2
-/* 087E00 80087200 3C08800E */  lui   $t0, %hi(D_800DFBDC) # $t0, 0x800e
+/* 087E00 80087200 3C08800E */  lui   $t0, %hi(gContPakStrings) # $t0, 0x800e
 /* 087E04 80087204 AFB4002C */  sw    $s4, 0x2c($sp)
 /* 087E08 80087208 AEAF0000 */  sw    $t7, ($s5)
 /* 087E0C 8008720C 01194021 */  addu  $t0, $t0, $t9
-/* 087E10 80087210 8D08FBDC */  lw    $t0, %lo(D_800DFBDC)($t0)
+/* 087E10 80087210 8D08FBDC */  lw    $t0, %lo(gContPakStrings)($t0)
 /* 087E14 80087214 3C148012 */  lui   $s4, %hi(D_80126A70) # $s4, 0x8012
 /* 087E18 80087218 26946A70 */  addiu $s4, %lo(D_80126A70) # addiu $s4, $s4, 0x6a70
 /* 087E1C 8008721C 3C01800E */  lui   $at, %hi(D_800DFADC) # $at, 0x800e
@@ -100,21 +100,21 @@ glabel func_800871D8
 /* 087F50 80087350 3C02800E */  lui   $v0, %hi(gMenuText) # $v0, 0x800e
 /* 087F54 80087354 8C42F4A0 */  lw    $v0, %lo(gMenuText)($v0)
 /* 087F58 80087358 8E830000 */  lw    $v1, ($s4)
-/* 087F5C 8008735C 3C0D800E */  lui   $t5, %hi(D_800DFB8C) # $t5, 0x800e
-/* 087F60 80087360 25ADFB8C */  addiu $t5, %lo(D_800DFB8C) # addiu $t5, $t5, -0x474
+/* 087F5C 8008735C 3C0D800E */  lui   $t5, %hi(gContPakRumbleDetectedStrings) # $t5, 0x800e
+/* 087F60 80087360 25ADFB8C */  addiu $t5, %lo(gContPakRumbleDetectedStrings) # addiu $t5, $t5, -0x474
 /* 087F64 80087364 8C470100 */  lw    $a3, 0x100($v0)
 /* 087F68 80087368 106D0005 */  beq   $v1, $t5, .L80087380
 /* 087F6C 8008736C 24040007 */   li    $a0, 7
-/* 087F70 80087370 3C0E800E */  lui   $t6, %hi(D_800DFBA4) # $t6, 0x800e
-/* 087F74 80087374 25CEFBA4 */  addiu $t6, %lo(D_800DFBA4) # addiu $t6, $t6, -0x45c
+/* 087F70 80087370 3C0E800E */  lui   $t6, %hi(gContPakSwitchToRumbleStrings) # $t6, 0x800e
+/* 087F74 80087374 25CEFBA4 */  addiu $t6, %lo(gContPakSwitchToRumbleStrings) # addiu $t6, $t6, -0x45c
 /* 087F78 80087378 146E0004 */  bne   $v1, $t6, .L8008738C
-/* 087F7C 8008737C 3C0F800E */   lui   $t7, %hi(D_800DFBBC) # $t7, 0x800e
+/* 087F7C 8008737C 3C0F800E */   lui   $t7, %hi(gContPakNeed2ndAdvStrings) # $t7, 0x800e
 .L80087380:
 /* 087F80 80087380 8C470260 */  lw    $a3, 0x260($v0)
 /* 087F84 80087384 10000007 */  b     .L800873A4
 /* 087F88 80087388 24180001 */   li    $t8, 1
 .L8008738C:
-/* 087F8C 8008738C 25EFFBBC */  addiu $t7, %lo(D_800DFBBC) # addiu $t7, $t7, -0x444
+/* 087F8C 8008738C 25EFFBBC */  addiu $t7, %lo(gContPakNeed2ndAdvStrings) # addiu $t7, $t7, -0x444
 /* 087F90 80087390 146F0004 */  bne   $v1, $t7, .L800873A4
 /* 087F94 80087394 24180001 */   li    $t8, 1
 /* 087F98 80087398 8C4701F4 */  lw    $a3, 0x1f4($v0)

--- a/asm/non_matchings/menu/func_8008F618.s
+++ b/asm/non_matchings/menu/func_8008F618.s
@@ -55,11 +55,11 @@ glabel func_8008F618
 /* 0902EC 8008F6EC 01C04025 */  move  $t0, $t6
 /* 0902F0 8008F6F0 00EE001A */  div   $zero, $a3, $t6
 /* 0902F4 8008F6F4 440D3000 */  mfc1  $t5, $f6
-/* 0902F8 8008F6F8 3C09800E */  lui   $t1, %hi(D_800E0840) # $t1, 0x800e
+/* 0902F8 8008F6F8 3C09800E */  lui   $t1, %hi(gTrackSelectBgData) # $t1, 0x800e
 /* 0902FC 8008F6FC 3C1F8012 */  lui   $ra, %hi(gTrackSelectViewPortHalfY) # $ra, 0x8012
 /* 090300 8008F700 44D9F800 */  ctc1  $t9, $31
 /* 090304 8008F704 27FF6478 */  addiu $ra, %lo(gTrackSelectViewPortHalfY) # addiu $ra, $ra, 0x6478
-/* 090308 8008F708 25290840 */  addiu $t1, %lo(D_800E0840) # addiu $t1, $t1, 0x840
+/* 090308 8008F708 25290840 */  addiu $t1, %lo(gTrackSelectBgData) # addiu $t1, $t1, 0x840
 /* 09030C 8008F70C 00401825 */  move  $v1, $v0
 /* 090310 8008F710 15000002 */  bnez  $t0, .L8008F71C
 /* 090314 8008F714 00000000 */   nop   
@@ -89,8 +89,8 @@ glabel func_8008F618
 /* 090368 8008F768 240EFF00 */  li    $t6, -256
 /* 09036C 8008F76C 3C19FB00 */  lui   $t9, 0xfb00
 /* 090370 8008F770 3C068012 */  lui   $a2, %hi(D_80126924) # $a2, 0x8012
-/* 090374 8008F774 3C11800E */  lui   $s1, %hi(D_800E0968) # $s1, 0x800e
-/* 090378 8008F778 3C12800E */  lui   $s2, %hi(D_800E0970) # $s2, 0x800e
+/* 090374 8008F774 3C11800E */  lui   $s1, %hi(gTrackSelectBgVertices) # $s1, 0x800e
+/* 090378 8008F778 3C12800E */  lui   $s2, %hi(gTrackSelectBgTriangles) # $s2, 0x800e
 /* 09037C 8008F77C 00007812 */  mflo  $t7
 /* 090380 8008F780 00EF3823 */  subu  $a3, $a3, $t7
 /* 090384 8008F784 240FFFFF */  li    $t7, -1
@@ -106,13 +106,13 @@ glabel func_8008F618
 /* 0903AC 8008F7AC 00067880 */  sll   $t7, $a2, 2
 /* 0903B0 8008F7B0 022F8821 */  addu  $s1, $s1, $t7
 /* 0903B4 8008F7B4 024F9021 */  addu  $s2, $s2, $t7
-/* 0903B8 8008F7B8 8E310968 */  lw    $s1, %lo(D_800E0968)($s1)
-/* 0903BC 8008F7BC 8E520970 */  lw    $s2, %lo(D_800E0970)($s2)
+/* 0903B8 8008F7B8 8E310968 */  lw    $s1, %lo(gTrackSelectBgVertices)($s1)
+/* 0903BC 8008F7BC 8E520970 */  lw    $s2, %lo(gTrackSelectBgTriangles)($s2)
 /* 0903C0 8008F7C0 0317082A */  slt   $at, $t8, $s7
 /* 0903C4 8008F7C4 10200008 */  beqz  $at, .L8008F7E8
 /* 0903C8 8008F7C8 00001825 */   move  $v1, $zero
-/* 0903CC 8008F7CC 3C10800E */  lui   $s0, %hi(D_800E0840) # $s0, 0x800e
-/* 0903D0 8008F7D0 26100840 */  addiu $s0, %lo(D_800E0840) # addiu $s0, $s0, 0x840
+/* 0903CC 8008F7CC 3C10800E */  lui   $s0, %hi(gTrackSelectBgData) # $s0, 0x800e
+/* 0903D0 8008F7D0 26100840 */  addiu $s0, %lo(gTrackSelectBgData) # addiu $s0, $s0, 0x840
 .L8008F7D4:
 /* 0903D4 8008F7D4 92190005 */  lbu   $t9, 5($s0)
 /* 0903D8 8008F7D8 24630005 */  addiu $v1, $v1, 5
@@ -135,10 +135,10 @@ glabel func_8008F618
 /* 090418 8008F818 00000000 */  nop   
 .L8008F81C:
 /* 09041C 8008F81C 92180001 */  lbu   $t8, 1($s0)
-/* 090420 8008F820 3C05800E */  lui   $a1, %hi(D_800E0730) # $a1, 0x800e
+/* 090420 8008F820 3C05800E */  lui   $a1, %hi(gTracksMenuBgTextures) # $a1, 0x800e
 /* 090424 8008F824 0018C880 */  sll   $t9, $t8, 2
 /* 090428 8008F828 00B92821 */  addu  $a1, $a1, $t9
-/* 09042C 8008F82C 8CA50730 */  lw    $a1, %lo(D_800E0730)($a1)
+/* 09042C 8008F82C 8CA50730 */  lw    $a1, %lo(gTracksMenuBgTextures)($a1)
 /* 090430 8008F830 A6340002 */  sh    $s4, 2($s1)
 /* 090434 8008F834 920E0002 */  lbu   $t6, 2($s0)
 /* 090438 8008F838 A634000C */  sh    $s4, 0xc($s1)

--- a/asm/non_matchings/menu/func_80092188.s
+++ b/asm/non_matchings/menu/func_80092188.s
@@ -230,24 +230,24 @@ glabel L8009246C
 /* 0930C8 800924C8 AFAE003C */   sw    $t6, 0x3c($sp)
 .L800924CC:
 /* 0930CC 800924CC 84426838 */  lh    $v0, %lo(D_80126830 + 8)($v0)
-/* 0930D0 800924D0 3C19800E */  lui   $t9, %hi(D_800E0418) # $t9, 0x800e
+/* 0930D0 800924D0 3C19800E */  lui   $t9, %hi(gTracksMenuAdventureHighlightIndex) # $t9, 0x800e
 /* 0930D4 800924D4 18400008 */  blez  $v0, .L800924F8
 /* 0930D8 800924D8 00000000 */   nop   
-/* 0930DC 800924DC 8F390418 */  lw    $t9, %lo(D_800E0418)($t9)
-/* 0930E0 800924E0 3C01800E */  lui   $at, %hi(D_800E0418) # $at, 0x800e
+/* 0930DC 800924DC 8F390418 */  lw    $t9, %lo(gTracksMenuAdventureHighlightIndex)($t9)
+/* 0930E0 800924E0 3C01800E */  lui   $at, %hi(gTracksMenuAdventureHighlightIndex) # $at, 0x800e
 /* 0930E4 800924E4 13200004 */  beqz  $t9, .L800924F8
 /* 0930E8 800924E8 240F0001 */   li    $t7, 1
-/* 0930EC 800924EC AC200418 */  sw    $zero, %lo(D_800E0418)($at)
+/* 0930EC 800924EC AC200418 */  sw    $zero, %lo(gTracksMenuAdventureHighlightIndex)($at)
 /* 0930F0 800924F0 10000189 */  b     .L80092B18
 /* 0930F4 800924F4 AFAF0034 */   sw    $t7, 0x34($sp)
 .L800924F8:
 /* 0930F8 800924F8 04410187 */  bgez  $v0, .L80092B18
-/* 0930FC 800924FC 3C18800E */   lui   $t8, %hi(D_800E0418) # $t8, 0x800e
-/* 093100 80092500 8F180418 */  lw    $t8, %lo(D_800E0418)($t8)
+/* 0930FC 800924FC 3C18800E */   lui   $t8, %hi(gTracksMenuAdventureHighlightIndex) # $t8, 0x800e
+/* 093100 80092500 8F180418 */  lw    $t8, %lo(gTracksMenuAdventureHighlightIndex)($t8)
 /* 093104 80092504 241F0001 */  li    $ra, 1
 /* 093108 80092508 17000183 */  bnez  $t8, .L80092B18
-/* 09310C 8009250C 3C01800E */   lui   $at, %hi(D_800E0418) # $at, 0x800e
-/* 093110 80092510 AC3F0418 */  sw    $ra, %lo(D_800E0418)($at)
+/* 09310C 8009250C 3C01800E */   lui   $at, %hi(gTracksMenuAdventureHighlightIndex) # $at, 0x800e
+/* 093110 80092510 AC3F0418 */  sw    $ra, %lo(gTracksMenuAdventureHighlightIndex)($at)
 /* 093114 80092514 10000180 */  b     .L80092B18
 /* 093118 80092518 AFBF0034 */   sw    $ra, 0x34($sp)
 glabel L8009251C
@@ -431,10 +431,10 @@ glabel L80092740
 /* 093394 80092794 AFB8003C */  sw    $t8, 0x3c($sp)
 .L80092798:
 /* 093398 80092798 84636830 */  lh    $v1, %lo(D_80126830)($v1)
-/* 09339C 8009279C 3C02800E */  lui   $v0, %hi(D_800E0414) # $v0, 0x800e
+/* 09339C 8009279C 3C02800E */  lui   $v0, %hi(gTracksMenuTimeTrialHighlightIndex) # $v0, 0x800e
 /* 0933A0 800927A0 18600015 */  blez  $v1, .L800927F8
 /* 0933A4 800927A4 00000000 */   nop   
-/* 0933A8 800927A8 8C420414 */  lw    $v0, %lo(D_800E0414)($v0)
+/* 0933A8 800927A8 8C420414 */  lw    $v0, %lo(gTracksMenuTimeTrialHighlightIndex)($v0)
 /* 0933AC 800927AC 3C048012 */  lui   $a0, %hi(D_80126848) # $a0, 0x8012
 /* 0933B0 800927B0 18400011 */  blez  $v0, .L800927F8
 /* 0933B4 800927B4 00000000 */   nop   
@@ -445,20 +445,20 @@ glabel L80092740
 /* 0933C8 800927C8 0C001223 */  jal   func_8000488C
 /* 0933CC 800927CC 00000000 */   nop   
 /* 0933D0 800927D0 3C038012 */  lui   $v1, %hi(D_80126830) # $v1, 0x8012
-/* 0933D4 800927D4 3C02800E */  lui   $v0, %hi(D_800E0414) # $v0, 0x800e
-/* 0933D8 800927D8 8C420414 */  lw    $v0, %lo(D_800E0414)($v0)
+/* 0933D4 800927D4 3C02800E */  lui   $v0, %hi(gTracksMenuTimeTrialHighlightIndex) # $v0, 0x800e
+/* 0933D8 800927D8 8C420414 */  lw    $v0, %lo(gTracksMenuTimeTrialHighlightIndex)($v0)
 /* 0933DC 800927DC 84636830 */  lh    $v1, %lo(D_80126830)($v1)
 /* 0933E0 800927E0 00000000 */  nop   
 /* 0933E4 800927E4 244EFFFF */  addiu $t6, $v0, -1
 .L800927E8:
-/* 0933E8 800927E8 3C01800E */  lui   $at, %hi(D_800E0414) # $at, 0x800e
+/* 0933E8 800927E8 3C01800E */  lui   $at, %hi(gTracksMenuTimeTrialHighlightIndex) # $at, 0x800e
 /* 0933EC 800927EC 240F0001 */  li    $t7, 1
-/* 0933F0 800927F0 AC2E0414 */  sw    $t6, %lo(D_800E0414)($at)
+/* 0933F0 800927F0 AC2E0414 */  sw    $t6, %lo(gTracksMenuTimeTrialHighlightIndex)($at)
 /* 0933F4 800927F4 AFAF0034 */  sw    $t7, 0x34($sp)
 .L800927F8:
 /* 0933F8 800927F8 046100C7 */  bgez  $v1, .L80092B18
-/* 0933FC 800927FC 3C19800E */   lui   $t9, %hi(D_800E0414) # $t9, 0x800e
-/* 093400 80092800 8F390414 */  lw    $t9, %lo(D_800E0414)($t9)
+/* 0933FC 800927FC 3C19800E */   lui   $t9, %hi(gTracksMenuTimeTrialHighlightIndex) # $t9, 0x800e
+/* 093400 80092800 8F390414 */  lw    $t9, %lo(gTracksMenuTimeTrialHighlightIndex)($t9)
 /* 093404 80092804 3C048012 */  lui   $a0, %hi(D_80126840) # $a0, 0x8012
 /* 093408 80092808 1F2000C4 */  bgtz  $t9, .L80092B1C
 /* 09340C 8009280C 8FAF003C */   lw    $t7, 0x3c($sp)
@@ -486,12 +486,12 @@ glabel L80092740
 /* 09345C 8009285C 0C000741 */  jal   play_sound_global
 /* 093460 80092860 24A56848 */   addiu $a1, %lo(D_80126848) # addiu $a1, $a1, 0x6848
 .L80092864:
-/* 093464 80092864 3C0E800E */  lui   $t6, %hi(D_800E0414) # $t6, 0x800e
-/* 093468 80092868 8DCE0414 */  lw    $t6, %lo(D_800E0414)($t6)
-/* 09346C 8009286C 3C01800E */  lui   $at, %hi(D_800E0414) # $at, 0x800e
+/* 093464 80092864 3C0E800E */  lui   $t6, %hi(gTracksMenuTimeTrialHighlightIndex) # $t6, 0x800e
+/* 093468 80092868 8DCE0414 */  lw    $t6, %lo(gTracksMenuTimeTrialHighlightIndex)($t6)
+/* 09346C 8009286C 3C01800E */  lui   $at, %hi(gTracksMenuTimeTrialHighlightIndex) # $at, 0x800e
 /* 093470 80092870 25CF0001 */  addiu $t7, $t6, 1
 /* 093474 80092874 100000A8 */  b     .L80092B18
-/* 093478 80092878 AC2F0414 */   sw    $t7, %lo(D_800E0414)($at)
+/* 093478 80092878 AC2F0414 */   sw    $t7, %lo(gTracksMenuTimeTrialHighlightIndex)($at)
 glabel L8009287C
 /* 09347C 8009287C 24010002 */  li    $at, 2
 /* 093480 80092880 1461003E */  bne   $v1, $at, .L8009297C
@@ -574,9 +574,9 @@ glabel L8009287C
 /* 09359C 8009299C AC3FF47C */  sw    $ra, %lo(gMenuDelay)($at)
 /* 0935A0 800929A0 0C01E2AB */  jal   set_background_draw_function
 /* 0935A4 800929A4 00002025 */   move  $a0, $zero
-/* 0935A8 800929A8 3C01800E */  lui   $at, %hi(D_800E097C) # $at, 0x800e
+/* 0935A8 800929A8 3C01800E */  lui   $at, %hi(gIsInTracksMenu) # $at, 0x800e
 /* 0935AC 800929AC 0C030060 */  jal   disable_new_screen_transitions
-/* 0935B0 800929B0 AC20097C */   sw    $zero, %lo(D_800E097C)($at)
+/* 0935B0 800929B0 AC20097C */   sw    $zero, %lo(gIsInTracksMenu)($at)
 /* 0935B4 800929B4 3C04800E */  lui   $a0, %hi(sMenuTransitionFadeIn) # $a0, 0x800e
 /* 0935B8 800929B8 0C030076 */  jal   transition_begin
 /* 0935BC 800929BC 2484F774 */   addiu $a0, %lo(sMenuTransitionFadeIn) # addiu $a0, $a0, -0x88c
@@ -711,7 +711,7 @@ glabel L8009287C
 /* 093788 80092B88 10200006 */  beqz  $at, .L80092BA4
 /* 09378C 80092B8C 00000000 */   nop   
 /* 093790 80092B90 8DEF69C8 */  lw    $t7, %lo(D_801269C8)($t7)
-/* 093794 80092B94 3C04800E */  lui   $a0, %hi(D_800E0414) # $a0, 0x800e
+/* 093794 80092B94 3C04800E */  lui   $a0, %hi(gTracksMenuTimeTrialHighlightIndex) # $a0, 0x800e
 /* 093798 80092B98 29E10004 */  slti  $at, $t7, 4
 /* 09379C 80092B9C 14200005 */  bnez  $at, .L80092BB4
 /* 0937A0 80092BA0 00000000 */   nop   
@@ -721,12 +721,12 @@ glabel L8009287C
 /* 0937AC 80092BAC 10000004 */  b     .L80092BC0
 /* 0937B0 80092BB0 00000000 */   nop   
 .L80092BB4:
-/* 0937B4 80092BB4 8C840414 */  lw    $a0, %lo(D_800E0414)($a0)
+/* 0937B4 80092BB4 8C840414 */  lw    $a0, %lo(gTracksMenuTimeTrialHighlightIndex)($a0)
 /* 0937B8 80092BB8 0C00392F */  jal   set_time_trial_enabled
 /* 0937BC 80092BBC 00000000 */   nop   
 .L80092BC0:
-/* 0937C0 80092BC0 3C19800E */  lui   $t9, %hi(D_800E0418) # $t9, 0x800e
-/* 0937C4 80092BC4 8F390418 */  lw    $t9, %lo(D_800E0418)($t9)
+/* 0937C0 80092BC0 3C19800E */  lui   $t9, %hi(gTracksMenuAdventureHighlightIndex) # $t9, 0x800e
+/* 0937C4 80092BC4 8F390418 */  lw    $t9, %lo(gTracksMenuAdventureHighlightIndex)($t9)
 /* 0937C8 80092BC8 3C01800E */  lui   $at, %hi(gIsInAdventureTwo) # $at, 0x800e
 /* 0937CC 80092BCC AC39F494 */  sw    $t9, %lo(gIsInAdventureTwo)($at)
 /* 0937D0 80092BD0 8FBF001C */  lw    $ra, 0x1c($sp)

--- a/asm/non_matchings/menu/func_80094D28.s
+++ b/asm/non_matchings/menu/func_80094D28.s
@@ -183,8 +183,8 @@ glabel L80094DD0
 /* 095BA8 80094FA8 10000177 */  b     .L80095588
 /* 095BAC 80094FAC E5B00088 */   swc1  $f16, 0x88($t5)
 glabel L80094FB0
-/* 095BB0 80094FB0 3C02800E */  lui   $v0, %hi(D_800E0BEC) # $v0, 0x800e
-/* 095BB4 80094FB4 24420BEC */  addiu $v0, %lo(D_800E0BEC) # addiu $v0, $v0, 0xbec
+/* 095BB0 80094FB0 3C02800E */  lui   $v0, %hi(gRaceResultsMenuElements) # $v0, 0x800e
+/* 095BB4 80094FB4 24420BEC */  addiu $v0, %lo(gRaceResultsMenuElements) # addiu $v0, $v0, 0xbec
 /* 095BB8 80094FB8 00002825 */  move  $a1, $zero
 /* 095BBC 80094FBC 240800FF */  li    $t0, 255
 /* 095BC0 80094FC0 240700FF */  li    $a3, 255
@@ -221,10 +221,10 @@ glabel L80094FB0
 /* 095C30 80095030 1140000D */  beqz  $t2, .L80095068
 /* 095C34 80095034 00000000 */   nop   
 /* 095C38 80095038 82190058 */  lb    $t9, 0x58($s0)
-/* 095C3C 8009503C 3C02800E */  lui   $v0, %hi(D_800E0BEC) # $v0, 0x800e
+/* 095C3C 8009503C 3C02800E */  lui   $v0, %hi(gRaceResultsMenuElements) # $v0, 0x800e
 /* 095C40 80095040 33380080 */  andi  $t8, $t9, 0x80
 /* 095C44 80095044 13000008 */  beqz  $t8, .L80095068
-/* 095C48 80095048 24420BEC */   addiu $v0, %lo(D_800E0BEC) # addiu $v0, $v0, 0xbec
+/* 095C48 80095048 24420BEC */   addiu $v0, %lo(gRaceResultsMenuElements) # addiu $v0, $v0, 0xbec
 /* 095C4C 8009504C 00137843 */  sra   $t7, $s3, 1
 /* 095C50 80095050 25EB0080 */  addiu $t3, $t7, 0x80
 /* 095C54 80095054 01131823 */  subu  $v1, $t0, $s3
@@ -233,16 +233,16 @@ glabel L80094FB0
 /* 095C60 80095060 10000149 */  b     .L80095588
 /* 095C64 80095064 A04300CE */   sb    $v1, 0xce($v0)
 .L80095068:
-/* 095C68 80095068 3C02800E */  lui   $v0, %hi(D_800E0BEC) # $v0, 0x800e
-/* 095C6C 8009506C 24420BEC */  addiu $v0, %lo(D_800E0BEC) # addiu $v0, $v0, 0xbec
+/* 095C68 80095068 3C02800E */  lui   $v0, %hi(gRaceResultsMenuElements) # $v0, 0x800e
+/* 095C6C 8009506C 24420BEC */  addiu $v0, %lo(gRaceResultsMenuElements) # addiu $v0, $v0, 0xbec
 /* 095C70 80095070 240C0080 */  li    $t4, 128
 /* 095C74 80095074 A04C00CC */  sb    $t4, 0xcc($v0)
 /* 095C78 80095078 A04700CD */  sb    $a3, 0xcd($v0)
 /* 095C7C 8009507C 10000142 */  b     .L80095588
 /* 095C80 80095080 A04700CE */   sb    $a3, 0xce($v0)
 glabel L80095084
-/* 095C84 80095084 3C06800E */  lui   $a2, %hi(D_800E0CEC+224) # $a2, 0x800e
-/* 095C88 80095088 24C60DCC */  addiu $a2, %lo(D_800E0CEC+224) # addiu $a2, $a2, 0xdcc
+/* 095C84 80095084 3C06800E */  lui   $a2, %hi(gRaceOrderMenuElements+224) # $a2, 0x800e
+/* 095C88 80095088 24C60DCC */  addiu $a2, %lo(gRaceOrderMenuElements+224) # addiu $a2, $a2, 0xdcc
 /* 095C8C 8009508C 00002825 */  move  $a1, $zero
 /* 095C90 80095090 24110008 */  li    $s1, 8
 .L80095094:
@@ -281,17 +281,17 @@ glabel L80095084
 /* 095D0C 8009510C 00000000 */   nop   
 glabel L80095110
 /* 095D10 80095110 820A0117 */  lb    $t2, 0x117($s0)
-/* 095D14 80095114 3C02800E */  lui   $v0, %hi(D_800E0E4C) # $v0, 0x800e
+/* 095D14 80095114 3C02800E */  lui   $v0, %hi(gRecordTimesMenuElements) # $v0, 0x800e
 /* 095D18 80095118 11400014 */  beqz  $t2, .L8009516C
-/* 095D1C 8009511C 24420E4C */   addiu $v0, %lo(D_800E0E4C) # addiu $v0, $v0, 0xe4c
+/* 095D1C 8009511C 24420E4C */   addiu $v0, %lo(gRecordTimesMenuElements) # addiu $v0, $v0, 0xe4c
 /* 095D20 80095120 82190058 */  lb    $t9, 0x58($s0)
 /* 095D24 80095124 24030003 */  li    $v1, 3
 /* 095D28 80095128 3338007F */  andi  $t8, $t9, 0x7f
 /* 095D2C 8009512C 13000010 */  beqz  $t8, .L80095170
 /* 095D30 80095130 240700FF */   li    $a3, 255
 /* 095D34 80095134 02630019 */  multu $s3, $v1
-/* 095D38 80095138 3C02800E */  lui   $v0, %hi(D_800E0E4C) # $v0, 0x800e
-/* 095D3C 8009513C 24420E4C */  addiu $v0, %lo(D_800E0E4C) # addiu $v0, $v0, 0xe4c
+/* 095D38 80095138 3C02800E */  lui   $v0, %hi(gRecordTimesMenuElements) # $v0, 0x800e
+/* 095D3C 8009513C 24420E4C */  addiu $v0, %lo(gRecordTimesMenuElements) # addiu $v0, $v0, 0xe4c
 /* 095D40 80095140 240400C0 */  li    $a0, 192
 /* 095D44 80095144 240800FF */  li    $t0, 255
 /* 095D48 80095148 240700FF */  li    $a3, 255
@@ -610,8 +610,8 @@ glabel L80095588
 /* 0961CC 800955CC 15800004 */  bnez  $t4, .L800955E0
 /* 0961D0 800955D0 3C0D8012 */   lui   $t5, %hi(gMenuOptionCount) # $t5, 0x8012
 /* 0961D4 800955D4 C4328520 */  lwc1  $f18, %lo(D_800E8520)($at)
-/* 0961D8 800955D8 3C01800E */  lui   $at, %hi(D_800DF454) # $at, 0x800e
-/* 0961DC 800955DC E432F454 */  swc1  $f18, %lo(D_800DF454)($at)
+/* 0961D8 800955D8 3C01800E */  lui   $at, %hi(gTrackSelectWoodFrameHeightScale) # $at, 0x800e
+/* 0961DC 800955DC E432F454 */  swc1  $f18, %lo(gTrackSelectWoodFrameHeightScale)($at)
 .L800955E0:
 /* 0961E0 800955E0 8DAD63E0 */  lw    $t5, %lo(gMenuOptionCount)($t5)
 /* 0961E4 800955E4 00000000 */  nop   
@@ -622,8 +622,8 @@ glabel L80095588
 /* 0961F8 800955F8 3C013F80 */  li    $at, 0x3F800000 # 1.000000
 .L800955FC:
 /* 0961FC 800955FC 44813000 */  mtc1  $at, $f6
-/* 096200 80095600 3C01800E */  lui   $at, %hi(D_800DF454) # $at, 0x800e
-/* 096204 80095604 E426F454 */  swc1  $f6, %lo(D_800DF454)($at)
+/* 096200 80095600 3C01800E */  lui   $at, %hi(gTrackSelectWoodFrameHeightScale) # $at, 0x800e
+/* 096204 80095604 E426F454 */  swc1  $f6, %lo(gTrackSelectWoodFrameHeightScale)($at)
 .L80095608:
 /* 096208 80095608 8FBF002C */  lw    $ra, 0x2c($sp)
 .L8009560C:

--- a/asm/non_matchings/menu/func_80096978.s
+++ b/asm/non_matchings/menu/func_80096978.s
@@ -252,9 +252,9 @@ glabel func_80096978
 /* 09793C 80096D3C 3C18800E */  lui   $t8, %hi(gNumberOfActivePlayers) # $t8, 0x800e
 /* 097940 80096D40 8F18F4BC */  lw    $t8, %lo(gNumberOfActivePlayers)($t8)
 /* 097944 80096D44 A022F4AC */  sb    $v0, %lo(sMenuGuiColourB)($at)
-/* 097948 80096D48 3C01800E */  lui   $at, %hi(D_800DF4B0) # $at, 0x800e
+/* 097948 80096D48 3C01800E */  lui   $at, %hi(sMenuGuiColourA) # $at, 0x800e
 /* 09794C 80096D4C 1B00006E */  blez  $t8, .L80096F08
-/* 097950 80096D50 A022F4B0 */   sb    $v0, %lo(D_800DF4B0)($at)
+/* 097950 80096D50 A022F4B0 */   sb    $v0, %lo(sMenuGuiColourA)($at)
 /* 097954 80096D54 8FAB00A8 */  lw    $t3, 0xa8($sp)
 /* 097958 80096D58 240D0078 */  li    $t5, 120
 /* 09795C 80096D5C 8FA900A0 */  lw    $t1, 0xa0($sp)
@@ -393,8 +393,8 @@ glabel func_80096978
 /* 097B48 80096F48 A02EF4A8 */  sb    $t6, %lo(sMenuGuiColourG)($at)
 /* 097B4C 80096F4C 8FB80078 */  lw    $t8, 0x78($sp)
 /* 097B50 80096F50 8FA80070 */  lw    $t0, 0x70($sp)
-/* 097B54 80096F54 3C01800E */  lui   $at, %hi(D_800DF4B0) # $at, 0x800e
-/* 097B58 80096F58 A020F4B0 */  sb    $zero, %lo(D_800DF4B0)($at)
+/* 097B54 80096F54 3C01800E */  lui   $at, %hi(sMenuGuiColourA) # $at, 0x800e
+/* 097B58 80096F58 A020F4B0 */  sb    $zero, %lo(sMenuGuiColourA)($at)
 /* 097B5C 80096F5C 25F90001 */  addiu $t9, $t7, 1
 /* 097B60 80096F60 2B210004 */  slti  $at, $t9, 4
 /* 097B64 80096F64 27090004 */  addiu $t1, $t8, 4

--- a/asm/non_matchings/menu/func_80098774.s
+++ b/asm/non_matchings/menu/func_80098774.s
@@ -11,7 +11,7 @@ glabel func_80098774
 /* 099398 80098798 0C01BAA4 */  jal   get_settings
 /* 09939C 8009879C AFB00018 */   sw    $s0, 0x18($sp)
 /* 0993A0 800987A0 12C00007 */  beqz  $s6, .L800987C0
-/* 0993A4 800987A4 3C05800E */   lui   $a1, %hi(D_800E1048) # $a1, 0x800e
+/* 0993A4 800987A4 3C05800E */   lui   $a1, %hi(gTrophyRankingsTitle) # $a1, 0x800e
 /* 0993A8 800987A8 3C0E800E */  lui   $t6, %hi(gMenuText) # $t6, 0x800e
 /* 0993AC 800987AC 8DCEF4A0 */  lw    $t6, %lo(gMenuText)($t6)
 /* 0993B0 800987B0 00000000 */  nop   
@@ -25,7 +25,7 @@ glabel func_80098774
 /* 0993CC 800987CC 8DE3007C */  lw    $v1, 0x7c($t7)
 /* 0993D0 800987D0 00000000 */  nop   
 .L800987D4:
-/* 0993D4 800987D4 24A51048 */  addiu $a1, %lo(D_800E1048) # addiu $a1, $a1, 0x1048
+/* 0993D4 800987D4 24A51048 */  addiu $a1, %lo(gTrophyRankingsTitle) # addiu $a1, $a1, 0x1048
 /* 0993D8 800987D8 ACA30014 */  sw    $v1, 0x14($a1)
 /* 0993DC 800987DC ACA30034 */  sw    $v1, 0x34($a1)
 /* 0993E0 800987E0 3C09800E */  lui   $t1, %hi(gRankingPlayerCount) # $t1, 0x800e
@@ -40,9 +40,9 @@ glabel func_80098774
 /* 099404 80098804 27080010 */  addiu $t0, $t8, 0x10
 /* 099408 80098808 24070108 */  li    $a3, 264
 .L8009880C:
-/* 09940C 8009880C 3C03800E */  lui   $v1, %hi(D_800E14BC) # $v1, 0x800e
+/* 09940C 8009880C 3C03800E */  lui   $v1, %hi(gTrophyRankingsIconPositions) # $v1, 0x800e
 /* 099410 80098810 00087080 */  sll   $t6, $t0, 2
-/* 099414 80098814 246314BC */  addiu $v1, %lo(D_800E14BC) # addiu $v1, $v1, 0x14bc
+/* 099414 80098814 246314BC */  addiu $v1, %lo(gTrophyRankingsIconPositions) # addiu $v1, $v1, 0x14bc
 /* 099418 80098818 25080001 */  addiu $t0, $t0, 1
 /* 09941C 8009881C 006E7821 */  addu  $t7, $v1, $t6
 /* 099420 80098820 0008C080 */  sll   $t8, $t0, 2
@@ -167,8 +167,8 @@ glabel func_80098774
 /* 0995DC 800989DC 258C0060 */  addiu $t4, $t4, 0x60
 /* 0995E0 800989E0 1420FFA8 */  bnez  $at, .L80098884
 /* 0995E4 800989E4 256B0060 */   addiu $t3, $t3, 0x60
-/* 0995E8 800989E8 3C05800E */  lui   $a1, %hi(D_800E1048) # $a1, 0x800e
-/* 0995EC 800989EC 24A51048 */  addiu $a1, %lo(D_800E1048) # addiu $a1, $a1, 0x1048
+/* 0995E8 800989E8 3C05800E */  lui   $a1, %hi(gTrophyRankingsTitle) # $a1, 0x800e
+/* 0995EC 800989EC 24A51048 */  addiu $a1, %lo(gTrophyRankingsTitle) # addiu $a1, $a1, 0x1048
 .L800989F0:
 /* 0995F0 800989F0 00107140 */  sll   $t6, $s0, 5
 .L800989F4:

--- a/asm/non_matchings/menu/load_menu_text.s
+++ b/asm/non_matchings/menu/load_menu_text.s
@@ -96,22 +96,22 @@ glabel load_menu_text
 /* 080658 8007FA58 2463FDA0 */  addiu $v1, %lo(gMagicCodeMenuStrings) # addiu $v1, $v1, -0x260
 /* 08065C 8007FA5C AC59003C */  sw    $t9, 0x3c($v0)
 /* 080660 8007FA60 8C8A0018 */  lw    $t2, 0x18($a0)
-/* 080664 8007FA64 3C07800E */  lui   $a3, %hi(D_800E0BEC) # $a3, 0x800e
+/* 080664 8007FA64 3C07800E */  lui   $a3, %hi(gRaceResultsMenuElements) # $a3, 0x800e
 /* 080668 8007FA68 AC4A004C */  sw    $t2, 0x4c($v0)
 /* 08066C 8007FA6C 8C8B0018 */  lw    $t3, 0x18($a0)
-/* 080670 8007FA70 24E70BEC */  addiu $a3, %lo(D_800E0BEC) # addiu $a3, $a3, 0xbec
+/* 080670 8007FA70 24E70BEC */  addiu $a3, %lo(gRaceResultsMenuElements) # addiu $a3, $a3, 0xbec
 /* 080674 8007FA74 AC4B005C */  sw    $t3, 0x5c($v0)
 /* 080678 8007FA78 8C8C001C */  lw    $t4, 0x1c($a0)
-/* 08067C 8007FA7C 3C09800E */  lui   $t1, %hi(D_800E0CEC) # $t1, 0x800e
+/* 08067C 8007FA7C 3C09800E */  lui   $t1, %hi(gRaceOrderMenuElements) # $t1, 0x800e
 /* 080680 8007FA80 AC2C69E0 */  sw    $t4, %lo(gMusicTestString)($at)
 /* 080684 8007FA84 8C8D0038 */  lw    $t5, 0x38($a0)
-/* 080688 8007FA88 25290CEC */  addiu $t1, %lo(D_800E0CEC) # addiu $t1, $t1, 0xcec
+/* 080688 8007FA88 25290CEC */  addiu $t1, %lo(gRaceOrderMenuElements) # addiu $t1, $t1, 0xcec
 /* 08068C 8007FA8C AC6D0000 */  sw    $t5, ($v1)
 /* 080690 8007FA90 8C8E003C */  lw    $t6, 0x3c($a0)
-/* 080694 8007FA94 3C06800E */  lui   $a2, %hi(D_800E0E4C) # $a2, 0x800e
+/* 080694 8007FA94 3C06800E */  lui   $a2, %hi(gRecordTimesMenuElements) # $a2, 0x800e
 /* 080698 8007FA98 AC6E0004 */  sw    $t6, 4($v1)
 /* 08069C 8007FA9C 8C8F0040 */  lw    $t7, 0x40($a0)
-/* 0806A0 8007FAA0 24C60E4C */  addiu $a2, %lo(D_800E0E4C) # addiu $a2, $a2, 0xe4c
+/* 0806A0 8007FAA0 24C60E4C */  addiu $a2, %lo(gRecordTimesMenuElements) # addiu $a2, $a2, 0xe4c
 /* 0806A4 8007FAA4 AC6F0008 */  sw    $t7, 8($v1)
 /* 0806A8 8007FAA8 8C980014 */  lw    $t8, 0x14($a0)
 /* 0806AC 8007FAAC 3C02800E */  lui   $v0, %hi(gOptionMenuStrings) # $v0, 0x800e
@@ -163,58 +163,58 @@ glabel load_menu_text
 /* 08075C 8007FB5C 24C603B0 */  addiu $a2, %lo(gFilenames) # addiu $a2, $a2, 0x3b0
 /* 080760 8007FB60 AC59000C */  sw    $t9, 0xc($v0)
 /* 080764 8007FB64 8C8A0044 */  lw    $t2, 0x44($a0)
-/* 080768 8007FB68 3C07800E */  lui   $a3, %hi(D_800DFAE4) # $a3, 0x800e
+/* 080768 8007FB68 3C07800E */  lui   $a3, %hi(gContPakNotPresentStrings) # $a3, 0x800e
 /* 08076C 8007FB6C AC4A0010 */  sw    $t2, 0x10($v0)
 /* 080770 8007FB70 8C8B0014 */  lw    $t3, 0x14($a0)
-/* 080774 8007FB74 24E7FAE4 */  addiu $a3, %lo(D_800DFAE4) # addiu $a3, $a3, -0x51c
+/* 080774 8007FB74 24E7FAE4 */  addiu $a3, %lo(gContPakNotPresentStrings) # addiu $a3, $a3, -0x51c
 /* 080778 8007FB78 AC4B0014 */  sw    $t3, 0x14($v0)
 /* 08077C 8007FB7C 8C8C0120 */  lw    $t4, 0x120($a0)
-/* 080780 8007FB80 3C03800E */  lui   $v1, %hi(D_800DFAFC) # $v1, 0x800e
+/* 080780 8007FB80 3C03800E */  lui   $v1, %hi(gContPakCorruptDataRepairStrings) # $v1, 0x800e
 /* 080784 8007FB84 ACCC0000 */  sw    $t4, ($a2)
 /* 080788 8007FB88 8C8D0124 */  lw    $t5, 0x124($a0)
-/* 08078C 8007FB8C 2463FAFC */  addiu $v1, %lo(D_800DFAFC) # addiu $v1, $v1, -0x504
+/* 08078C 8007FB8C 2463FAFC */  addiu $v1, %lo(gContPakCorruptDataRepairStrings) # addiu $v1, $v1, -0x504
 /* 080790 8007FB90 ACCD0004 */  sw    $t5, 4($a2)
 /* 080794 8007FB94 8C8E0128 */  lw    $t6, 0x128($a0)
-/* 080798 8007FB98 3C05800E */  lui   $a1, %hi(D_800DFB14) # $a1, 0x800e
+/* 080798 8007FB98 3C05800E */  lui   $a1, %hi(gContPakDamagedStrings) # $a1, 0x800e
 /* 08079C 8007FB9C ACCE0008 */  sw    $t6, 8($a2)
 /* 0807A0 8007FBA0 8C8F0168 */  lw    $t7, 0x168($a0)
-/* 0807A4 8007FBA4 24A5FB14 */  addiu $a1, %lo(D_800DFB14) # addiu $a1, $a1, -0x4ec
+/* 0807A4 8007FBA4 24A5FB14 */  addiu $a1, %lo(gContPakDamagedStrings) # addiu $a1, $a1, -0x4ec
 /* 0807A8 8007FBA8 ACEF0000 */  sw    $t7, ($a3)
 /* 0807AC 8007FBAC 8C98016C */  lw    $t8, 0x16c($a0)
-/* 0807B0 8007FBB0 3C08800E */  lui   $t0, %hi(D_800DFB2C) # $t0, 0x800e
+/* 0807B0 8007FBB0 3C08800E */  lui   $t0, %hi(gContPakFullStrings) # $t0, 0x800e
 /* 0807B4 8007FBB4 ACF80004 */  sw    $t8, 4($a3)
 /* 0807B8 8007FBB8 8C990154 */  lw    $t9, 0x154($a0)
-/* 0807BC 8007FBBC 2508FB2C */  addiu $t0, %lo(D_800DFB2C) # addiu $t0, $t0, -0x4d4
+/* 0807BC 8007FBBC 2508FB2C */  addiu $t0, %lo(gContPakFullStrings) # addiu $t0, $t0, -0x4d4
 /* 0807C0 8007FBC0 ACF9000C */  sw    $t9, 0xc($a3)
 /* 0807C4 8007FBC4 8C8A0168 */  lw    $t2, 0x168($a0)
-/* 0807C8 8007FBC8 3C02800E */  lui   $v0, %hi(D_800DFB40) # $v0, 0x800e
+/* 0807C8 8007FBC8 3C02800E */  lui   $v0, %hi(gContPakDiffContStrings) # $v0, 0x800e
 /* 0807CC 8007FBCC AC6A0000 */  sw    $t2, ($v1)
 /* 0807D0 8007FBD0 8C8B0174 */  lw    $t3, 0x174($a0)
-/* 0807D4 8007FBD4 2442FB40 */  addiu $v0, %lo(D_800DFB40) # addiu $v0, $v0, -0x4c0
+/* 0807D4 8007FBD4 2442FB40 */  addiu $v0, %lo(gContPakDiffContStrings) # addiu $v0, $v0, -0x4c0
 /* 0807D8 8007FBD8 AC6B0004 */  sw    $t3, 4($v1)
 /* 0807DC 8007FBDC 8C8C0178 */  lw    $t4, 0x178($a0)
-/* 0807E0 8007FBE0 3C06800E */  lui   $a2, %hi(D_800DFB8C) # $a2, 0x800e
+/* 0807E0 8007FBE0 3C06800E */  lui   $a2, %hi(gContPakRumbleDetectedStrings) # $a2, 0x800e
 /* 0807E4 8007FBE4 AC6C000C */  sw    $t4, 0xc($v1)
 /* 0807E8 8007FBE8 8C8D0154 */  lw    $t5, 0x154($a0)
-/* 0807EC 8007FBEC 24C6FB8C */  addiu $a2, %lo(D_800DFB8C) # addiu $a2, $a2, -0x474
+/* 0807EC 8007FBEC 24C6FB8C */  addiu $a2, %lo(gContPakRumbleDetectedStrings) # addiu $a2, $a2, -0x474
 /* 0807F0 8007FBF0 AC6D0010 */  sw    $t5, 0x10($v1)
 /* 0807F4 8007FBF4 8C8E0168 */  lw    $t6, 0x168($a0)
-/* 0807F8 8007FBF8 3C03800E */  lui   $v1, %hi(D_800DFB5C) # $v1, 0x800e
+/* 0807F8 8007FBF8 3C03800E */  lui   $v1, %hi(gContPakNoRoomForGhostsStrings) # $v1, 0x800e
 /* 0807FC 8007FBFC ACAE0000 */  sw    $t6, ($a1)
 /* 080800 8007FC00 8C8F017C */  lw    $t7, 0x17c($a0)
-/* 080804 8007FC04 2463FB5C */  addiu $v1, %lo(D_800DFB5C) # addiu $v1, $v1, -0x4a4
+/* 080804 8007FC04 2463FB5C */  addiu $v1, %lo(gContPakNoRoomForGhostsStrings) # addiu $v1, $v1, -0x4a4
 /* 080808 8007FC08 ACAF0004 */  sw    $t7, 4($a1)
 /* 08080C 8007FC0C 8C980180 */  lw    $t8, 0x180($a0)
-/* 080810 8007FC10 3C07800E */  lui   $a3, %hi(D_800DFBA4) # $a3, 0x800e
+/* 080810 8007FC10 3C07800E */  lui   $a3, %hi(gContPakSwitchToRumbleStrings) # $a3, 0x800e
 /* 080814 8007FC14 ACB8000C */  sw    $t8, 0xc($a1)
 /* 080818 8007FC18 8C990154 */  lw    $t9, 0x154($a0)
-/* 08081C 8007FC1C 24E7FBA4 */  addiu $a3, %lo(D_800DFBA4) # addiu $a3, $a3, -0x45c
+/* 08081C 8007FC1C 24E7FBA4 */  addiu $a3, %lo(gContPakSwitchToRumbleStrings) # addiu $a3, $a3, -0x45c
 /* 080820 8007FC20 ACB90010 */  sw    $t9, 0x10($a1)
 /* 080824 8007FC24 8C8A0168 */  lw    $t2, 0x168($a0)
-/* 080828 8007FC28 3C05800E */  lui   $a1, %hi(D_800DFB74) # $a1, 0x800e
+/* 080828 8007FC28 3C05800E */  lui   $a1, %hi(gContPakCorruptDataStrings) # $a1, 0x800e
 /* 08082C 8007FC2C AD0A0000 */  sw    $t2, ($t0)
 /* 080830 8007FC30 8C8B0184 */  lw    $t3, 0x184($a0)
-/* 080834 8007FC34 24A5FB74 */  addiu $a1, %lo(D_800DFB74) # addiu $a1, $a1, -0x48c
+/* 080834 8007FC34 24A5FB74 */  addiu $a1, %lo(gContPakCorruptDataStrings) # addiu $a1, $a1, -0x48c
 /* 080838 8007FC38 AD0B0004 */  sw    $t3, 4($t0)
 /* 08083C 8007FC3C 8C8C0188 */  lw    $t4, 0x188($a0)
 /* 080840 8007FC40 3C01800E */  lui   $at, %hi(sBadControllerPakMenuText) # $at, 0x800e
@@ -232,10 +232,10 @@ glabel load_menu_text
 /* 080870 8007FC70 250809F8 */  addiu $t0, %lo(D_800E09F8) # addiu $t0, $t0, 0x9f8
 /* 080874 8007FC74 AC580010 */  sw    $t8, 0x10($v0)
 /* 080878 8007FC78 8C990168 */  lw    $t9, 0x168($a0)
-/* 08087C 8007FC7C 3C02800E */  lui   $v0, %hi(D_800DFBBC) # $v0, 0x800e
+/* 08087C 8007FC7C 3C02800E */  lui   $v0, %hi(gContPakNeed2ndAdvStrings) # $v0, 0x800e
 /* 080880 8007FC80 AC790000 */  sw    $t9, ($v1)
 /* 080884 8007FC84 8C8A0198 */  lw    $t2, 0x198($a0)
-/* 080888 8007FC88 2442FBBC */  addiu $v0, %lo(D_800DFBBC) # addiu $v0, $v0, -0x444
+/* 080888 8007FC88 2442FBBC */  addiu $v0, %lo(gContPakNeed2ndAdvStrings) # addiu $v0, $v0, -0x444
 /* 08088C 8007FC8C AC6A0004 */  sw    $t2, 4($v1)
 /* 080890 8007FC90 8C8B019C */  lw    $t3, 0x19c($a0)
 /* 080894 8007FC94 00000000 */  nop   

--- a/asm/non_matchings/menu/menu_credits_loop.s
+++ b/asm/non_matchings/menu/menu_credits_loop.s
@@ -66,9 +66,9 @@ glabel menu_credits_loop
 /* 09C00C 8009B40C 3C068012 */  lui   $a2, %hi(gOpacityDecayTimer) # $a2, 0x8012
 /* 09C010 8009B410 24C663D8 */  addiu $a2, %lo(gOpacityDecayTimer) # addiu $a2, $a2, 0x63d8
 /* 09C014 8009B414 8CC20000 */  lw    $v0, ($a2)
-/* 09C018 8009B418 3C03800E */  lui   $v1, %hi(D_800DF460) # $v1, 0x800e
+/* 09C018 8009B418 3C03800E */  lui   $v1, %hi(gMenuCurIndex) # $v1, 0x800e
 /* 09C01C 8009B41C 18400041 */  blez  $v0, .L8009B524
-/* 09C020 8009B420 2463F460 */   addiu $v1, %lo(D_800DF460) # addiu $v1, $v1, -0xba0
+/* 09C020 8009B420 2463F460 */   addiu $v1, %lo(gMenuCurIndex) # addiu $v1, $v1, -0xba0
 /* 09C024 8009B424 8FAC0088 */  lw    $t4, 0x88($sp)
 /* 09C028 8009B428 8C6B0000 */  lw    $t3, ($v1)
 /* 09C02C 8009B42C 000C6A00 */  sll   $t5, $t4, 8
@@ -91,9 +91,9 @@ glabel menu_credits_loop
 /* 09C068 8009B468 32597FFF */  andi  $t9, $s2, 0x7fff
 /* 09C06C 8009B46C 3C10800E */  lui   $s0, %hi(gRacerPortraits) # $s0, 0x800e
 /* 09C070 8009B470 3C178012 */  lui   $s7, %hi(sMenuCurrDisplayList) # $s7, 0x8012
-/* 09C074 8009B474 3C16800E */  lui   $s6, %hi(D_800E0B18) # $s6, 0x800e
+/* 09C074 8009B474 3C16800E */  lui   $s6, %hi(unused_800E0B18) # $s6, 0x800e
 /* 09C078 8009B478 03209025 */  move  $s2, $t9
-/* 09C07C 8009B47C 26D60B18 */  addiu $s6, %lo(D_800E0B18) # addiu $s6, $s6, 0xb18
+/* 09C07C 8009B47C 26D60B18 */  addiu $s6, %lo(unused_800E0B18) # addiu $s6, $s6, 0xb18
 /* 09C080 8009B480 26F763A0 */  addiu $s7, %lo(sMenuCurrDisplayList) # addiu $s7, $s7, 0x63a0
 /* 09C084 8009B484 26100AF0 */  addiu $s0, %lo(gRacerPortraits) # addiu $s0, $s0, 0xaf0
 .L8009B488:
@@ -159,12 +159,12 @@ glabel menu_credits_loop
 /* 09C16C 8009B56C 3C013F00 */  li    $at, 0x3F000000 # 0.500000
 /* 09C170 8009B570 15A0012C */  bnez  $t5, .L8009BA24
 /* 09C174 8009B574 3C168012 */   lui   $s6, %hi(D_80126BC4) # $s6, 0x8012
-/* 09C178 8009B578 3C1E800E */  lui   $fp, %hi(D_800E17F4) # $fp, 0x800e
+/* 09C178 8009B578 3C1E800E */  lui   $fp, %hi(gCreditsControlData) # $fp, 0x800e
 /* 09C17C 8009B57C 3C08800E */  lui   $t0, %hi(gCreditsArray) # $t0, 0x800e
 /* 09C180 8009B580 4481A000 */  mtc1  $at, $f20
 /* 09C184 8009B584 AFA0006C */  sw    $zero, 0x6c($sp)
 /* 09C188 8009B588 25081938 */  addiu $t0, %lo(gCreditsArray) # addiu $t0, $t0, 0x1938
-/* 09C18C 8009B58C 27DE17F4 */  addiu $fp, %lo(D_800E17F4) # addiu $fp, $fp, 0x17f4
+/* 09C18C 8009B58C 27DE17F4 */  addiu $fp, %lo(gCreditsControlData) # addiu $fp, $fp, 0x17f4
 /* 09C190 8009B590 26D66BC4 */  addiu $s6, %lo(D_80126BC4) # addiu $s6, $s6, 0x6bc4
 /* 09C194 8009B594 24076000 */  li    $a3, 24576
 .L8009B598:
@@ -260,26 +260,26 @@ glabel menu_credits_loop
 /* 09C2D8 8009B6D8 024D9023 */  subu  $s2, $s2, $t5
 /* 09C2DC 8009B6DC 26520008 */  addiu $s2, $s2, 8
 .L8009B6E0:
-/* 09C2E0 8009B6E0 3C01800E */  lui   $at, %hi(D_800E1B50) # $at, 0x800e
-/* 09C2E4 8009B6E4 A42E1B50 */  sh    $t6, %lo(D_800E1B50)($at)
+/* 09C2E0 8009B6E0 3C01800E */  lui   $at, %hi(gCreditsMenuElements) # $at, 0x800e
+/* 09C2E4 8009B6E4 A42E1B50 */  sh    $t6, %lo(gCreditsMenuElements)($at)
 /* 09C2E8 8009B6E8 24013000 */  li    $at, 12288
 /* 09C2EC 8009B6EC 14410005 */  bne   $v0, $at, .L8009B704
 /* 09C2F0 8009B6F0 2418FF60 */   li    $t8, -160
 /* 09C2F4 8009B6F4 240F00A0 */  li    $t7, 160
-/* 09C2F8 8009B6F8 3C01800E */  lui   $at, %hi(D_800E1B50+8) # $at, 0x800e
+/* 09C2F8 8009B6F8 3C01800E */  lui   $at, %hi(gCreditsMenuElements+8) # $at, 0x800e
 /* 09C2FC 8009B6FC 10000003 */  b     .L8009B70C
-/* 09C300 8009B700 A42F1B58 */   sh    $t7, %lo(D_800E1B50+8)($at)
+/* 09C300 8009B700 A42F1B58 */   sh    $t7, %lo(gCreditsMenuElements+8)($at)
 .L8009B704:
-/* 09C304 8009B704 3C01800E */  lui   $at, %hi(D_800E1B50+8) # $at, 0x800e
-/* 09C308 8009B708 A4381B58 */  sh    $t8, %lo(D_800E1B50+8)($at)
+/* 09C304 8009B704 3C01800E */  lui   $at, %hi(gCreditsMenuElements+8) # $at, 0x800e
+/* 09C308 8009B708 A4381B58 */  sh    $t8, %lo(gCreditsMenuElements+8)($at)
 .L8009B70C:
 /* 09C30C 8009B70C 0205082A */  slt   $at, $s0, $a1
 /* 09C310 8009B710 10200042 */  beqz  $at, .L8009B81C
 /* 09C314 8009B714 0200A025 */   move  $s4, $s0
-/* 09C318 8009B718 3C10800E */  lui   $s0, %hi(D_800E1B50) # $s0, 0x800e
+/* 09C318 8009B718 3C10800E */  lui   $s0, %hi(gCreditsMenuElements) # $s0, 0x800e
 /* 09C31C 8009B71C 0014C840 */  sll   $t9, $s4, 1
 /* 09C320 8009B720 03D98821 */  addu  $s1, $fp, $t9
-/* 09C324 8009B724 26101B50 */  addiu $s0, %lo(D_800E1B50) # addiu $s0, $s0, 0x1b50
+/* 09C324 8009B724 26101B50 */  addiu $s0, %lo(gCreditsMenuElements) # addiu $s0, $s0, 0x1b50
 .L8009B728:
 /* 09C328 8009B728 A6120002 */  sh    $s2, 2($s0)
 /* 09C32C 8009B72C A6120006 */  sh    $s2, 6($s0)
@@ -308,10 +308,10 @@ glabel menu_credits_loop
 /* 09C388 8009B788 A2000031 */  sb    $zero, 0x31($s0)
 /* 09C38C 8009B78C 01EE7821 */  addu  $t7, $t7, $t6
 /* 09C390 8009B790 8DEF1A94 */  lw    $t7, %lo(gCreditsBestTimesArray)($t7)
-/* 09C394 8009B794 3C19800E */  lui   $t9, %hi(D_800E17F4) # $t9, 0x800e
+/* 09C394 8009B794 3C19800E */  lui   $t9, %hi(gCreditsControlData) # $t9, 0x800e
 /* 09C398 8009B798 83A6005B */  lb    $a2, 0x5b($sp)
 /* 09C39C 8009B79C 3C08800E */  lui   $t0, %hi(gCreditsArray) # $t0, 0x800e
-/* 09C3A0 8009B7A0 273917F4 */  addiu $t9, %lo(D_800E17F4) # addiu $t9, $t9, 0x17f4
+/* 09C3A0 8009B7A0 273917F4 */  addiu $t9, %lo(gCreditsControlData) # addiu $t9, $t9, 0x17f4
 /* 09C3A4 8009B7A4 0005C040 */  sll   $t8, $a1, 1
 /* 09C3A8 8009B7A8 25081938 */  addiu $t0, %lo(gCreditsArray) # addiu $t0, $t0, 0x1938
 /* 09C3AC 8009B7AC 03192021 */  addu  $a0, $t8, $t9
@@ -320,8 +320,8 @@ glabel menu_credits_loop
 /* 09C3B8 8009B7B8 10000013 */  b     .L8009B808
 /* 09C3BC 8009B7BC AE0FFFF4 */   sw    $t7, -0xc($s0)
 .L8009B7C0:
-/* 09C3C0 8009B7C0 3C0A800E */  lui   $t2, %hi(D_800E17F4) # $t2, 0x800e
-/* 09C3C4 8009B7C4 254A17F4 */  addiu $t2, %lo(D_800E17F4) # addiu $t2, $t2, 0x17f4
+/* 09C3C0 8009B7C0 3C0A800E */  lui   $t2, %hi(gCreditsControlData) # $t2, 0x800e
+/* 09C3C4 8009B7C4 254A17F4 */  addiu $t2, %lo(gCreditsControlData) # addiu $t2, $t2, 0x17f4
 /* 09C3C8 8009B7C8 00054840 */  sll   $t1, $a1, 1
 /* 09C3CC 8009B7CC 326C0001 */  andi  $t4, $s3, 1
 /* 09C3D0 8009B7D0 11800004 */  beqz  $t4, .L8009B7E4
@@ -346,8 +346,8 @@ glabel menu_credits_loop
 /* 09C414 8009B814 1420FFC4 */  bnez  $at, .L8009B728
 /* 09C418 8009B818 24170020 */   li    $s7, 32
 .L8009B81C:
-/* 09C41C 8009B81C 3C04800E */  lui   $a0, %hi(D_800E1B50) # $a0, 0x800e
-/* 09C420 8009B820 24841B50 */  addiu $a0, %lo(D_800E1B50) # addiu $a0, $a0, 0x1b50
+/* 09C41C 8009B81C 3C04800E */  lui   $a0, %hi(gCreditsMenuElements) # $a0, 0x800e
+/* 09C420 8009B820 24841B50 */  addiu $a0, %lo(gCreditsMenuElements) # addiu $a0, $a0, 0x1b50
 /* 09C424 8009B824 0013C940 */  sll   $t9, $s3, 5
 /* 09C428 8009B828 00994821 */  addu  $t1, $a0, $t9
 /* 09C42C 8009B82C AD200014 */  sw    $zero, 0x14($t1)
@@ -401,8 +401,8 @@ glabel menu_credits_loop
 /* 09C4E4 8009B8E4 1160FFF8 */  beqz  $t3, .L8009B8C8
 /* 09C4E8 8009B8E8 01202825 */   move  $a1, $t1
 .L8009B8EC:
-/* 09C4EC 8009B8EC 3C03800E */  lui   $v1, %hi(D_800E1B50) # $v1, 0x800e
-/* 09C4F0 8009B8F0 24631B50 */  addiu $v1, %lo(D_800E1B50) # addiu $v1, $v1, 0x1b50
+/* 09C4EC 8009B8EC 3C03800E */  lui   $v1, %hi(gCreditsMenuElements) # $v1, 0x800e
+/* 09C4F0 8009B8F0 24631B50 */  addiu $v1, %lo(gCreditsMenuElements) # addiu $v1, $v1, 0x1b50
 /* 09C4F4 8009B8F4 240400A0 */  li    $a0, 160
 /* 09C4F8 8009B8F8 24013000 */  li    $at, 12288
 /* 09C4FC 8009B8FC 14410003 */  bne   $v0, $at, .L8009B90C
@@ -419,8 +419,8 @@ glabel menu_credits_loop
 /* 09C520 8009B920 0010C140 */  sll   $t8, $s0, 5
 /* 09C524 8009B924 0018C823 */  negu  $t9, $t8
 /* 09C528 8009B928 00147940 */  sll   $t7, $s4, 5
-/* 09C52C 8009B92C 3C0A800E */  lui   $t2, %hi(D_800E1B50) # $t2, 0x800e
-/* 09C530 8009B930 254A1B50 */  addiu $t2, %lo(D_800E1B50) # addiu $t2, $t2, 0x1b50
+/* 09C52C 8009B92C 3C0A800E */  lui   $t2, %hi(gCreditsMenuElements) # $t2, 0x800e
+/* 09C530 8009B930 254A1B50 */  addiu $t2, %lo(gCreditsMenuElements) # addiu $t2, $t2, 0x1b50
 /* 09C534 8009B934 01F94821 */  addu  $t1, $t7, $t9
 /* 09C538 8009B938 00147040 */  sll   $t6, $s4, 1
 /* 09C53C 8009B93C 03CE8821 */  addu  $s1, $fp, $t6
@@ -443,19 +443,19 @@ glabel menu_credits_loop
 /* 09C578 8009B978 000FC823 */  negu  $t9, $t7
 /* 09C57C 8009B97C 0014C140 */  sll   $t8, $s4, 5
 /* 09C580 8009B980 03194821 */  addu  $t1, $t8, $t9
-# Setting D_800E1B50[1].source? Not sure why adding $t1 then
-/* 09C584 8009B984 3C01800E */  lui   $at, %hi(D_800E1B50+0x34)
+# Setting gCreditsMenuElements[1].source? Not sure why adding $t1 then
+/* 09C584 8009B984 3C01800E */  lui   $at, %hi(gCreditsMenuElements+0x34)
 /* 09C588 8009B988 448A8000 */  mtc1  $t2, $f16
 /* 09C58C 8009B98C 00290821 */  addu  $at, $at, $t1
-/* 09C590 8009B990 AC201B84 */  sw    $zero, %lo(D_800E1B50+0x34)($at)
+/* 09C590 8009B990 AC201B84 */  sw    $zero, %lo(gCreditsMenuElements+0x34)($at)
 /* 09C594 8009B994 468084A0 */  cvt.s.w $f18, $f16
 /* 09C598 8009B998 3C014270 */  li    $at, 0x42700000 # 60.000000
 /* 09C59C 8009B99C 44812000 */  mtc1  $at, $f4
-/* 09C5A0 8009B9A0 3C04800E */  lui   $a0, %hi(D_800E1B50) # $a0, 0x800e
+/* 09C5A0 8009B9A0 3C04800E */  lui   $a0, %hi(gCreditsMenuElements) # $a0, 0x800e
 /* 09C5A4 8009B9A4 46049183 */  div.s $f6, $f18, $f4
 /* 09C5A8 8009B9A8 4405A000 */  mfc1  $a1, $f20
 /* 09C5AC 8009B9AC 4407A000 */  mfc1  $a3, $f20
-/* 09C5B0 8009B9B0 24841B50 */  addiu $a0, %lo(D_800E1B50) # addiu $a0, $a0, 0x1b50
+/* 09C5B0 8009B9B0 24841B50 */  addiu $a0, %lo(gCreditsMenuElements) # addiu $a0, $a0, 0x1b50
 /* 09C5B4 8009B9B4 AFA00010 */  sw    $zero, 0x10($sp)
 /* 09C5B8 8009B9B8 AFA00014 */  sw    $zero, 0x14($sp)
 /* 09C5BC 8009B9BC 44063000 */  mfc1  $a2, $f6

--- a/asm/non_matchings/menu/menu_ghost_data_init.s
+++ b/asm/non_matchings/menu/menu_ghost_data_init.s
@@ -35,52 +35,52 @@ glabel menu_ghost_data_init
 /* 09A6DC 80099ADC 2484174C */   addiu $a0, %lo(D_800E174C) # addiu $a0, $a0, 0x174c
 /* 09A6E0 80099AE0 0C03105C */  jal   load_font
 /* 09A6E4 80099AE4 24040002 */   li    $a0, 2
-/* 09A6E8 80099AE8 3C028012 */  lui   $v0, %hi(gMenuTextures) # $v0, 0x8012
-/* 09A6EC 80099AEC 24426550 */  addiu $v0, %lo(gMenuTextures) # addiu $v0, $v0, 0x6550
+/* 09A6E8 80099AE8 3C028012 */  lui   $v0, %hi(gMenuObjects) # $v0, 0x8012
+/* 09A6EC 80099AEC 24426550 */  addiu $v0, %lo(gMenuObjects) # addiu $v0, $v0, 0x6550
 /* 09A6F0 80099AF0 8C570038 */  lw    $s7, 0x38($v0)
-/* 09A6F4 80099AF4 3C01800E */  lui   $at, %hi(D_800E153C) # $at, 0x800e
-/* 09A6F8 80099AF8 AC37153C */  sw    $s7, %lo(D_800E153C)($at)
+/* 09A6F4 80099AF4 3C01800E */  lui   $at, %hi(gDrawTexDinoDomainGhostBg) # $at, 0x800e
+/* 09A6F8 80099AF8 AC37153C */  sw    $s7, %lo(gDrawTexDinoDomainGhostBg)($at)
 /* 09A6FC 80099AFC 8C5E003C */  lw    $fp, 0x3c($v0)
-/* 09A700 80099B00 3C01800E */  lui   $at, %hi(D_800E153C+0x28) # $at, 0x800e
-/* 09A704 80099B04 AC3E1564 */  sw    $fp, %lo(D_800E153C+0x28)($at)
+/* 09A700 80099B00 3C01800E */  lui   $at, %hi(gDrawTexDinoDomainGhostBg+0x28) # $at, 0x800e
+/* 09A704 80099B04 AC3E1564 */  sw    $fp, %lo(gDrawTexDinoDomainGhostBg+0x28)($at)
 /* 09A708 80099B08 8C430040 */  lw    $v1, 0x40($v0)
-/* 09A70C 80099B0C 3C01800E */  lui   $at, %hi(D_800E1594) # $at, 0x800e
-/* 09A710 80099B10 AC231594 */  sw    $v1, %lo(D_800E1594)($at)
+/* 09A70C 80099B0C 3C01800E */  lui   $at, %hi(gDrawTexSherbetIslandGhostBg) # $at, 0x800e
+/* 09A710 80099B10 AC231594 */  sw    $v1, %lo(gDrawTexSherbetIslandGhostBg)($at)
 /* 09A714 80099B14 8C440044 */  lw    $a0, 0x44($v0)
-/* 09A718 80099B18 3C01800E */  lui   $at, %hi(D_800E1594+0x28) # $at, 0x800e
-/* 09A71C 80099B1C AC2415BC */  sw    $a0, %lo(D_800E1594+0x28)($at)
+/* 09A718 80099B18 3C01800E */  lui   $at, %hi(gDrawTexSherbetIslandGhostBg+0x28) # $at, 0x800e
+/* 09A71C 80099B1C AC2415BC */  sw    $a0, %lo(gDrawTexSherbetIslandGhostBg+0x28)($at)
 /* 09A720 80099B20 8C450048 */  lw    $a1, 0x48($v0)
-/* 09A724 80099B24 3C01800E */  lui   $at, %hi(D_800E15EC) # $at, 0x800e
-/* 09A728 80099B28 AC2515EC */  sw    $a1, %lo(D_800E15EC)($at)
+/* 09A724 80099B24 3C01800E */  lui   $at, %hi(gDrawTexSnowflakeMountainGhostBg) # $at, 0x800e
+/* 09A728 80099B28 AC2515EC */  sw    $a1, %lo(gDrawTexSnowflakeMountainGhostBg)($at)
 /* 09A72C 80099B2C 8C46004C */  lw    $a2, 0x4c($v0)
-/* 09A730 80099B30 3C01800E */  lui   $at, %hi(D_800E15EC+0x28) # $at, 0x800e
-/* 09A734 80099B34 AC261614 */  sw    $a2, %lo(D_800E15EC+0x28)($at)
+/* 09A730 80099B30 3C01800E */  lui   $at, %hi(gDrawTexSnowflakeMountainGhostBg+0x28) # $at, 0x800e
+/* 09A734 80099B34 AC261614 */  sw    $a2, %lo(gDrawTexSnowflakeMountainGhostBg+0x28)($at)
 /* 09A738 80099B38 8C470050 */  lw    $a3, 0x50($v0)
-/* 09A73C 80099B3C 3C01800E */  lui   $at, %hi(D_800E1644) # $at, 0x800e
-/* 09A740 80099B40 AC271644 */  sw    $a3, %lo(D_800E1644)($at)
+/* 09A73C 80099B3C 3C01800E */  lui   $at, %hi(gDrawTexDragonForestGhostBg) # $at, 0x800e
+/* 09A740 80099B40 AC271644 */  sw    $a3, %lo(gDrawTexDragonForestGhostBg)($at)
 /* 09A744 80099B44 8C490054 */  lw    $t1, 0x54($v0)
-/* 09A748 80099B48 3C01800E */  lui   $at, %hi(D_800E1644+0x28) # $at, 0x800e
-/* 09A74C 80099B4C AC29166C */  sw    $t1, %lo(D_800E1644+0x28)($at)
+/* 09A748 80099B48 3C01800E */  lui   $at, %hi(gDrawTexDragonForestGhostBg+0x28) # $at, 0x800e
+/* 09A74C 80099B4C AC29166C */  sw    $t1, %lo(gDrawTexDragonForestGhostBg+0x28)($at)
 /* 09A750 80099B50 8C4A0058 */  lw    $t2, 0x58($v0)
-/* 09A754 80099B54 3C01800E */  lui   $at, %hi(D_800E169C) # $at, 0x800e
+/* 09A754 80099B54 3C01800E */  lui   $at, %hi(gDrawTexFutureFunLandGhostBg) # $at, 0x800e
 /* 09A758 80099B58 24080001 */  li    $t0, 1
 /* 09A75C 80099B5C AFA60058 */  sw    $a2, 0x58($sp)
-/* 09A760 80099B60 AC2A169C */  sw    $t2, %lo(D_800E169C)($at)
+/* 09A760 80099B60 AC2A169C */  sw    $t2, %lo(gDrawTexFutureFunLandGhostBg)($at)
 /* 09A764 80099B64 AFAA004C */  sw    $t2, 0x4c($sp)
 /* 09A768 80099B68 24060005 */  li    $a2, 5
 /* 09A76C 80099B6C 310A0001 */  andi  $t2, $t0, 1
 /* 09A770 80099B70 01460019 */  multu $t2, $a2
 /* 09A774 80099B74 8C4B005C */  lw    $t3, 0x5c($v0)
-/* 09A778 80099B78 3C01800E */  lui   $at, %hi(D_800E169C+0x28) # $at, 0x800e
-/* 09A77C 80099B7C AC2B16C4 */  sw    $t3, %lo(D_800E169C+0x28)($at)
+/* 09A778 80099B78 3C01800E */  lui   $at, %hi(gDrawTexFutureFunLandGhostBg+0x28) # $at, 0x800e
+/* 09A77C 80099B7C AC2B16C4 */  sw    $t3, %lo(gDrawTexFutureFunLandGhostBg+0x28)($at)
 /* 09A780 80099B80 AFAB0048 */  sw    $t3, 0x48($sp)
-/* 09A784 80099B84 3C0F800E */  lui   $t7, %hi(D_800E153C) # $t7, 0x800e
+/* 09A784 80099B84 3C0F800E */  lui   $t7, %hi(gDrawTexDinoDomainGhostBg) # $t7, 0x800e
 /* 09A788 80099B88 AFA5005C */  sw    $a1, 0x5c($sp)
 /* 09A78C 80099B8C AFA90050 */  sw    $t1, 0x50($sp)
-/* 09A790 80099B90 3C05800E */  lui   $a1, %hi(D_800E1594) # $a1, 0x800e
+/* 09A790 80099B90 3C05800E */  lui   $a1, %hi(gDrawTexSherbetIslandGhostBg) # $a1, 0x800e
 /* 09A794 80099B94 000848C0 */  sll   $t1, $t0, 3
-/* 09A798 80099B98 25EF153C */  addiu $t7, %lo(D_800E153C) # addiu $t7, $t7, 0x153c
-/* 09A79C 80099B9C 24A51594 */  addiu $a1, %lo(D_800E1594) # addiu $a1, $a1, 0x1594
+/* 09A798 80099B98 25EF153C */  addiu $t7, %lo(gDrawTexDinoDomainGhostBg) # addiu $t7, $t7, 0x153c
+/* 09A79C 80099B9C 24A51594 */  addiu $a1, %lo(gDrawTexSherbetIslandGhostBg) # addiu $a1, $a1, 0x1594
 /* 09A7A0 80099BA0 0000C012 */  mflo  $t8
 /* 09A7A4 80099BA4 01185821 */  addu  $t3, $t0, $t8
 /* 09A7A8 80099BA8 39580001 */  xori  $t8, $t2, 1
@@ -92,21 +92,21 @@ glabel menu_ghost_data_init
 /* 09A7C0 80099BC0 ADE30000 */  sw    $v1, ($t7)
 /* 09A7C4 80099BC4 AFA30064 */  sw    $v1, 0x64($sp)
 /* 09A7C8 80099BC8 AFA70054 */  sw    $a3, 0x54($sp)
-/* 09A7CC 80099BCC 3C07800E */  lui   $a3, %hi(D_800E169C) # $a3, 0x800e
+/* 09A7CC 80099BCC 3C07800E */  lui   $a3, %hi(gDrawTexFutureFunLandGhostBg) # $a3, 0x800e
 /* 09A7D0 80099BD0 AFA40060 */  sw    $a0, 0x60($sp)
-/* 09A7D4 80099BD4 24E7169C */  addiu $a3, %lo(D_800E169C) # addiu $a3, $a3, 0x169c
+/* 09A7D4 80099BD4 24E7169C */  addiu $a3, %lo(gDrawTexFutureFunLandGhostBg) # addiu $a3, $a3, 0x169c
 /* 09A7D8 80099BD8 250D0001 */  addiu $t5, $t0, 1
 /* 09A7DC 80099BDC 0000C812 */  mflo  $t9
 /* 09A7E0 80099BE0 01196021 */  addu  $t4, $t0, $t9
 /* 09A7E4 80099BE4 000C70C0 */  sll   $t6, $t4, 3
 /* 09A7E8 80099BE8 00AEC021 */  addu  $t8, $a1, $t6
 /* 09A7EC 80099BEC AF040000 */  sw    $a0, ($t8)
-/* 09A7F0 80099BF0 3C19800E */  lui   $t9, %hi(D_800E15EC) # $t9, 0x800e
+/* 09A7F0 80099BF0 3C19800E */  lui   $t9, %hi(gDrawTexSnowflakeMountainGhostBg) # $t9, 0x800e
 /* 09A7F4 80099BF4 8FAF0058 */  lw    $t7, 0x58($sp)
-/* 09A7F8 80099BF8 273915EC */  addiu $t9, %lo(D_800E15EC) # addiu $t9, $t9, 0x15ec
+/* 09A7F8 80099BF8 273915EC */  addiu $t9, %lo(gDrawTexSnowflakeMountainGhostBg) # addiu $t9, $t9, 0x15ec
 /* 09A7FC 80099BFC 01391821 */  addu  $v1, $t1, $t9
-/* 09A800 80099C00 3C18800E */  lui   $t8, %hi(D_800E1644) # $t8, 0x800e
-/* 09A804 80099C04 27181644 */  addiu $t8, %lo(D_800E1644) # addiu $t8, $t8, 0x1644
+/* 09A800 80099C00 3C18800E */  lui   $t8, %hi(gDrawTexDragonForestGhostBg) # $t8, 0x800e
+/* 09A804 80099C04 27181644 */  addiu $t8, %lo(gDrawTexDragonForestGhostBg) # addiu $t8, $t8, 0x1644
 /* 09A808 80099C08 AC6F0028 */  sw    $t7, 0x28($v1)
 /* 09A80C 80099C0C 8FAF004C */  lw    $t7, 0x4c($sp)
 /* 09A810 80099C10 01382021 */  addu  $a0, $t1, $t8

--- a/asm/non_matchings/menu/menu_ghost_data_init.s
+++ b/asm/non_matchings/menu/menu_ghost_data_init.s
@@ -27,12 +27,12 @@ glabel menu_ghost_data_init
 /* 09A6C0 80099AC0 0C02658F */  jal   func_8009963C
 /* 09A6C4 80099AC4 00000000 */   nop   
 .L80099AC8:
-/* 09A6C8 80099AC8 3C04800E */  lui   $a0, %hi(D_800E1708) # $a0, 0x800e
+/* 09A6C8 80099AC8 3C04800E */  lui   $a0, %hi(gGhostDataObjectIndices) # $a0, 0x800e
 /* 09A6CC 80099ACC 0C02719D */  jal   func_8009C674
-/* 09A6D0 80099AD0 24841708 */   addiu $a0, %lo(D_800E1708) # addiu $a0, $a0, 0x1708
-/* 09A6D4 80099AD4 3C04800E */  lui   $a0, %hi(D_800E174C) # $a0, 0x800e
+/* 09A6D0 80099AD0 24841708 */   addiu $a0, %lo(gGhostDataObjectIndices) # addiu $a0, $a0, 0x1708
+/* 09A6D4 80099AD4 3C04800E */  lui   $a0, %hi(gGhostDataImageIndices) # $a0, 0x800e
 /* 09A6D8 80099AD8 0C027229 */  jal   allocate_menu_images
-/* 09A6DC 80099ADC 2484174C */   addiu $a0, %lo(D_800E174C) # addiu $a0, $a0, 0x174c
+/* 09A6DC 80099ADC 2484174C */   addiu $a0, %lo(gGhostDataImageIndices) # addiu $a0, $a0, 0x174c
 /* 09A6E0 80099AE0 0C03105C */  jal   load_font
 /* 09A6E4 80099AE4 24040002 */   li    $a0, 2
 /* 09A6E8 80099AE8 3C028012 */  lui   $v0, %hi(gMenuObjects) # $v0, 0x8012

--- a/asm/non_matchings/menu/menu_track_select_init.s
+++ b/asm/non_matchings/menu/menu_track_select_init.s
@@ -153,10 +153,10 @@ glabel menu_track_select_init
 /* 08F5E4 8008E9E4 24A50970 */  addiu $a1, %lo(gTrackSelectBgTriangles) # addiu $a1, $a1, 0x970
 /* 08F5E8 8008E9E8 ACA20000 */  sw    $v0, ($a1)
 /* 08F5EC 8008E9EC 244B0280 */  addiu $t3, $v0, 0x280
-/* 08F5F0 8008E9F0 3C01800E */  lui   $at, %hi(D_800E0974) # $at, 0x800e
-/* 08F5F4 8008E9F4 AC2B0974 */  sw    $t3, %lo(D_800E0974)($at)
+/* 08F5F0 8008E9F0 3C01800E */  lui   $at, %hi(gTrackSelectBgTriangles+4) # $at, 0x800e
+/* 08F5F4 8008E9F4 AC2B0974 */  sw    $t3, %lo(gTrackSelectBgTriangles+4)($at)
 /* 08F5F8 8008E9F8 8CAC0004 */  lw    $t4, 4($a1)
-/* 08F5FC 8008E9FC 3C01800E */  lui   $at, %hi(D_800E096C) # $at, 0x800e
+/* 08F5FC 8008E9FC 3C01800E */  lui   $at, %hi(gTrackSelectBgVertices+4) # $at, 0x800e
 /* 08F600 8008EA00 258D0280 */  addiu $t5, $t4, 0x280
 /* 08F604 8008EA04 AC2D0968 */  sw    $t5, %lo(gTrackSelectBgVertices)($at)
 /* 08F608 8008EA08 3C0E800E */  lui   $t6, %hi(gTrackSelectBgVertices) # $t6, 0x800e
@@ -164,7 +164,7 @@ glabel menu_track_select_init
 /* 08F610 8008EA10 3C03800E */  lui   $v1, %hi(gTrackSelectBgVertices) # $v1, 0x800e
 /* 08F614 8008EA14 3C08800E */  lui   $t0, %hi(gTrackSelectBgTriangles) # $t0, 0x800e
 /* 08F618 8008EA18 25CF0320 */  addiu $t7, $t6, 0x320
-/* 08F61C 8008EA1C AC2F096C */  sw    $t7, %lo(D_800E096C)($at)
+/* 08F61C 8008EA1C AC2F096C */  sw    $t7, %lo(gTrackSelectBgVertices+4)($at)
 /* 08F620 8008EA20 2404FF60 */  li    $a0, -160
 /* 08F624 8008EA24 25080970 */  addiu $t0, %lo(gTrackSelectBgTriangles) # addiu $t0, $t0, 0x970
 /* 08F628 8008EA28 24630968 */  addiu $v1, %lo(gTrackSelectBgVertices) # addiu $v1, $v1, 0x968

--- a/asm/non_matchings/menu/menu_track_select_init.s
+++ b/asm/non_matchings/menu/menu_track_select_init.s
@@ -20,8 +20,8 @@ glabel menu_track_select_init
 /* 08F3E8 8008E7E8 27A50078 */   addiu $a1, $sp, 0x78
 /* 08F3EC 8008E7EC 0C0078A7 */  jal   get_misc_asset
 /* 08F3F0 8008E7F0 2404001A */   li    $a0, 26
-/* 08F3F4 8008E7F4 3C03800E */  lui   $v1, %hi(D_800DF488) # $v1, 0x800e
-/* 08F3F8 8008E7F8 2463F488 */  addiu $v1, %lo(D_800DF488) # addiu $v1, $v1, -0xb78
+/* 08F3F4 8008E7F4 3C03800E */  lui   $v1, %hi(gTitleScreenLoaded) # $v1, 0x800e
+/* 08F3F8 8008E7F8 2463F488 */  addiu $v1, %lo(gTitleScreenLoaded) # addiu $v1, $v1, -0xb78
 /* 08F3FC 8008E7FC 8C6E0000 */  lw    $t6, ($v1)
 /* 08F400 8008E800 0040B825 */  move  $s7, $v0
 /* 08F404 8008E804 11C00009 */  beqz  $t6, .L8008E82C
@@ -29,10 +29,10 @@ glabel menu_track_select_init
 /* 08F40C 8008E80C AC2069C8 */  sw    $zero, %lo(D_801269C8)($at)
 /* 08F410 8008E810 3C018012 */  lui   $at, %hi(D_801269CC) # $at, 0x8012
 /* 08F414 8008E814 AC2069CC */  sw    $zero, %lo(D_801269CC)($at)
-/* 08F418 8008E818 3C01800E */  lui   $at, %hi(D_800E0414) # $at, 0x800e
-/* 08F41C 8008E81C AC200414 */  sw    $zero, %lo(D_800E0414)($at)
-/* 08F420 8008E820 3C01800E */  lui   $at, %hi(D_800E0418) # $at, 0x800e
-/* 08F424 8008E824 AC200418 */  sw    $zero, %lo(D_800E0418)($at)
+/* 08F418 8008E818 3C01800E */  lui   $at, %hi(gTracksMenuTimeTrialHighlightIndex) # $at, 0x800e
+/* 08F41C 8008E81C AC200414 */  sw    $zero, %lo(gTracksMenuTimeTrialHighlightIndex)($at)
+/* 08F420 8008E820 3C01800E */  lui   $at, %hi(gTracksMenuAdventureHighlightIndex) # $at, 0x800e
+/* 08F424 8008E824 AC200418 */  sw    $zero, %lo(gTracksMenuAdventureHighlightIndex)($at)
 /* 08F428 8008E828 AC600000 */  sw    $zero, ($v1)
 .L8008E82C:
 /* 08F42C 8008E82C 0C01E948 */  jal   get_video_width_and_height_as_s32
@@ -99,12 +99,12 @@ glabel menu_track_select_init
 /* 08F520 8008E920 24050069 */  li    $a1, 105
 /* 08F524 8008E924 0C01DED7 */  jal   set_background_fill_colour
 /* 08F528 8008E928 240600DF */   li    $a2, 223
-/* 08F52C 8008E92C 3C11800E */  lui   $s1, %hi(D_800E0710) # $s1, 0x800e
-/* 08F530 8008E930 3C168012 */  lui   $s6, %hi(gMenuTextures) # $s6, 0x8012
-/* 08F534 8008E934 3C12800E */  lui   $s2, %hi(D_800E0730) # $s2, 0x800e
-/* 08F538 8008E938 26520730 */  addiu $s2, %lo(D_800E0730) # addiu $s2, $s2, 0x730
-/* 08F53C 8008E93C 26D66550 */  addiu $s6, %lo(gMenuTextures) # addiu $s6, $s6, 0x6550
-/* 08F540 8008E940 26310710 */  addiu $s1, %lo(D_800E0710) # addiu $s1, $s1, 0x710
+/* 08F52C 8008E92C 3C11800E */  lui   $s1, %hi(gTracksMenuBgTextureIndices) # $s1, 0x800e
+/* 08F530 8008E930 3C168012 */  lui   $s6, %hi(gMenuObjects) # $s6, 0x8012
+/* 08F534 8008E934 3C12800E */  lui   $s2, %hi(gTracksMenuBgTextures) # $s2, 0x800e
+/* 08F538 8008E938 26520730 */  addiu $s2, %lo(gTracksMenuBgTextures) # addiu $s2, $s2, 0x730
+/* 08F53C 8008E93C 26D66550 */  addiu $s6, %lo(gMenuObjects) # addiu $s6, $s6, 0x6550
+/* 08F540 8008E940 26310710 */  addiu $s1, %lo(gTracksMenuBgTextureIndices) # addiu $s1, $s1, 0x710
 /* 08F544 8008E944 00002825 */  move  $a1, $zero
 .L8008E948:
 /* 08F548 8008E948 86240000 */  lh    $a0, ($s1)
@@ -149,8 +149,8 @@ glabel menu_track_select_init
 /* 08F5D4 8008E9D4 34A500FF */  ori   $a1, (0xFFFF00FF & 0xFFFF) # ori $a1, $a1, 0xff
 /* 08F5D8 8008E9D8 0C01C327 */  jal   allocate_from_main_pool_safe
 /* 08F5DC 8008E9DC 24040B40 */   li    $a0, 2880
-/* 08F5E0 8008E9E0 3C05800E */  lui   $a1, %hi(D_800E0970) # $a1, 0x800e
-/* 08F5E4 8008E9E4 24A50970 */  addiu $a1, %lo(D_800E0970) # addiu $a1, $a1, 0x970
+/* 08F5E0 8008E9E0 3C05800E */  lui   $a1, %hi(gTrackSelectBgTriangles) # $a1, 0x800e
+/* 08F5E4 8008E9E4 24A50970 */  addiu $a1, %lo(gTrackSelectBgTriangles) # addiu $a1, $a1, 0x970
 /* 08F5E8 8008E9E8 ACA20000 */  sw    $v0, ($a1)
 /* 08F5EC 8008E9EC 244B0280 */  addiu $t3, $v0, 0x280
 /* 08F5F0 8008E9F0 3C01800E */  lui   $at, %hi(D_800E0974) # $at, 0x800e
@@ -158,16 +158,16 @@ glabel menu_track_select_init
 /* 08F5F8 8008E9F8 8CAC0004 */  lw    $t4, 4($a1)
 /* 08F5FC 8008E9FC 3C01800E */  lui   $at, %hi(D_800E096C) # $at, 0x800e
 /* 08F600 8008EA00 258D0280 */  addiu $t5, $t4, 0x280
-/* 08F604 8008EA04 AC2D0968 */  sw    $t5, %lo(D_800E0968)($at)
-/* 08F608 8008EA08 3C0E800E */  lui   $t6, %hi(D_800E0968) # $t6, 0x800e
-/* 08F60C 8008EA0C 8DCE0968 */  lw    $t6, %lo(D_800E0968)($t6)
-/* 08F610 8008EA10 3C03800E */  lui   $v1, %hi(D_800E0968) # $v1, 0x800e
-/* 08F614 8008EA14 3C08800E */  lui   $t0, %hi(D_800E0970) # $t0, 0x800e
+/* 08F604 8008EA04 AC2D0968 */  sw    $t5, %lo(gTrackSelectBgVertices)($at)
+/* 08F608 8008EA08 3C0E800E */  lui   $t6, %hi(gTrackSelectBgVertices) # $t6, 0x800e
+/* 08F60C 8008EA0C 8DCE0968 */  lw    $t6, %lo(gTrackSelectBgVertices)($t6)
+/* 08F610 8008EA10 3C03800E */  lui   $v1, %hi(gTrackSelectBgVertices) # $v1, 0x800e
+/* 08F614 8008EA14 3C08800E */  lui   $t0, %hi(gTrackSelectBgTriangles) # $t0, 0x800e
 /* 08F618 8008EA18 25CF0320 */  addiu $t7, $t6, 0x320
 /* 08F61C 8008EA1C AC2F096C */  sw    $t7, %lo(D_800E096C)($at)
 /* 08F620 8008EA20 2404FF60 */  li    $a0, -160
-/* 08F624 8008EA24 25080970 */  addiu $t0, %lo(D_800E0970) # addiu $t0, $t0, 0x970
-/* 08F628 8008EA28 24630968 */  addiu $v1, %lo(D_800E0968) # addiu $v1, $v1, 0x968
+/* 08F624 8008EA24 25080970 */  addiu $t0, %lo(gTrackSelectBgTriangles) # addiu $t0, $t0, 0x970
+/* 08F628 8008EA28 24630968 */  addiu $v1, %lo(gTrackSelectBgVertices) # addiu $v1, $v1, 0x968
 /* 08F62C 8008EA2C 240500FF */  li    $a1, 255
 /* 08F630 8008EA30 24070320 */  li    $a3, 800
 /* 08F634 8008EA34 2406FC00 */  li    $a2, -1024
@@ -259,10 +259,10 @@ glabel menu_track_select_init
 /* 08F788 8008EB88 0068082B */  sltu  $at, $v1, $t0
 /* 08F78C 8008EB8C 1420FFAB */  bnez  $at, .L8008EA3C
 /* 08F790 8008EB90 00001025 */   move  $v0, $zero
-/* 08F794 8008EB94 3C03800E */  lui   $v1, %hi(D_800E0970) # $v1, 0x800e
+/* 08F794 8008EB94 3C03800E */  lui   $v1, %hi(gTrackSelectBgTriangles) # $v1, 0x800e
 /* 08F798 8008EB98 3C08800E */  lui   $t0, %hi(gQMarkPtr) # $t0, 0x800e
 /* 08F79C 8008EB9C 25080978 */  addiu $t0, %lo(gQMarkPtr) # addiu $t0, $t0, 0x978
-/* 08F7A0 8008EBA0 24630970 */  addiu $v1, %lo(D_800E0970) # addiu $v1, $v1, 0x970
+/* 08F7A0 8008EBA0 24630970 */  addiu $v1, %lo(gTrackSelectBgTriangles) # addiu $v1, $v1, 0x970
 /* 08F7A4 8008EBA4 24070003 */  li    $a3, 3
 /* 08F7A8 8008EBA8 24060001 */  li    $a2, 1
 /* 08F7AC 8008EBAC 24050002 */  li    $a1, 2
@@ -328,14 +328,14 @@ glabel menu_track_select_init
 /* 08F898 8008EC98 0C019A06 */  jal   camEnableUserView
 /* 08F89C 8008EC9C 00002825 */   move  $a1, $zero
 /* 08F8A0 8008ECA0 240A0001 */  li    $t2, 1
-/* 08F8A4 8008ECA4 3C01800E */  lui   $at, %hi(D_800E097C) # $at, 0x800e
-/* 08F8A8 8008ECA8 3C04800E */  lui   $a0, %hi(D_800E07C4) # $a0, 0x800e
-/* 08F8AC 8008ECAC AC2A097C */  sw    $t2, %lo(D_800E097C)($at)
+/* 08F8A4 8008ECA4 3C01800E */  lui   $at, %hi(gIsInTracksMenu) # $at, 0x800e
+/* 08F8A8 8008ECA8 3C04800E */  lui   $a0, %hi(gTrackSelectObjectIndices) # $a0, 0x800e
+/* 08F8AC 8008ECAC AC2A097C */  sw    $t2, %lo(gIsInTracksMenu)($at)
 /* 08F8B0 8008ECB0 0C02719D */  jal   func_8009C674
-/* 08F8B4 8008ECB4 248407C4 */   addiu $a0, %lo(D_800E07C4) # addiu $a0, $a0, 0x7c4
-/* 08F8B8 8008ECB8 3C04800E */  lui   $a0, %hi(D_800E07E0) # $a0, 0x800e
+/* 08F8B4 8008ECB4 248407C4 */   addiu $a0, %lo(gTrackSelectObjectIndices) # addiu $a0, $a0, 0x7c4
+/* 08F8B8 8008ECB8 3C04800E */  lui   $a0, %hi(gTrackSelectImageIndices) # $a0, 0x800e
 /* 08F8BC 8008ECBC 0C027229 */  jal   allocate_menu_images
-/* 08F8C0 8008ECC0 248407E0 */   addiu $a0, %lo(D_800E07E0) # addiu $a0, $a0, 0x7e0
+/* 08F8C0 8008ECC0 248407E0 */   addiu $a0, %lo(gTrackSelectImageIndices) # addiu $a0, $a0, 0x7e0
 /* 08F8C4 8008ECC4 0C02392C */  jal   assign_menu_arrow_textures
 /* 08F8C8 8008ECC8 00000000 */   nop   
 /* 08F8CC 8008ECCC 3C02800E */  lui   $v0, %hi(D_800E05D4) # $v0, 0x800e
@@ -538,8 +538,8 @@ glabel menu_track_select_init
 /* 08FBB0 8008EFB0 00000000 */   nop   
 /* 08FBB4 8008EFB4 0C01BD59 */  jal   set_D_800DD430
 /* 08FBB8 8008EFB8 24040001 */   li    $a0, 1
-/* 08FBBC 8008EFBC 3C0C800E */  lui   $t4, %hi(D_800E0418) # $t4, 0x800e
-/* 08FBC0 8008EFC0 8D8C0418 */  lw    $t4, %lo(D_800E0418)($t4)
+/* 08FBBC 8008EFBC 3C0C800E */  lui   $t4, %hi(gTracksMenuAdventureHighlightIndex) # $t4, 0x800e
+/* 08FBC0 8008EFC0 8D8C0418 */  lw    $t4, %lo(gTracksMenuAdventureHighlightIndex)($t4)
 /* 08FBC4 8008EFC4 3C01800E */  lui   $at, %hi(gIsInAdventureTwo) # $at, 0x800e
 /* 08FBC8 8008EFC8 3C0B800E */  lui   $t3, %hi(gMultiplayerSelectedNumberOfRacers) # $t3, 0x800e
 /* 08FBCC 8008EFCC 8D6B0410 */  lw    $t3, %lo(gMultiplayerSelectedNumberOfRacers)($t3)

--- a/asm/non_matchings/menu/render_file_select_menu.s
+++ b/asm/non_matchings/menu/render_file_select_menu.s
@@ -28,12 +28,12 @@ glabel render_file_select_menu
 /* 08D9D4 8008CDD4 02E02025 */   move  $a0, $s7
 /* 08D9D8 8008CDD8 3C118012 */  lui   $s1, %hi(gSavefileInfo) # $s1, 0x8012
 /* 08D9DC 8008CDDC 3C10800E */  lui   $s0, %hi(gFileSelectButtons) # $s0, 0x800e
-/* 08D9E0 8008CDE0 3C158012 */  lui   $s5, %hi(gMenuTextures) # $s5, 0x8012
+/* 08D9E0 8008CDE0 3C158012 */  lui   $s5, %hi(gMenuObjects) # $s5, 0x8012
 /* 08D9E4 8008CDE4 3C13B0E0 */  lui   $s3, (0xB0E0C0FF >> 16) # lui $s3, 0xb0e0
 /* 08D9E8 8008CDE8 3C12800E */  lui   $s2, %hi(gIsInAdventureTwo) # $s2, 0x800e
 /* 08D9EC 8008CDEC 2652F494 */  addiu $s2, %lo(gIsInAdventureTwo) # addiu $s2, $s2, -0xb6c
 /* 08D9F0 8008CDF0 3673C0FF */  ori   $s3, (0xB0E0C0FF & 0xFFFF) # ori $s3, $s3, 0xc0ff
-/* 08D9F4 8008CDF4 26B56550 */  addiu $s5, %lo(gMenuTextures) # addiu $s5, $s5, 0x6550
+/* 08D9F4 8008CDF4 26B56550 */  addiu $s5, %lo(gMenuObjects) # addiu $s5, $s5, 0x6550
 /* 08D9F8 8008CDF8 261003CC */  addiu $s0, %lo(gFileSelectButtons) # addiu $s0, $s0, 0x3cc
 /* 08D9FC 8008CDFC 263164A0 */  addiu $s1, %lo(gSavefileInfo) # addiu $s1, $s1, 0x64a0
 /* 08DA00 8008CE00 24140078 */  li    $s4, 120

--- a/asm/non_matchings/menu/render_track_select_setup_ui.s
+++ b/asm/non_matchings/menu/render_track_select_setup_ui.s
@@ -93,17 +93,17 @@ glabel render_track_select_setup_ui
 /* 091C74 80091074 17000004 */  bnez  $t8, .L80091088
 /* 091C78 80091078 00000000 */   nop   
 /* 091C7C 8009107C C42484F0 */  lwc1  $f4, %lo(D_800E84F0)($at)
-/* 091C80 80091080 3C01800E */  lui   $at, %hi(D_800DF454) # $at, 0x800e
-/* 091C84 80091084 E424F454 */  swc1  $f4, %lo(D_800DF454)($at)
+/* 091C80 80091080 3C01800E */  lui   $at, %hi(gTrackSelectWoodFrameHeightScale) # $at, 0x800e
+/* 091C84 80091084 E424F454 */  swc1  $f4, %lo(gTrackSelectWoodFrameHeightScale)($at)
 .L80091088:
 /* 091C88 80091088 0C027298 */  jal   func_8009CA60
 /* 091C8C 8009108C 00000000 */   nop   
 /* 091C90 80091090 3C013F80 */  li    $at, 0x3F800000 # 1.000000
 /* 091C94 80091094 44813000 */  mtc1  $at, $f6
 /* 091C98 80091098 3C02800E */  lui   $v0, %hi(gMenuDelay) # $v0, 0x800e
-/* 091C9C 8009109C 3C01800E */  lui   $at, %hi(D_800DF454) # $at, 0x800e
+/* 091C9C 8009109C 3C01800E */  lui   $at, %hi(gTrackSelectWoodFrameHeightScale) # $at, 0x800e
 /* 091CA0 800910A0 8C42F47C */  lw    $v0, %lo(gMenuDelay)($v0)
-/* 091CA4 800910A4 E426F454 */  swc1  $f6, %lo(D_800DF454)($at)
+/* 091CA4 800910A4 E426F454 */  swc1  $f6, %lo(gTrackSelectWoodFrameHeightScale)($at)
 .L800910A8:
 /* 091CA8 800910A8 2841FFEA */  slti  $at, $v0, -0x16
 /* 091CAC 800910AC 1420042A */  bnez  $at, .L80092158
@@ -205,10 +205,10 @@ glabel render_track_select_setup_ui
 /* 091E18 80091218 00003025 */   move  $a2, $zero
 /* 091E1C 8009121C 0282082A */  slt   $at, $s4, $v0
 /* 091E20 80091220 10200002 */  beqz  $at, .L8009122C
-/* 091E24 80091224 3C10800E */   lui   $s0, %hi(D_800E0700) # $s0, 0x800e
+/* 091E24 80091224 3C10800E */   lui   $s0, %hi(gTracksMenuAdventureButton) # $s0, 0x800e
 /* 091E28 80091228 0040A025 */  move  $s4, $v0
 .L8009122C:
-/* 091E2C 8009122C 26100700 */  addiu $s0, %lo(D_800E0700) # addiu $s0, $s0, 0x700
+/* 091E2C 8009122C 26100700 */  addiu $s0, %lo(gTracksMenuAdventureButton) # addiu $s0, $s0, 0x700
 /* 091E30 80091230 86020004 */  lh    $v0, 4($s0)
 /* 091E34 80091234 3C048012 */  lui   $a0, %hi(sMenuCurrDisplayList) # $a0, 0x8012
 /* 091E38 80091238 0282082A */  slt   $at, $s4, $v0
@@ -221,8 +221,8 @@ glabel render_track_select_setup_ui
 .L80091250:
 /* 091E50 80091250 8FCE0000 */  lw    $t6, ($fp)
 /* 091E54 80091254 3C01B0E0 */  lui   $at, (0xB0E0C000 >> 16) # lui $at, 0xb0e0
-/* 091E58 80091258 3C188012 */  lui   $t8, %hi(gMenuTextures) # $t8, 0x8012
-/* 091E5C 8009125C 8F18665C */  lw    $t8, %lo(gMenuTextures + 0x10C)($t8)
+/* 091E58 80091258 3C188012 */  lui   $t8, %hi(gMenuObjects) # $t8, 0x8012
+/* 091E5C 8009125C 8F18665C */  lw    $t8, %lo(gMenuObjects + 0x10C)($t8)
 /* 091E60 80091260 86090002 */  lh    $t1, 2($s0)
 /* 091E64 80091264 860B0006 */  lh    $t3, 6($s0)
 /* 091E68 80091268 860C0008 */  lh    $t4, 8($s0)
@@ -248,10 +248,10 @@ glabel render_track_select_setup_ui
 /* 091EB8 800912B8 86080002 */  lh    $t0, 2($s0)
 /* 091EBC 800912BC 8FA90080 */  lw    $t1, 0x80($sp)
 /* 091EC0 800912C0 03285021 */  addu  $t2, $t9, $t0
-/* 091EC4 800912C4 3C16800E */  lui   $s6, %hi(D_800E0418) # $s6, 0x800e
+/* 091EC4 800912C4 3C16800E */  lui   $s6, %hi(gTracksMenuAdventureHighlightIndex) # $s6, 0x800e
 /* 091EC8 800912C8 0149B821 */  addu  $s7, $t2, $t1
 /* 091ECC 800912CC 26F70001 */  addiu $s7, $s7, 1
-/* 091ED0 800912D0 26D60418 */  addiu $s6, %lo(D_800E0418) # addiu $s6, $s6, 0x418
+/* 091ED0 800912D0 26D60418 */  addiu $s6, %lo(gTracksMenuAdventureHighlightIndex) # addiu $s6, $s6, 0x418
 /* 091ED4 800912D4 0000A025 */  move  $s4, $zero
 /* 091ED8 800912D8 00008825 */  move  $s1, $zero
 /* 091EDC 800912DC 241200A1 */  li    $s2, 161
@@ -503,8 +503,8 @@ glabel render_track_select_setup_ui
 /* 092298 80091698 26100648 */  addiu $s0, %lo(D_800E0648) # addiu $s0, $s0, 0x648
 /* 09229C 8009169C 26F70097 */  addiu $s7, $s7, 0x97
 .L800916A0:
-/* 0922A0 800916A0 3C0E800E */  lui   $t6, %hi(D_800E0414) # $t6, 0x800e
-/* 0922A4 800916A4 8DCE0414 */  lw    $t6, %lo(D_800E0414)($t6)
+/* 0922A0 800916A0 3C0E800E */  lui   $t6, %hi(gTracksMenuTimeTrialHighlightIndex) # $t6, 0x800e
+/* 0922A4 800916A4 8DCE0414 */  lw    $t6, %lo(gTracksMenuTimeTrialHighlightIndex)($t6)
 /* 0922A8 800916A8 3C048012 */  lui   $a0, %hi(sMenuCurrDisplayList) # $a0, 0x8012
 /* 0922AC 800916AC 16AE0011 */  bne   $s5, $t6, .L800916F4
 /* 0922B0 800916B0 248463A0 */   addiu $a0, %lo(sMenuCurrDisplayList) # addiu $a0, $a0, 0x63a0
@@ -554,8 +554,8 @@ glabel render_track_select_setup_ui
 /* 092350 80091750 17000047 */  bnez  $t8, .L80091870
 /* 092354 80091754 28410002 */   slti  $at, $v0, 2
 /* 092358 80091758 01C20019 */  multu $t6, $v0
-/* 09235C 8009175C 3C19800E */  lui   $t9, %hi(D_800E0688) # $t9, 0x800e
-/* 092360 80091760 27390688 */  addiu $t9, %lo(D_800E0688) # addiu $t9, $t9, 0x688
+/* 09235C 8009175C 3C19800E */  lui   $t9, %hi(gTracksMenuPlayerNamePositions) # $t9, 0x800e
+/* 092360 80091760 27390688 */  addiu $t9, %lo(gTracksMenuPlayerNamePositions) # addiu $t9, $t9, 0x688
 /* 092364 80091764 3C11800E */  lui   $s1, %hi(D_800E0660) # $s1, 0x800e
 /* 092368 80091768 3C128012 */  lui   $s2, %hi(D_801269C4) # $s2, 0x8012
 /* 09236C 8009176C 0040B825 */  move  $s7, $v0
@@ -660,8 +660,8 @@ glabel render_track_select_setup_ui
 /* 0924D8 800918D8 00154880 */  sll   $t1, $s5, 2
 /* 0924DC 800918DC 01354823 */  subu  $t1, $t1, $s5
 /* 0924E0 800918E0 3C0A800E */  lui   $t2, %hi(gRaceSelectionImages) # $t2, 0x800e
-/* 0924E4 800918E4 3C0C800E */  lui   $t4, %hi(D_800E06B0) # $t4, 0x800e
-/* 0924E8 800918E8 258C06B0 */  addiu $t4, %lo(D_800E06B0) # addiu $t4, $t4, 0x6b0
+/* 0924E4 800918E4 3C0C800E */  lui   $t4, %hi(gTracksMenuVehicleNamePositions) # $t4, 0x800e
+/* 0924E8 800918E8 258C06B0 */  addiu $t4, %lo(gTracksMenuVehicleNamePositions) # addiu $t4, $t4, 0x6b0
 /* 0924EC 800918EC 254A0624 */  addiu $t2, %lo(gRaceSelectionImages) # addiu $t2, $t2, 0x624
 /* 0924F0 800918F0 00094080 */  sll   $t0, $t1, 2
 /* 0924F4 800918F4 3C118012 */  lui   $s1, %hi(gPlayerSelectVehicle) # $s1, 0x8012
@@ -791,8 +791,8 @@ glabel render_track_select_setup_ui
 /* 0926C0 80091AC0 10000019 */  b     .L80091B28
 /* 0926C4 80091AC4 00000000 */   nop   
 .L80091AC8:
-/* 0926C8 80091AC8 3C0C800E */  lui   $t4, %hi(D_800E0414) # $t4, 0x800e
-/* 0926CC 80091ACC 8D8C0414 */  lw    $t4, %lo(D_800E0414)($t4)
+/* 0926C8 80091AC8 3C0C800E */  lui   $t4, %hi(gTracksMenuTimeTrialHighlightIndex) # $t4, 0x800e
+/* 0926CC 80091ACC 8D8C0414 */  lw    $t4, %lo(gTracksMenuTimeTrialHighlightIndex)($t4)
 /* 0926D0 80091AD0 3C05800E */  lui   $a1, %hi(D_800E0648) # $a1, 0x800e
 /* 0926D4 80091AD4 01960019 */  multu $t4, $s6
 /* 0926D8 80091AD8 8FC90000 */  lw    $t1, ($fp)
@@ -936,8 +936,8 @@ glabel render_track_select_setup_ui
 .L80091CE8:
 /* 0928E8 80091CE8 0060A025 */  move  $s4, $v1
 .L80091CEC:
-/* 0928EC 80091CEC 3C0B8012 */  lui   $t3, %hi(gMenuTextures) # $t3, 0x8012
-/* 0928F0 80091CF0 8D6B665C */  lw    $t3, %lo(gMenuTextures + 0x10C)($t3)
+/* 0928EC 80091CEC 3C0B8012 */  lui   $t3, %hi(gMenuObjects) # $t3, 0x8012
+/* 0928F0 80091CF0 8D6B665C */  lw    $t3, %lo(gMenuObjects + 0x10C)($t3)
 /* 0928F4 80091CF4 864E0002 */  lh    $t6, 2($s2)
 /* 0928F8 80091CF8 86590006 */  lh    $t9, 6($s2)
 /* 0928FC 80091CFC 86490008 */  lh    $t1, 8($s2)

--- a/asm/non_matchings/menu/render_track_select_setup_ui.s
+++ b/asm/non_matchings/menu/render_track_select_setup_ui.s
@@ -499,8 +499,8 @@ glabel render_track_select_setup_ui
 /* 092288 80091688 0C01E2AE */  jal   render_textured_rectangle
 /* 09228C 8009168C AFB8001C */   sw    $t8, 0x1c($sp)
 /* 092290 80091690 8FB70080 */  lw    $s7, 0x80($sp)
-/* 092294 80091694 3C10800E */  lui   $s0, %hi(D_800E0648) # $s0, 0x800e
-/* 092298 80091698 26100648 */  addiu $s0, %lo(D_800E0648) # addiu $s0, $s0, 0x648
+/* 092294 80091694 3C10800E */  lui   $s0, %hi(gTrackSelectTTImage) # $s0, 0x800e
+/* 092298 80091698 26100648 */  addiu $s0, %lo(gTrackSelectTTImage) # addiu $s0, $s0, 0x648
 /* 09229C 8009169C 26F70097 */  addiu $s7, $s7, 0x97
 .L800916A0:
 /* 0922A0 800916A0 3C0E800E */  lui   $t6, %hi(gTracksMenuTimeTrialHighlightIndex) # $t6, 0x800e
@@ -556,11 +556,11 @@ glabel render_track_select_setup_ui
 /* 092358 80091758 01C20019 */  multu $t6, $v0
 /* 09235C 8009175C 3C19800E */  lui   $t9, %hi(gTracksMenuPlayerNamePositions) # $t9, 0x800e
 /* 092360 80091760 27390688 */  addiu $t9, %lo(gTracksMenuPlayerNamePositions) # addiu $t9, $t9, 0x688
-/* 092364 80091764 3C11800E */  lui   $s1, %hi(D_800E0660) # $s1, 0x800e
+/* 092364 80091764 3C11800E */  lui   $s1, %hi(gTrackSelectPlayerImage) # $s1, 0x800e
 /* 092368 80091768 3C128012 */  lui   $s2, %hi(D_801269C4) # $s2, 0x8012
 /* 09236C 8009176C 0040B825 */  move  $s7, $v0
 /* 092370 80091770 265269C4 */  addiu $s2, %lo(D_801269C4) # addiu $s2, $s2, 0x69c4
-/* 092374 80091774 26310660 */  addiu $s1, %lo(D_800E0660) # addiu $s1, $s1, 0x660
+/* 092374 80091774 26310660 */  addiu $s1, %lo(gTrackSelectPlayerImage) # addiu $s1, $s1, 0x660
 /* 092378 80091778 0000A825 */  move  $s5, $zero
 /* 09237C 8009177C 00009812 */  mflo  $s3
 /* 092380 80091780 00137840 */  sll   $t7, $s3, 1
@@ -793,7 +793,7 @@ glabel render_track_select_setup_ui
 .L80091AC8:
 /* 0926C8 80091AC8 3C0C800E */  lui   $t4, %hi(gTracksMenuTimeTrialHighlightIndex) # $t4, 0x800e
 /* 0926CC 80091ACC 8D8C0414 */  lw    $t4, %lo(gTracksMenuTimeTrialHighlightIndex)($t4)
-/* 0926D0 80091AD0 3C05800E */  lui   $a1, %hi(D_800E0648) # $a1, 0x800e
+/* 0926D0 80091AD0 3C05800E */  lui   $a1, %hi(gTrackSelectTTImage) # $a1, 0x800e
 /* 0926D4 80091AD4 01960019 */  multu $t4, $s6
 /* 0926D8 80091AD8 8FC90000 */  lw    $t1, ($fp)
 /* 0926DC 80091ADC 3C048012 */  lui   $a0, %hi(sMenuCurrDisplayList) # $a0, 0x8012
@@ -809,7 +809,7 @@ glabel render_track_select_setup_ui
 /* 092704 80091B04 00006812 */  mflo  $t5
 /* 092708 80091B08 000DC080 */  sll   $t8, $t5, 2
 /* 09270C 80091B0C 00B82821 */  addu  $a1, $a1, $t8
-/* 092710 80091B10 8CA50648 */  lw    $a1, %lo(D_800E0648)($a1)
+/* 092710 80091B10 8CA50648 */  lw    $a1, %lo(gTrackSelectTTImage)($a1)
 /* 092714 80091B14 0C01E2AE */  jal   render_textured_rectangle
 /* 092718 80091B18 AFA9001C */   sw    $t1, 0x1c($sp)
 /* 09271C 80091B1C 3C02800E */  lui   $v0, %hi(gNumberOfActivePlayers) # $v0, 0x800e

--- a/lib/src/mips1/al/alSynStartVoiceParams.h
+++ b/lib/src/mips1/al/alSynStartVoiceParams.h
@@ -5,11 +5,11 @@
 #include "audio_internal.h"
 
 // Can be changed in the "Audio Options" menu.
-enum StereoPanMode {
+typedef enum StereoPanMode {
     STEREO,
     MONO,
     HEADPHONES
-};
+} StereoPanMode;
 
 void set_stereo_pan_mode(s32 panMode);
 s32 modify_panning(s32 pan);

--- a/rename.sh
+++ b/rename.sh
@@ -2,19 +2,22 @@
 
 shopt -s globstar
 
-if [ "$#" -le "2" ];
+if [ "$#" -lt "2" ];
 then
     echo "usage: $0 old_name new_name"
     exit 1
 fi
 
-# If the 3rd argument is "--check", then make sure the new symbol doesn't already exist!
-if [ "$3" == "--check" ];
+if [ "$#" -gt "2" ];
 then
-    if grep -rlq "$2" asm/**/*.s src/**/*.{c,h} lib/**/*.{c,s} include/*.h undefined_syms.txt dkr.ld;
+    # If the 3rd argument is "--check", then make sure the new symbol doesn't already exist!
+    if [ "$3" == "--check" ];
     then
-        echo "$2 already exist"
-        exit 1
+        if grep -rlq "$2" asm/**/*.s src/**/*.{c,h} lib/**/*.{c,s} include/*.h undefined_syms.txt dkr.ld;
+        then
+            echo "$2 already exist"
+            exit 1
+        fi
     fi
 fi
 

--- a/rename.sh
+++ b/rename.sh
@@ -2,10 +2,20 @@
 
 shopt -s globstar
 
-if [ "$#" -ne "2" ];
+if [ "$#" -le "2" ];
 then
     echo "usage: $0 old_name new_name"
     exit 1
+fi
+
+# If the 3rd argument is "--check", then make sure the new symbol doesn't already exist!
+if [ "$3" == "--check" ];
+then
+    if grep -rlq "$2" asm/**/*.s src/**/*.{c,h} lib/**/*.{c,s} include/*.h undefined_syms.txt dkr.ld;
+    then
+        echo "$2 already exist"
+        exit 1
+    fi
 fi
 
 # Rename all instances within text files.

--- a/src/menu.c
+++ b/src/menu.c
@@ -1029,7 +1029,7 @@ char *gQMarkPtr = "?";
 //   set to FALSE when leaving the menu.
 // This is effectively unused, since it is only read from the 
 //   unused function func_8008E790()
-s32 gIsInTracksMenu = 0;
+s32 gIsInTracksMenu = FALSE;
 
 s32 gTrackNameVoiceDelay = 0;
 s32 gMenuOptionCap = 0;
@@ -7037,7 +7037,7 @@ void menu_track_select_init(void) {
     resize_viewport(0, 80, gTrackSelectViewPortHalfY - (gTrackSelectViewPortHalfY >> 1), SCREEN_HEIGHT, (gTrackSelectViewPortHalfY >> 1) + gTrackSelectViewPortHalfY);
     copy_viewports_to_stack();
     camEnableUserView(0, 0);
-    gIsInTracksMenu = 1;
+    gIsInTracksMenu = TRUE;
     func_8009C674(gTrackSelectObjectIndices);
     allocate_menu_images(gTrackSelectImageIndices);
     assign_menu_arrow_textures();
@@ -7650,7 +7650,7 @@ void func_80090918(s32 updateRate) {
         }
         if (gMenuDelay < -22) {
             set_background_draw_function(NULL);
-            gIsInTracksMenu = 0;
+            gIsInTracksMenu = FALSE;
         }
         if (gMenuDelay > 30) {
             if ((is_adventure_two_unlocked()) && (D_801269C8 != 5)) {

--- a/src/menu.c
+++ b/src/menu.c
@@ -133,7 +133,7 @@ u16 D_80126520[6];
 Settings *gSavefileData[4];
 u8 D_80126540[8];
 s32 gMultiplayerSelectedNumberOfRacersCopy; // Saved version gMultiplayerSelectedNumberOfRacers?
-TextureHeader *gMenuTextures[128]; // lookup table? Contains Objects as well. Need to change name and type.
+TextureHeader *gMenuObjects[128]; // lookup table? Contains Objects as well. Need to change name and type.
 u8 D_80126750[128]; // Seems to be a boolean for "This texture exists" for the above array.
 s32 D_801267D0;
 s32 D_801267D4;
@@ -272,23 +272,23 @@ s32 D_80126CC0;
 
 /************ .data ************/
 
-s8 D_800DF450 = 0;
-f32 D_800DF454 = 1.0f;
+s8 gInAdvModeTrophyRace = 0;
+f32 gTrackSelectWoodFrameHeightScale = 1.0f;
 s32 gResetTitleScale = 1;
 s32 gTitleScreenCurrentOption = 0; // 0 = "Start", 1 = "Options"
-s32 D_800DF460 = 0; // Currently selected menu index? Reused in different menus.
-s32 D_800DF464 = 4; // Currently unknown, might be a different type.
-s32 D_800DF468 = 0;
-s32 D_800DF46C = 0;
+s32 gMenuCurIndex = 0; // Currently selected menu index? Reused in different menus.
+s32 ununsed_800DF464 = 4; // Currently unknown, might be a different type.
+s32 ununsed_800DF468 = 0;
+s32 gMissingControllerDelay = 0;
 s32 gCurrentMenuId = 0; // Currently unknown, might be a different type.
-s32 D_800DF474 = 0;     // Currently unknown, might be a different type.
-s32 D_800DF478 = 0;     // Currently unknown, might be a different type.
+s32 ununsed_800DF474 = 0;     // Currently unknown, might be a different type.
+s32 unused_800DF478 = 0;     // Currently unknown, might be a different type.
 s32 gMenuDelay = 0;
 s32 gNumberOfReadyPlayers = 0;
 s32 D_800DF484 = 0; // Currently unknown, might be a different type.
-s32 D_800DF488 = 0;
-s32 D_800DF48C = 0; // Currently unknown, might be a different type.
-s32 D_800DF490 = 0; // Currently unknown, might be a different type.
+s32 gTitleScreenLoaded = 0;
+s32 unused_800DF48C = 0; // Currently unknown, might be a different type.
+s32 unused_800DF490 = 0; // Currently unknown, might be a different type.
 s32 gIsInAdventureTwo = 0;
 s32 gPlayerHasSeenCautionMenu = 0;
 s32 *gMenuTextLangTable = NULL;
@@ -299,21 +299,21 @@ u8 sMenuGuiColourR = 0xFF;
 u8 sMenuGuiColourG = 0xFF;
 u8 sMenuGuiColourB = 0xFF;
 
-u8  D_800DF4B0              = 0;
-s32 D_800DF4B4              = 0;
+u8  sMenuGuiColourA              = 0;
+s32 gMenuSpriteFlags              = 0;
 s32 gIsInTracksMode         = 1;
 s32 gNumberOfActivePlayers  = 1;
 s32 gIsInTwoPlayerAdventure = 0;
 s32 gTrackIdForPreview    = ASSET_LEVEL_CENTRALAREAHUB;
 s32 gTrackSelectRow         = 0; // 1 = Dino Domain, 2 = Sherbet Island, etc.
 s32 gSaveFileIndex          = 0;
-s32 D_800DF4D0              = 0; // Unused?
+s32 unused_800DF4D0              = 0; // Unused?
 s32 gTrackIdToLoad          = 0;
-s8 D_800DF4D8               = 1;
+s8 unused_800DF4D8               = 1;
 s8 gNextTajChallengeMenu    = FALSE;
 s8 gNeedToCloseDialogueBox  = FALSE;
 
-s8 D_800DF4E4[4] = {
+s8 gDoneTalkingToNPC[4] = {
     0, 0, 0, 0
 };
 
@@ -321,7 +321,7 @@ s32 D_800DF4E8 = 0; // Currently unknown, might be a different type.
 s8 gDialogueOptionTangible = FALSE;
 
 // Unused?
-s32 D_800DF4F0[] = {
+s32 unused_800DF4F0[] = {
     0x4000, 0x8000, 0x1000, 0x2000, 0x8000, 0x10, 0x400, 0x00
 };
 
@@ -348,13 +348,13 @@ unk800DF510 sMenuImageProperties[18] = {
 };
 
 s16 *gAssetsMenuElementIds[1] = { NULL }; // This is probably not correct.
-s16 D_800DF754 = 0;
-s16 D_800DF758 = 0;
+s16 gMenuElementIdCount = 0;
+s16 gMenuObjectsCount = 0;
 unk800DF510 *gMenuImageStack = NULL;
 
 s32 sMenuMusicVolume = 0x7F;
 s32 sMenuGuiOpacity = 0xFF;
-s32 D_800DF768 = 1;
+s32 unused_800DF768 = 1;
 
 FadeTransition sMenuTransitionFadeInFast = FADE_TRANSITION(FADE_FULLSCREEN, FADE_FLAG_NONE, FADE_COLOR_BLACK, 10, -1);
 FadeTransition sMenuTransitionFadeIn = FADE_TRANSITION(FADE_FULLSCREEN, FADE_FLAG_NONE, FADE_COLOR_BLACK, 18, -1);
@@ -362,11 +362,11 @@ FadeTransition sMenuTransitionFadeOut = FADE_TRANSITION(FADE_FULLSCREEN, FADE_FL
 UNUSED FadeTransition sMenuTransitionFadeInWhite = FADE_TRANSITION(FADE_FULLSCREEN, FADE_FLAG_NONE, FADE_COLOR_WHITE, 18, -1);
 UNUSED FadeTransition sMenuTransitionFadeOutWhite = FADE_TRANSITION(FADE_FULLSCREEN, FADE_FLAG_OUT, FADE_COLOR_WHITE, 18, 0);
 
-s32 D_800DF794 = 4;
-MenuElement *D_800DF798 = NULL;
-s32 D_800DF79C = 0; //PAL Y Offset?
+s32 gTrophyRankingsState = 4;
+MenuElement *gTrophyRankingsMenuElements = NULL;
+s32 gDrawMenuElementsYOffset = 0; //PAL Y Offset?
 
-s32 D_800DF7A0 = 0;
+s32 gDrawMenuElementsYOffset2 = 0;
 char *gTitleMenuStrings[3] = { 0, 0, 0 };
 
 // Version text shown on the title screen? See 1:15 in https://www.youtube.com/watch?v=OHSCLcA74ao.
@@ -404,7 +404,7 @@ DrawTexture sGameTitleTileOffsets[12] = {
 };
 
 // Title screen cinematic text
-unk800DF83C D_800DF83C[10] = {
+unk800DF83C gTitleCinematicText[10] = {
     { "TIMBER", 14.0f, 14.5f, 16.5f, 17.0f, -80.0f, SCREEN_HEIGHT_FLOAT - 32.0f, SCREEN_WIDTH_FLOAT_HALF, SCREEN_HEIGHT_FLOAT - 32.0f, SCREEN_WIDTH_FLOAT + 80.0f, SCREEN_HEIGHT_FLOAT - 32.0f },
     { "BUMPER", 19.0f, 19.5f, 21.5f, 22.0f, -80.0f, SCREEN_HEIGHT_FLOAT - 32.0f, SCREEN_WIDTH_FLOAT_HALF, SCREEN_HEIGHT_FLOAT - 32.0f, SCREEN_WIDTH_FLOAT + 80.0f, SCREEN_HEIGHT_FLOAT - 32.0f },
     { "CONKER", 24.0f, 24.5f, 26.5f, 27.0f, -80.0f, SCREEN_HEIGHT_FLOAT - 32.0f, SCREEN_WIDTH_FLOAT_HALF, SCREEN_HEIGHT_FLOAT - 32.0f, SCREEN_WIDTH_FLOAT + 80.0f, SCREEN_HEIGHT_FLOAT - 32.0f },
@@ -417,16 +417,16 @@ unk800DF83C D_800DF83C[10] = {
     { "DIDDY", 63.5f, 64.0f, 66.0f, 66.5f, -80.0f, SCREEN_HEIGHT_FLOAT - 32.0f, SCREEN_WIDTH_FLOAT_HALF, SCREEN_HEIGHT_FLOAT - 32.0f, SCREEN_WIDTH_FLOAT + 80.0f, SCREEN_HEIGHT_FLOAT - 32.0f }
 };
 
-s32 D_800DF9F4 = 0;
+s32 gTitleCinematicTextColourCount = 0;
 
-MenuColour D_800DF9F8[4] = {
+MenuColour gTitleCinematicTextColours[4] = {
     { 255, 255, 0, 255, 204 },
     { 0, 255, 0, 255, 153 },
     { 0, 255, 255, 255, 102 },
     { 0, 0, 255, 255, 51 }
 };
 
-UNUSED u8 D_800DFA10[4] = {
+UNUSED u8 unused_800DFA10[4] = {
     0, 0, 15, 120
 };
 
@@ -449,15 +449,15 @@ unk800DFA3C gAudioMenuStrings[8] = {
     {   0,   0,    0,    0,    0,    0,    0, 0, 0,  0, NULL },
 };
 
-s32 D_800DFABC = 0; // Currently unknown, might be a different type.
+s32 gMusicTestSongIndex = 0; // Currently unknown, might be a different type.
 
 s32 gSfxVolumeSliderValue = 256;   // Value from 0 to 256
 s32 gMusicVolumeSliderValue = 256; // Value from 0 to 256
 
-s32 D_800DFAC8 = 0;
+s32 gAudioOutputType = 0;
 
 // This is used for RGBA colors for the save options Controller Pak BG.
-u32 D_800DFACC[MAXCONTROLLERS] = {
+u32 gContPakSaveBgColours[MAXCONTROLLERS] = {
     COLOUR_RGBA32(64, 64, 255, 255),  // Blue for controller 1
     COLOUR_RGBA32(255, 64, 64, 255),  // Red for controller 2
     COLOUR_RGBA32(255, 208, 64, 255), // Yellow for controller 3
@@ -467,25 +467,25 @@ u32 D_800DFACC[MAXCONTROLLERS] = {
 s32 D_800DFADC = 0; // Currently unknown, might be a different type.
 s32 D_800DFAE0 = 0; // Currently unknown, might be a different type.
 
-char *D_800DFAE4[6] = { 0, 0, 0, 0, 0, 0 };
-char *D_800DFAFC[6] = { 0, 0, 0, 0, 0, 0 };
-char *D_800DFB14[6] = { 0, 0, 0, 0, 0, 0 };
-char *D_800DFB2C[5] = { 0, 0, 0, 0, 0 };
-char *D_800DFB40[7] = { 0, 0, 0, 0, 0, 0, 0 };
-char *D_800DFB5C[6] = { 0, 0, 0, 0, 0, 0 };
-char *D_800DFB74[6] = { 0, 0, 0, 0, 0, 0 };
-char *D_800DFB8C[6] = { 0, 0, 0, 0, 0, 0 };
-char *D_800DFBA4[6] = { 0, 0, 0, 0, 0, 0 };
-char *D_800DFBBC[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
-s32 D_800DFBDC = 0;
+char *gContPakNotPresentStrings[6] = { 0, 0, 0, 0, 0, 0 };
+char *gContPakCorruptDataRepairStrings[6] = { 0, 0, 0, 0, 0, 0 };
+char *gContPakDamagedStrings[6] = { 0, 0, 0, 0, 0, 0 };
+char *gContPakFullStrings[5] = { 0, 0, 0, 0, 0 };
+char *gContPakDiffContStrings[7] = { 0, 0, 0, 0, 0, 0, 0 };
+char *gContPakNoRoomForGhostsStrings[6] = { 0, 0, 0, 0, 0, 0 };
+char *gContPakCorruptDataStrings[6] = { 0, 0, 0, 0, 0, 0 };
+char *gContPakRumbleDetectedStrings[6] = { 0, 0, 0, 0, 0, 0 };
+char *gContPakSwitchToRumbleStrings[6] = { 0, 0, 0, 0, 0, 0 };
+char *gContPakNeed2ndAdvStrings[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+s32 gContPakStrings = 0;
 
 // Unused?
 char **D_800DFBE0[10] = {
-    D_800DFAE4, D_800DFAFC, D_800DFB14, D_800DFB2C, D_800DFB40, D_800DFB5C, D_800DFB8C, D_800DFBA4, D_800DFB74, D_800DFBBC
+    gContPakNotPresentStrings, gContPakCorruptDataRepairStrings, gContPakDamagedStrings, gContPakFullStrings, gContPakDiffContStrings, gContPakNoRoomForGhostsStrings, gContPakRumbleDetectedStrings, gContPakSwitchToRumbleStrings, gContPakCorruptDataStrings, gContPakNeed2ndAdvStrings
 };
 
-s32 D_800DFC08 = 0;      // Currently unknown, might be a different type.
-s32 D_800DFC0C = 0xFFFF; // Currently unknown, might be a different type.
+s32 unused_800DFC08 = 0;      // Currently unknown, might be a different type.
+s32 unused_800DFC0C = 0xFFFF; // Currently unknown, might be a different type.
 
 DrawTexture D_800DFC10[2] = { { NULL, 0, 0 }, { NULL, 0, 0 } };
 DrawTexture D_800DFC20[2] = { { NULL, 0, 0 }, { NULL, 0, 0 } };
@@ -497,7 +497,7 @@ DrawTexture D_800DFC60[2] = { { NULL, 0, 0 }, { NULL, 0, 0 } };
 // Unused?
 u8 D_800DFC70[8] = { 0x40, 0x40, 0x04, 0x04, 0xFF, 0, 0, 0 };
 
-s16 D_800DFC78[26] = {
+s16 gSaveMenuObjectIndices[26] = {
     0x0024, 0x0025, 0x0018, 0x0019,
     0x001A, 0x001B, 0x001C, 0x001D,
     0x003D, 0x003F, 0x003E, 0x003C,
@@ -508,7 +508,7 @@ s16 D_800DFC78[26] = {
 };
 
 //Image textures, likely for the below menu
-s16 D_800DFCAC[4] = {
+s16 gSaveMenuImageIndices[4] = {
     0x000B, 0x000C, 0x0002, 0xFFFF
 };
 
@@ -529,7 +529,7 @@ s32 gUnlockedMagicCodes = 0;
 
 char *gMagicCodeMenuStrings[5] = { 0, 0, 0, 0, 0 };
 
-u8 D_800DFDB4[10][2] = {
+u8 gCharacterVolumes[10][2] = {
     { 0x0F, 0x64 },
     { 0x0C, 0x07 },
     { 0x09, 0x64 },
@@ -542,8 +542,8 @@ u8 D_800DFDB4[10][2] = {
     { 0x04, 0x64 },
 };
 
-s16 D_800DFDC8[2] = { -1, 0 };
-s16 D_800DFDCC[2] = { -1, 0 };
+s16 gCharSelectObjectIndices[2] = { -1, 0 };
+s16 gCharSelectImageIndices[2] = { -1, 0 };
 
 // Not sure what this is
 // Used for gCurrCharacterSelectData when Neither T.T. Nor Drumstick are unlocked
@@ -632,9 +632,9 @@ CharacterSelectData gCharacterSelectBytesComplete[] = {
 //!@bug T.T's down input selects Tiptup. It should be set to NONE.
 };
 
-s32 D_800DFFCC = 0; // Likely unused.
-s32 D_800DFFD0 = 0;
-s32 D_800DFFD4 = -1;
+s32 unused_800DFFCC = 0; // Likely unused.
+s32 gEnteredCharSelectFrom = 0;
+s32 unused_800DFFD4 = -1;
 
 MenuElement gCautionMenuTextElements[14] = {
     { SCREEN_WIDTH_HALF + 1,  35, SCREEN_WIDTH_HALF + 1,  35, SCREEN_WIDTH_HALF + 1,  35,   0,   0,   0, 255, 128, ASSET_FONTS_BIGFONT, 12, 0, { NULL }, {{ 0, 0, 0, 0 }} },
@@ -675,11 +675,11 @@ MenuElement gGameSelectTextElemsWithAdv2[9] = {
     {    0,   0,    0,   0,    0,   0,   0,   0,   0,   0,   0, 0,  0, 0, { NULL },   {{ 0, 0, 0, 0 }} },
 };
 
-s16 D_800E0398[6] = {
+s16 gFileSelectObjectIndices[6] = {
     0x00, 0x43, 0x40, 0x41, 0x42, -1
 };
 
-s16 D_800E03A4[6] = {
+s16 gFileSelectImageIndices[6] = {
     0x00, 0x0B, 0x0C, 0x0A, -1, 0
 };
 
@@ -688,7 +688,7 @@ char *gFilenames[3] = {
 };
 
 // Unused?
-u16 D_800E03BC[8] = {
+u16 unused_800E03BC[8] = {
     0x004C,
     0x0070,
     0x00F4,
@@ -716,8 +716,8 @@ s16 gFileSelectElementPos[10] = {
 // Either 0 (2 racers), 1 (4 racers), or 2 (6 racers)
 s32 gMultiplayerSelectedNumberOfRacers = 0;
 
-s32 D_800E0414 = 0;
-s32 D_800E0418 = 0;
+s32 gTracksMenuTimeTrialHighlightIndex = 0;
+s32 gTracksMenuAdventureHighlightIndex = 0;
 DrawTexture gMenuSelectionArrowUp[2] = { { NULL, -12, -8 }, { NULL, 0, 0 }};
 DrawTexture gMenuSelectionArrowLeft[2] = { { NULL, -8, -12 }, { NULL, 0, 0 }};
 DrawTexture gMenuSelectionArrowDown[2] = { { NULL, -12, -8 }, { NULL, 0, 0 }};
@@ -765,7 +765,7 @@ DrawTexture *gMenuSelectionArrows[4] = {
     gMenuSelectionArrowUp, gMenuSelectionArrowLeft, gMenuSelectionArrowDown, gMenuSelectionArrowRight
 };
 
-u16 D_800E0688[20] = {
+u16 gTracksMenuPlayerNamePositions[20] = {
     0x44, 0x72, 0x44, 0x72,
     0xCC, 0x72, 0x21, 0x72,
     0x88, 0x72, 0xEF, 0x72,
@@ -773,18 +773,18 @@ u16 D_800E0688[20] = {
     0xAA, 0x72, 0xEF, 0x72,
 };
 
-u16 D_800E06B0[10] = {
+u16 gTracksMenuVehicleNamePositions[10] = {
     0x68, 0x21, 0xFB, 0x27, 0x8E, 0xF5, 0x27, 0x6C, 0xB0, 0xF5
 };
 
 //Paired X / Y Offsets. X Is First, Y is Second. For NTSC.
-s16 D_800E06C4[8] = {
+s16 gTracksMenuArrowPositionsNTSC[8] = {
     0x0000, 0xFFC2, 0x0055, 0x0000,
     0x0000, 0x003E, 0xFFAB, 0x0000,
 };
 
 //Paired X / Y Offsets. X Is First, Y is Second. For PAL.
-s16 D_800E06D4[8] = {
+s16 gTracksMenuArrowPositionsPAL[8] = {
     0x0000, 0xFFB6, 0x0055, 0x0000,
     0x0000, 0x004A, 0xFFAB, 0x0000,
 };
@@ -793,19 +793,19 @@ ButtonTextElement gTwoPlayerRacerCountMenu = {
     SCREEN_WIDTH_HALF - 80, 140, 160, 64, 4, 4, { 80, 20, 58, 40, 80, 40, 102, 40 }
 };
 
-ButtonElement D_800E0700 = {
+ButtonElement gTracksMenuAdventureButton = {
     80, 152, 160, 40, 4, 4, 80, 14
 };
 
-// Often access like D_800E0710[i * 3 + 1]. Maybe it's s16[4][3]?
-s16 D_800E0710[16] = {
+// Often access like gTracksMenuBgTextureIndices[i * 3 + 1]. Maybe it's s16[4][3]?
+s16 gTracksMenuBgTextureIndices[16] = {
     0x0E, 0x0F, 0x00, 0x10,
     0x11, 0x20, 0x12, 0x13,
     0x00, 0x14, 0x15, 0x20,
     0x16, 0x17, 0x20, 0x00
 };
 
-TextureHeader *D_800E0730[10] = {
+TextureHeader *gTracksMenuBgTextures[10] = {
     NULL, NULL, // Dino domain
     NULL, NULL, // Sherbet Island
     NULL, NULL, // Snowflake Mountain
@@ -871,18 +871,18 @@ s16 gTTVoiceLines[53] = {
     -1
 };
 
-s16 D_800E07C4[14] = {
+s16 gTrackSelectObjectIndices[14] = {
     0x05, 0x06, 0x07, 0x3D,
     0x3C, 0x3F, 0x3E, 0x08,
     0x09, 0x0A, 0x0B, 0x0C,
     0x0D, -1
 };
 
-s16 D_800E07E0[4] = {
+s16 gTrackSelectImageIndices[4] = {
     0x04, 0x05, 0x06, -1
 };
 
-s16 D_800E07E8[36] = {
+s16 gTrackSelectPreviewObjectIndices[36] = {
     0x0004, 0x0000, 0x0001, 0x0002,
     0x0003, 0x0018, 0x0019, 0x001A,
     0x001B, 0x001C, 0x001D, 0x0024,
@@ -894,13 +894,13 @@ s16 D_800E07E8[36] = {
     0x0041, 0x0043, 0x005E, 0xFFFF
 };
 
-s16 D_800E0830[8] = {
+s16 gTrackSelectPreviewImageIndices[8] = {
     0x07, 0x00, 0x01, 0x02,
     0x03, 0x0B, 0x0C, -1
 };
 
 // Not a struct, since the entries can *technically* be either 4 or 5 bytes. But it is always 5 in the final game.
-u8 D_800E0840[295] = {
+u8 gTrackSelectBgData[295] = {
     0, 0, 255, 255, 0, 
     1, 1, 255, 255, 0, 
     2, 0, 255, 255, 0, 
@@ -961,25 +961,25 @@ u8 D_800E0840[295] = {
     41, 9, 255, 255, 32, 
     255, 0, 0, 0, 0
 };
-Vertex *D_800E0968 = NULL;
+Vertex *gTrackSelectBgVertices = NULL;
 s32 D_800E096C = 0;
-Triangle *D_800E0970 = NULL;
+Triangle *gTrackSelectBgTriangles = NULL;
 s32 D_800E0974 = 0;
 char *gQMarkPtr = "?";
-s32 D_800E097C = 0;
+s32 gIsInTracksMenu = 0;
 s32 gTrackNameVoiceDelay = 0;
 s32 gMenuOptionCap = 0;
 s32 gMenuSubOption = 0;
-s32 D_800E098C = 0; //Player ID or controllerIndex maybe?
+s32 gLastPlayerWhoPaused = 0; //Player ID or controllerIndex maybe?
 
-ColourRGBA D_800E0990[4] = {
+ColourRGBA gPlayerPauseBgColour[4] = {
     {{{  64,  64, 255, 160 }}},
     {{{ 255,  64,  64, 160 }}},
     {{{ 208, 192,  32, 176 }}},
     {{{  32, 192,  64, 176 }}},
 };
 
-ColourRGBA D_800E09A0[4] = {
+ColourRGBA gPlayerPauseOptionsTextColour[4] = {
     {{{   0, 255,   0, 128 }}},
     {{{   0, 255,   0,  96 }}},
     {{{   0,   0, 255,  96 }}},
@@ -1010,11 +1010,11 @@ s16 D_800E0A10[2] = {
 //If you wish to use / the Rumble Pak / insert it now!
 char *sInsertRumblePakMenuText[4] = { 0, 0, 0, 0 };
 
-s16 D_800E0A24[14] = {
+s16 gRaceResultsObjectIndices[14] = {
     0x0005, 0x003B, 0x0032, 0x0033, 0x0034, 0x0035, 0x0036, 0x0039, 0x0037, 0x0038, 0x003A, 0x0000, 0x0001, 0xFFFF
 };
 
-s16 D_800E0A40[8] = {
+s16 gRaceResultsImageIndices[8] = {
     0x0004, 0x0000, 0x0001, 0xFFFF, 0x0300, 0x0000, 0x0012, 0xFFFF
 };
 
@@ -1035,7 +1035,7 @@ DrawTexture *gRacerPortraits[10] = {
     gMenuPortraitPipsy, gMenuPortraitTimber
 };
 
-s16 D_800E0B18[74] = {
+s16 unused_800E0B18[74] = {
     0x0140, 0x017C, 0x01B8, 0x01F4,
     0x0230, 0x026C, 0x02A8, 0x02E4,
     0x01E0, 0x0000, 0x0018, 0x0039,
@@ -1071,7 +1071,7 @@ char *gRacePlacementsArray[8] = {
     gFifthPlace, gSixthPlace, gSeventhPlace, gEighthPlace
 };
 
-MenuElement D_800E0BEC[8] = {
+MenuElement gRaceResultsMenuElements[8] = {
     { 352, 172,  32, 172, -288, 172, 255, 255, 255, 0, 255, ASSET_FONTS_FUNFONT,  0, 3, { &gMenuPortraitKrunch }, {{ 0, 0, 0, 0 }} },
     { 452, 166, 132, 166, -188, 166, 255, 255, 255, 0, 255, ASSET_FONTS_FUNFONT, 12, 0, {      NULL   }, {{ 0, 0, 0, 0 }} },
     { 560, 184, 240, 184,  -80, 184, 255, 255, 255, 0, 255, ASSET_FONTS_FUNFONT, 12, 0, {      NULL   }, {{ 0, 0, 0, 0 }} },
@@ -1082,7 +1082,7 @@ MenuElement D_800E0BEC[8] = {
     {   0,   0,   0,   0,    0,   0,   0,   0,   0, 0,   0, 0,  0, 0, {      NULL   }, {{ 0, 0, 0, 0 }} },
 };
 
-MenuElement D_800E0CEC[11] = {
+MenuElement gRaceOrderMenuElements[11] = {
     { 575, 172, 255, 172,  -65, 172, 255, 255, 255,   0, 255, ASSET_FONTS_FUNFONT,  0, 3, { &gMenuPortraitKrunch }, {{ 0, 0, 0, 0 }} },
     { 542, 172, 222, 172,  -98, 172, 255, 255, 255,   0, 255, ASSET_FONTS_FUNFONT,  0, 3, { &gMenuPortraitKrunch }, {{ 0, 0, 0, 0 }} },
     { 509, 172, 189, 172, -131, 172, 255, 255, 255,   0, 255, ASSET_FONTS_FUNFONT,  0, 3, { &gMenuPortraitKrunch }, {{ 0, 0, 0, 0 }} },
@@ -1097,7 +1097,7 @@ MenuElement D_800E0CEC[11] = {
 
 };
 
-MenuElement D_800E0E4C[9] = {
+MenuElement gRecordTimesMenuElements[9] = {
     { 481, 174, 161, 174, -159, 174,   0,   0,   0, 255, 128, ASSET_FONTS_FUNFONT, 12, 0, {       NULL  }, {{ 0, 0, 0, 0 }} },
     { 479, 172, 159, 172, -161, 172, 255, 255, 255,   0, 255, ASSET_FONTS_FUNFONT, 12, 0, {       NULL  }, {{ 0, 0, 0, 0 }} },
     { 368, 192,  48, 192, -272, 192, 255,  64,  64,  96, 255, ASSET_FONTS_FUNFONT,  8, 0, {       NULL  }, {{ 0, 0, 0, 0 }} },
@@ -1113,18 +1113,18 @@ MenuElement D_800E0E4C[9] = {
 // The length of the array must be a power of two.
 u8 gFileNameValidChars[32] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ.?    ";
 
-char D_800E0F8C = '\0';
-s32 D_800E0F90 = 192;
-s32 D_800E0F94 = 160;
-s32 D_800E0F98 = 120;
-s32 D_800E0F9C = ASSET_FONTS_BIGFONT;
-s32 D_800E0FA0 = 0;
+char gCurFilenameCharBeingDrawn = '\0';
+s32 gEnterInitalsY = 192;
+s32 gFilenameX = 160;
+s32 gFilenameY = 120;
+s32 gFilenameFont = ASSET_FONTS_BIGFONT;
+s32 gCurrentFilenameChars = 0;
 s32 D_800E0FA4 = 0;
-char D_800E0FA8[4] = "DKR"; // Default file name?
+char gCheckAdvEnterInitials[4] = "DKR"; // Default file name?
 s32 D_800E0FAC = 0;
-s32 D_800E0FB0 = 0;
+s32 gIndexOfCurInputCharacter = 0;
 
-s16 D_800E0FB4[18] = {
+s16 gAdvTrackInitObjectIndices[18] = {
     0x0004, 0x0000, 0x0001, 0x0018,
     0x0019, 0x001A, 0x001B, 0x001C,
     0x001D, 0x001E, 0x001F, 0x0020,
@@ -1132,7 +1132,7 @@ s16 D_800E0FB4[18] = {
     0x005E, -1
 };
 
-s16 D_800E0FD8[6] = {
+s16 gAdvTrackInitImageIndices[6] = {
     7, 0, 1, 2, 3, -1
 };
 
@@ -1142,7 +1142,7 @@ s32 gTrophyRaceRound = 0; // Rounds 1 - 4 (as 0 - 3)
 s32 gPrevTrophyRaceRound = 0;
 
 // Unused? Not sure what this is.
-u32 D_800E0FF4[4] = {
+u32 unused_800E0FF4[4] = {
     0x01FFFFFF, 0x0012FFFF, 0x81FFFFFF, 0x00120000
 };
 
@@ -1151,22 +1151,22 @@ s32 gTrophyRacePointsArray[8] = {
     9, 7, 5, 3, 1, 0, 0, 0
 };
 
-s16 D_800E1024[14] = {
+s16 gGhostDataObjectIndices[14] = {
     0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3A, 0x3B, 0x00, 0x01, -1, 0x00
 };
 
-s16 D_800E1040[3] = {
+s16 gGhostDataImageIndices[3] = {
     0, 1, -1
 };
 
-MenuElement D_800E1048[1][2] = { 
+MenuElement gTrophyRankingsTitle[1][2] = { 
     {
         { SCREEN_WIDTH + 160 + 1, 35, SCREEN_WIDTH_HALF + 1, 35, -159, 35, 0, 0, 0, 255, 128, ASSET_FONTS_BIGFONT, 12, 0, { NULL }, {{ 0, 0, 0, 0 }} },
         { SCREEN_WIDTH + 160, 32, SCREEN_WIDTH_HALF, 32, -160, 32, 255, 255, 255, 0, 255, ASSET_FONTS_BIGFONT, 12, 0, { NULL }, {{ 0, 0, 0, 0 }} }
     }
 };
 
-MenuElement D_800E1088[8][3] = {
+MenuElement gTrophyRankingsCharDetails[8][3] = {
     {
         { 64, -192, 64, 48, 64, 288, 255, 255, 255, 0, 255, ASSET_FONTS_FUNFONT, 0, 3, { &gMenuPortraitKrunch }, {{ 0, 0, 0, 0 }} },
         { 32, -192, 32, 48, 32, 288, 255, 255, 255, 0, 255, ASSET_FONTS_FUNFONT, 0, 0, { gFirstPlace }, {{ 0, 0, 0, 0 }} },
@@ -1210,7 +1210,7 @@ MenuElement D_800E1088[8][3] = {
 };
 MenuElement D_800E1088_END = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ASSET_FONTS_FUNFONT, 0, 0, { NULL }, {{ 0, 0, 0, 0 }} };
 
-s16 D_800E13A8[138] = {
+s16 gTrophyRankingsRawIconPositions[138] = {
     0x0040, 0x0020, 0x0082, 0x0040, 0x0020, 0x0082, 0x0040, 0x0020,
     0x0082, 0x0040, 0x0020, 0x0082, 0x00DC, 0x00BC, 0x011E, 0x00DC,
     0x00BC, 0x011E, 0x00DC, 0x00BC, 0x011E, 0x00DC, 0x00BC, 0x011E,
@@ -1231,19 +1231,19 @@ s16 D_800E13A8[138] = {
     0x006C, 0x00CE
 };
 
-s16 *D_800E14BC[32] = {
+s16 *gTrophyRankingsIconPositions[32] = {
     NULL, NULL, NULL, NULL,
-    &D_800E13A8[126], &D_800E13A8[90], &D_800E13A8[126], &D_800E13A8[24],
-    NULL, NULL , &D_800E13A8[72], &D_800E13A8[90],
-    NULL, NULL, &D_800E13A8[0], &D_800E13A8[24],
+    &gTrophyRankingsRawIconPositions[126], &gTrophyRankingsRawIconPositions[90], &gTrophyRankingsRawIconPositions[126], &gTrophyRankingsRawIconPositions[24],
+    NULL, NULL , &gTrophyRankingsRawIconPositions[72], &gTrophyRankingsRawIconPositions[90],
+    NULL, NULL, &gTrophyRankingsRawIconPositions[0], &gTrophyRankingsRawIconPositions[24],
     NULL, NULL, NULL, NULL,
-    &D_800E13A8[126], &D_800E13A8[108], &D_800E13A8[126], &D_800E13A8[48],
-    NULL, NULL, &D_800E13A8[72], &D_800E13A8[108],
-    NULL, NULL, &D_800E13A8[0], &D_800E13A8[48]
+    &gTrophyRankingsRawIconPositions[126], &gTrophyRankingsRawIconPositions[108], &gTrophyRankingsRawIconPositions[126], &gTrophyRankingsRawIconPositions[48],
+    NULL, NULL, &gTrophyRankingsRawIconPositions[72], &gTrophyRankingsRawIconPositions[108],
+    NULL, NULL, &gTrophyRankingsRawIconPositions[0], &gTrophyRankingsRawIconPositions[48]
 };
 
 // DrawTextures for Dino Domain ghost background.
-DrawTexture D_800E153C[] = {
+DrawTexture gDrawTexDinoDomainGhostBg[] = {
     { NULL, 0, 0 },
     { NULL, 64, 0 },
     { NULL, 128, 0 },
@@ -1258,7 +1258,7 @@ DrawTexture D_800E153C[] = {
 };
 
 // DrawTextures for Sherbet Island ghost background.
-DrawTexture D_800E1594[] = {
+DrawTexture gDrawTexSherbetIslandGhostBg[] = {
     { NULL, 0, 0 },
     { NULL, 64, 0 },
     { NULL, 128, 0 },
@@ -1273,7 +1273,7 @@ DrawTexture D_800E1594[] = {
 };
 
 // DrawTextures for Snowflake Mountain ghost background.
-DrawTexture D_800E15EC[] = {
+DrawTexture gDrawTexSnowflakeMountainGhostBg[] = {
     { NULL, 0, 0 },
     { NULL, 64, 0 },
     { NULL, 128, 0 },
@@ -1288,7 +1288,7 @@ DrawTexture D_800E15EC[] = {
 };
 
 // DrawTextures for Dragon Forest ghost background.
-DrawTexture D_800E1644[] = {
+DrawTexture gDrawTexDragonForestGhostBg[] = {
     { NULL, 0, 0 },
     { NULL, 64, 0 },
     { NULL, 128, 0 },
@@ -1303,7 +1303,7 @@ DrawTexture D_800E1644[] = {
 };
 
 // DrawTextures for Future Fun Land ghost background.
-DrawTexture D_800E169C[] = {
+DrawTexture gDrawTexFutureFunLandGhostBg[] = {
     { NULL, 0, 0 },
     { NULL, 64, 0 },
     { NULL, 128, 0 },
@@ -1317,12 +1317,12 @@ DrawTexture D_800E169C[] = {
     { NULL, 0, 0 }
 };
 
-DrawTexture *D_800E16F4[5] = {
-    D_800E153C, // Dino Domain
-    D_800E1594, // Sherbet Island
-    D_800E15EC, // Snowflake Mountain
-    D_800E1644, // Dragon Forest
-    D_800E169C  // Future Fun Land
+DrawTexture *gDrawTexWorldBgs[5] = {
+    gDrawTexDinoDomainGhostBg, // Dino Domain
+    gDrawTexSherbetIslandGhostBg, // Sherbet Island
+    gDrawTexSnowflakeMountainGhostBg, // Snowflake Mountain
+    gDrawTexDragonForestGhostBg, // Dragon Forest
+    gDrawTexFutureFunLandGhostBg  // Future Fun Land
 };
 
 s16 D_800E1708[34] = {
@@ -1337,11 +1337,11 @@ s16 D_800E174C[4] = {
     0, 1, 7, -1
 };
 
-s16 D_800E1754[10] = {
+s16 gGhostDataElementPositions[10] = {
     0x78, 0x12, 0x08, 0x06, 0xC0, 0x06, 0xD4, 0x1A, 0x78, 0x22
 };
 
-s16 D_800E1768[12] = {
+s16 gIntroCinematicObjectIndices[12] = {
     0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3A, 0x3B, -1, 0
 };
 
@@ -1359,15 +1359,15 @@ Gfx dCreditsFade[11] = {
     gsSPEndDisplayList(),
 };
 
-s16 D_800E17D8[12] = {
+s16 gCreditsObjectIndices[12] = {
     0x0032, 0x0033, 0x0034, 0x0035, 0x0036, 0x0037, 0x0038, 0x0039, 0x003A, 0x003B, -1, 0
 };
 
-s16 D_800E17F0[2] = {
+s16 gCreditsImageIndices[2] = {
     -1, 0
 };
 
-s16 D_800E17F4[130] = {
+s16 gCreditsControlData[130] = {
     0x20A5, 0x0000, 0x20A5, 0x0001, 0x0002, 0x20A5, 0x0003, 0x0004,
     0x0005, 0x0006, 0x4000, 0x20A5, 0x0007, 0x0008, 0x20A5, 0x0009,
     0x000A, 0x000B, 0x000C, 0x30A5, 0x000D, 0x000E, 0x000F, 0x4000,
@@ -1472,7 +1472,7 @@ s32 gCheatsInCreditsArray[21] = {
 
 s32 gViewingCreditsFromCheat = FALSE; // Set to 1 if viewing credits from "WHODIDTHIS" cheat
 
-MenuElement D_800E1B50[9] = {
+MenuElement gCreditsMenuElements[9] = {
     { 480, 104, 160, 104, -160, 104, 255,   0, 255, 48, 255, ASSET_FONTS_FUNFONT, 4, 0, { NULL }, {{ 0, 0, 0, 0 }} },
     { 480, 132, 160, 132, -160, 132, 255, 255, 255,  0, 255, ASSET_FONTS_BIGFONT, 4, 0, { NULL }, {{ 0, 0, 0, 0 }} },
     { 480, 104, 160, 104, -160, 104, 255, 255, 255,  0, 255, ASSET_FONTS_BIGFONT, 4, 0, { NULL }, {{ 0, 0, 0, 0 }} },
@@ -1508,7 +1508,7 @@ UNUSED Gfx dMenuHudDrawModes[][2] = {
     }
 };
 
-s8 D_800E1CD0[32] = {
+s8 gWoodPanelsIndices[32] = {
     0, 1, 2, 0, 2, 3, 4, 5,
     6, 4, 6, 7, 8, 9, 10, 8,
     10, 11, 12, 13, 14, 12, 14, 15,
@@ -1516,7 +1516,7 @@ s8 D_800E1CD0[32] = {
 };
 
 // UV coordinate indices
-u8 D_800E1CF0[5][12] = {
+u8 gWoodPanelTexCoords[5][12] = {
     { 0, 0, 3, 0, 2, 1, 0, 0, 2, 1, 1, 1 }, 
     { 2, 1, 3, 0, 3, 3, 2, 1, 3, 3, 2, 2 }, 
     { 1, 2, 2, 2, 3, 3, 1, 2, 3, 3, 0, 3 }, 
@@ -1525,7 +1525,7 @@ u8 D_800E1CF0[5][12] = {
 };
 
 // Position offsets, why are there 10?
-u16 D_800E1D2C[10][4] = {
+u16 gWoodPanelVertCoords[10][4] = {
     {   0,    0, 256,    0 },
     { 511,  255,   1,  255 },
     { 511,  255, 256,    0 },
@@ -1539,7 +1539,7 @@ u16 D_800E1D2C[10][4] = {
 };
 
 // Colours
-s16 D_800E1D7C[5][4] = {
+s16 gWoodPanelVertColours[5][4] = {
     { 216, 216, 216, 256 },
     { 176, 176, 176, 256 },
     {  96,  96,  96, 256 },
@@ -1547,32 +1547,32 @@ s16 D_800E1D7C[5][4] = {
     { 256, 256, 256, 256 }
 };
 
-s32 *D_800E1DA4[2] = {
+s32 *gWoodPanelVertices[2] = {
     NULL, NULL
 };
 
-s32 *D_800E1DAC[2] = {
+s32 *gWoodPanelTriangles[2] = {
     NULL, NULL
 };
 
 s32 D_800E1DB4 = 0;
-s32 D_800E1DB8 = 0;
+s32 gWoodPanelCount = 0;
 s32 D_800E1DBC = 0;
 
-s32 D_800E1DC0 = 32;
-s32 D_800E1DC4 = 32;
+s32 gWoodPanelTexScaleU = 32;
+s32 gWoodPanelTexScaleV = 32;
 
 s16 D_800E1DC8[16] = {
     1, 1, -1, 1, -1, 1, -1, -1, 1, -1, -1, -1, 1, 1, 1, -1
 };
 
-FadeTransition D_800E1DE8 = FADE_TRANSITION(FADE_FULLSCREEN, FADE_FLAG_NONE, FADE_COLOR_BLACK, 120, -1);
+FadeTransition gFadeLogoToTitleScreen = FADE_TRANSITION(FADE_FULLSCREEN, FADE_FLAG_NONE, FADE_COLOR_BLACK, 120, -1);
 
 char gRareCopyrightString[24] = "(C) COPYRIGHT RARE 1997";
 
-FadeTransition D_800E1E08 = FADE_TRANSITION(FADE_FULLSCREEN, FADE_FLAG_NONE, FADE_COLOR_BLACK, 52, -1);
+FadeTransition gFadeTitleScreenDemo = FADE_TRANSITION(FADE_FULLSCREEN, FADE_FLAG_NONE, FADE_COLOR_BLACK, 52, -1);
 
-char *D_800E1E10 = " (ADV.";
+char *gConPakAdvSavePrefix = " (ADV.";
 
 
 /*******************************/
@@ -1645,14 +1645,14 @@ void load_menu_text(s32 language) {
         gMagicCodeMenuStrings[1] = gMenuText[ASSET_MENU_TEXT_CLEARALLCODES];                         // "CLEAR ALL CODES"
         gMagicCodeMenuStrings[2] = gMenuText[ASSET_MENU_TEXT_CODELIST];                              // "CODE LIST"
         gMagicCodeMenuStrings[3] = gMenuText[ASSET_MENU_TEXT_RETURN];                                // "RETURN"
-        D_800E0BEC[1].unk14_a.asciiText = gMenuText[ASSET_MENU_TEXT_LAPTIMES];                       // "LAP TIMES"
-        D_800E0BEC[2].unk14_a.asciiText = gMenuText[ASSET_MENU_TEXT_OVERALLTIME];                    // "OVERALL TIME"
-        D_800E0CEC[8].unk14_a.asciiText = gMenuText[ASSET_MENU_TEXT_RACEORDER];                      // "RACE ORDER"
-        D_800E0CEC[9].unk14_a.asciiText = gMenuText[ASSET_MENU_TEXT_RACEORDER];                      // "RACE ORDER"
-        D_800E0E4C[0].unk14_a.asciiText = gMenuText[ASSET_MENU_TEXT_RECORDTIMES];                    // "RECORD TIMES"
-        D_800E0E4C[1].unk14_a.asciiText = gMenuText[ASSET_MENU_TEXT_RECORDTIMES];                    // "RECORD TIMES"
-        D_800E0E4C[2].unk14_a.asciiText = gMenuText[ASSET_MENU_TEXT_BESTTIME];                       // "BEST TIME"
-        D_800E0E4C[5].unk14_a.asciiText = gMenuText[ASSET_MENU_TEXT_BESTLAP];                        // "BEST LAP"
+        gRaceResultsMenuElements[1].unk14_a.asciiText = gMenuText[ASSET_MENU_TEXT_LAPTIMES];                       // "LAP TIMES"
+        gRaceResultsMenuElements[2].unk14_a.asciiText = gMenuText[ASSET_MENU_TEXT_OVERALLTIME];                    // "OVERALL TIME"
+        gRaceOrderMenuElements[8].unk14_a.asciiText = gMenuText[ASSET_MENU_TEXT_RACEORDER];                      // "RACE ORDER"
+        gRaceOrderMenuElements[9].unk14_a.asciiText = gMenuText[ASSET_MENU_TEXT_RACEORDER];                      // "RACE ORDER"
+        gRecordTimesMenuElements[0].unk14_a.asciiText = gMenuText[ASSET_MENU_TEXT_RECORDTIMES];                    // "RECORD TIMES"
+        gRecordTimesMenuElements[1].unk14_a.asciiText = gMenuText[ASSET_MENU_TEXT_RECORDTIMES];                    // "RECORD TIMES"
+        gRecordTimesMenuElements[2].unk14_a.asciiText = gMenuText[ASSET_MENU_TEXT_BESTTIME];                       // "BEST TIME"
+        gRecordTimesMenuElements[5].unk14_a.asciiText = gMenuText[ASSET_MENU_TEXT_BESTLAP];                        // "BEST LAP"
         gOptionMenuStrings[0] = gMenuText[ASSET_MENU_TEXT_LANGUAGE];                                 // "ENGLISH"
         if (sEepromSettings & 0x2000000) {
             gOptionMenuStrings[1] = gMenuText[ASSET_MENU_TEXT_SUBTITLESON];                          // "SUBTITLES ON"
@@ -1666,47 +1666,47 @@ void load_menu_text(s32 language) {
         gFilenames[0] = gMenuText[ASSET_MENU_TEXT_GAMEA];                                            // "GAME A"
         gFilenames[1] = gMenuText[ASSET_MENU_TEXT_GAMEB];                                            // "GAME B"
         gFilenames[2] = gMenuText[ASSET_MENU_TEXT_GAMEC];                                            // "GAME C"
-        D_800DFAE4[0] = gMenuText[ASSET_MENU_TEXT_CONTPAKX];                                         // "CONTROLLER PAK ~"
-        D_800DFAE4[1] = gMenuText[ASSET_MENU_TEXT_CONTPAKNOTPRESENT];                                // "IS NOT PRESENT."
-        D_800DFAE4[3] = gMenuText[ASSET_MENU_TEXT_CANCEL];                                           // "CANCEL"
-        D_800DFAFC[0] = gMenuText[ASSET_MENU_TEXT_CONTPAKX];                                         // "CONTROLLER PAK ~"
-        D_800DFAFC[1] = gMenuText[ASSET_MENU_TEXT_CONTPAKHASCORRUPTDATA_0];                          // "CONTAINS CORRUPT DATA."
-        D_800DFAFC[3] = gMenuText[ASSET_MENU_TEXT_CONTPAKHASCORRUPTDATA_1];                          // "ATTEMPT TO REPAIR"
-        D_800DFAFC[4] = gMenuText[ASSET_MENU_TEXT_CANCEL];                                           // "CANCEL"
-        D_800DFB14[0] = gMenuText[ASSET_MENU_TEXT_CONTPAKX];                                         // "CONTROLLER PAK ~"
-        D_800DFB14[1] = gMenuText[ASSET_MENU_TEXT_CONTPAKISDAMAGED_0];                               // "IRREPARABLY DAMAGED."
-        D_800DFB14[3] = gMenuText[ASSET_MENU_TEXT_CONTPAKISDAMAGED_1];                               // "REFORMAT PAK"
-        D_800DFB14[4] = gMenuText[ASSET_MENU_TEXT_CANCEL];                                           // "CANCEL"
-        D_800DFB2C[0] = gMenuText[ASSET_MENU_TEXT_CONTPAKX];                                         // "CONTROLLER PAK ~"
-        D_800DFB2C[1] = gMenuText[ASSET_MENU_TEXT_CONTPAKISFULL];                                    // "FULL."
-        D_800DFB2C[3] = gMenuText[ASSET_MENU_TEXT_CONTINUE];                                         // "CONTINUE"
-        D_800DFB40[0] = gMenuText[ASSET_MENU_TEXT_CONTPAKX];                                         // "CONTROLLER PAK ~"
-        D_800DFB40[1] = gMenuText[ASSET_MENU_TEXT_CONTPAKDIFFERENT_0];                               // "DIFFERENT CONTROLLER"
-        D_800DFB40[2] = gMenuText[ASSET_MENU_TEXT_CONTPAKDIFFERENT_1];                               // "PAK IS INSERTED."
-        D_800DFB40[4] = gMenuText[ASSET_MENU_TEXT_CANCEL];                                           // "CANCEL"
-        D_800DFB5C[0] = gMenuText[ASSET_MENU_TEXT_CONTPAKX];                                         // "CONTROLLER PAK ~"
-        D_800DFB5C[1] = gMenuText[ASSET_MENU_TEXT_CANNOTSTOREANYMOREGHOSTS_0];                       // "CANNOT STORE ANY"
-        D_800DFB5C[2] = gMenuText[ASSET_MENU_TEXT_CANNOTSTOREANYMOREGHOSTS_1];                       // "MORE GHOSTS."
-        D_800DFB5C[4] = gMenuText[ASSET_MENU_TEXT_CONTINUE];                                         // "CONTINUE"
-        D_800DFB74[0] = gMenuText[ASSET_MENU_TEXT_CONTPAKX];                                         // "CONTROLLER PAK ~"
-        D_800DFB74[1] = gMenuText[ASSET_MENU_TEXT_CORRUPTDATA_0];                                    // "CORRUPT DATA."
-        D_800DFB74[3] = gMenuText[ASSET_MENU_TEXT_TRYAGAIN];                                         // "TRY AGAIN"
-        D_800DFB74[4] = gMenuText[ASSET_MENU_TEXT_CANCEL];                                           // "CANCEL"
-        D_800DFB8C[0] = gMenuText[ASSET_MENU_TEXT_RUMBLEPAKDETECTED_0];                              // "Rumble Pak Detected"
-        D_800DFB8C[1] = gMenuText[ASSET_MENU_TEXT_RUMBLEPAKDETECTED_1];                              // "Insert any Controller Paks"
-        D_800DFB8C[2] = gMenuText[ASSET_MENU_TEXT_RUMBLEPAKDETECTED_2];                              // "you wish to use now!"
-        D_800DFB8C[4] = gMenuText[ASSET_MENU_TEXT_CONTINUE];                                         // "CONTINUE"
-        D_800DFBA4[0] = gMenuText[ASSET_MENU_TEXT_INSERTDEVICE_0];                                   // "If you wish to use any"
-        D_800DFBA4[1] = gMenuText[ASSET_MENU_TEXT_INSERTDEVICE_1];                                   // "Rumble Paks then please"
-        D_800DFBA4[2] = gMenuText[ASSET_MENU_TEXT_INSERTDEVICE_2];                                   // "insert them now."
-        D_800DFBA4[4] = gMenuText[ASSET_MENU_TEXT_CONTINUE];                                         // "CONTINUE"
-        D_800DFBBC[0] = gMenuText[ASSET_MENU_TEXT_ADVTWOLOADERROR_0];                                // "SORRY, BUT YOU"
-        D_800DFBBC[1] = gMenuText[ASSET_MENU_TEXT_ADVTWOLOADERROR_1];                                // "CAN'T LOAD GAMES"
-        D_800DFBBC[2] = gMenuText[ASSET_MENU_TEXT_ADVTWOLOADERROR_2];                                // "FOR THE SECOND"
-        D_800DFBBC[3] = gMenuText[ASSET_MENU_TEXT_ADVTWOLOADERROR_3];                                // "ADVENTURE UNTIL"
-        D_800DFBBC[4] = gMenuText[ASSET_MENU_TEXT_ADVTWOLOADERROR_4];                                // "YOU HAVE COMPLETED"
-        D_800DFBBC[5] = gMenuText[ASSET_MENU_TEXT_ADVTWOLOADERROR_5];                                // "THE FIRST."
-        D_800DFBBC[7] = gMenuText[ASSET_MENU_TEXT_CONTINUE];                                         // "CONTINUE"
+        gContPakNotPresentStrings[0] = gMenuText[ASSET_MENU_TEXT_CONTPAKX];                                         // "CONTROLLER PAK ~"
+        gContPakNotPresentStrings[1] = gMenuText[ASSET_MENU_TEXT_CONTPAKNOTPRESENT];                                // "IS NOT PRESENT."
+        gContPakNotPresentStrings[3] = gMenuText[ASSET_MENU_TEXT_CANCEL];                                           // "CANCEL"
+        gContPakCorruptDataRepairStrings[0] = gMenuText[ASSET_MENU_TEXT_CONTPAKX];                                         // "CONTROLLER PAK ~"
+        gContPakCorruptDataRepairStrings[1] = gMenuText[ASSET_MENU_TEXT_CONTPAKHASCORRUPTDATA_0];                          // "CONTAINS CORRUPT DATA."
+        gContPakCorruptDataRepairStrings[3] = gMenuText[ASSET_MENU_TEXT_CONTPAKHASCORRUPTDATA_1];                          // "ATTEMPT TO REPAIR"
+        gContPakCorruptDataRepairStrings[4] = gMenuText[ASSET_MENU_TEXT_CANCEL];                                           // "CANCEL"
+        gContPakDamagedStrings[0] = gMenuText[ASSET_MENU_TEXT_CONTPAKX];                                         // "CONTROLLER PAK ~"
+        gContPakDamagedStrings[1] = gMenuText[ASSET_MENU_TEXT_CONTPAKISDAMAGED_0];                               // "IRREPARABLY DAMAGED."
+        gContPakDamagedStrings[3] = gMenuText[ASSET_MENU_TEXT_CONTPAKISDAMAGED_1];                               // "REFORMAT PAK"
+        gContPakDamagedStrings[4] = gMenuText[ASSET_MENU_TEXT_CANCEL];                                           // "CANCEL"
+        gContPakFullStrings[0] = gMenuText[ASSET_MENU_TEXT_CONTPAKX];                                         // "CONTROLLER PAK ~"
+        gContPakFullStrings[1] = gMenuText[ASSET_MENU_TEXT_CONTPAKISFULL];                                    // "FULL."
+        gContPakFullStrings[3] = gMenuText[ASSET_MENU_TEXT_CONTINUE];                                         // "CONTINUE"
+        gContPakDiffContStrings[0] = gMenuText[ASSET_MENU_TEXT_CONTPAKX];                                         // "CONTROLLER PAK ~"
+        gContPakDiffContStrings[1] = gMenuText[ASSET_MENU_TEXT_CONTPAKDIFFERENT_0];                               // "DIFFERENT CONTROLLER"
+        gContPakDiffContStrings[2] = gMenuText[ASSET_MENU_TEXT_CONTPAKDIFFERENT_1];                               // "PAK IS INSERTED."
+        gContPakDiffContStrings[4] = gMenuText[ASSET_MENU_TEXT_CANCEL];                                           // "CANCEL"
+        gContPakNoRoomForGhostsStrings[0] = gMenuText[ASSET_MENU_TEXT_CONTPAKX];                                         // "CONTROLLER PAK ~"
+        gContPakNoRoomForGhostsStrings[1] = gMenuText[ASSET_MENU_TEXT_CANNOTSTOREANYMOREGHOSTS_0];                       // "CANNOT STORE ANY"
+        gContPakNoRoomForGhostsStrings[2] = gMenuText[ASSET_MENU_TEXT_CANNOTSTOREANYMOREGHOSTS_1];                       // "MORE GHOSTS."
+        gContPakNoRoomForGhostsStrings[4] = gMenuText[ASSET_MENU_TEXT_CONTINUE];                                         // "CONTINUE"
+        gContPakCorruptDataStrings[0] = gMenuText[ASSET_MENU_TEXT_CONTPAKX];                                         // "CONTROLLER PAK ~"
+        gContPakCorruptDataStrings[1] = gMenuText[ASSET_MENU_TEXT_CORRUPTDATA_0];                                    // "CORRUPT DATA."
+        gContPakCorruptDataStrings[3] = gMenuText[ASSET_MENU_TEXT_TRYAGAIN];                                         // "TRY AGAIN"
+        gContPakCorruptDataStrings[4] = gMenuText[ASSET_MENU_TEXT_CANCEL];                                           // "CANCEL"
+        gContPakRumbleDetectedStrings[0] = gMenuText[ASSET_MENU_TEXT_RUMBLEPAKDETECTED_0];                              // "Rumble Pak Detected"
+        gContPakRumbleDetectedStrings[1] = gMenuText[ASSET_MENU_TEXT_RUMBLEPAKDETECTED_1];                              // "Insert any Controller Paks"
+        gContPakRumbleDetectedStrings[2] = gMenuText[ASSET_MENU_TEXT_RUMBLEPAKDETECTED_2];                              // "you wish to use now!"
+        gContPakRumbleDetectedStrings[4] = gMenuText[ASSET_MENU_TEXT_CONTINUE];                                         // "CONTINUE"
+        gContPakSwitchToRumbleStrings[0] = gMenuText[ASSET_MENU_TEXT_INSERTDEVICE_0];                                   // "If you wish to use any"
+        gContPakSwitchToRumbleStrings[1] = gMenuText[ASSET_MENU_TEXT_INSERTDEVICE_1];                                   // "Rumble Paks then please"
+        gContPakSwitchToRumbleStrings[2] = gMenuText[ASSET_MENU_TEXT_INSERTDEVICE_2];                                   // "insert them now."
+        gContPakSwitchToRumbleStrings[4] = gMenuText[ASSET_MENU_TEXT_CONTINUE];                                         // "CONTINUE"
+        gContPakNeed2ndAdvStrings[0] = gMenuText[ASSET_MENU_TEXT_ADVTWOLOADERROR_0];                                // "SORRY, BUT YOU"
+        gContPakNeed2ndAdvStrings[1] = gMenuText[ASSET_MENU_TEXT_ADVTWOLOADERROR_1];                                // "CAN'T LOAD GAMES"
+        gContPakNeed2ndAdvStrings[2] = gMenuText[ASSET_MENU_TEXT_ADVTWOLOADERROR_2];                                // "FOR THE SECOND"
+        gContPakNeed2ndAdvStrings[3] = gMenuText[ASSET_MENU_TEXT_ADVTWOLOADERROR_3];                                // "ADVENTURE UNTIL"
+        gContPakNeed2ndAdvStrings[4] = gMenuText[ASSET_MENU_TEXT_ADVTWOLOADERROR_4];                                // "YOU HAVE COMPLETED"
+        gContPakNeed2ndAdvStrings[5] = gMenuText[ASSET_MENU_TEXT_ADVTWOLOADERROR_5];                                // "THE FIRST."
+        gContPakNeed2ndAdvStrings[7] = gMenuText[ASSET_MENU_TEXT_CONTINUE];                                         // "CONTINUE"
         gTitleMenuStrings[0] = gMenuText[ASSET_MENU_TEXT_START];                                     // "START"
         gTitleMenuStrings[1] = gMenuText[ASSET_MENU_TEXT_OPTIONS];                                   // "OPTIONS"
         gGameSelectTextElemsNoAdv2[0].unk14_a.asciiText = gMenuText[ASSET_MENU_TEXT_GAMESELECT];     // "GAME SELECT"
@@ -1756,23 +1756,23 @@ GLOBAL_ASM("asm/non_matchings/menu/load_menu_text.s")
 #endif
 
 void func_8007FF88(void) {
-    if (D_800E1DAC[0] != NULL) {
-        free_from_memory_pool(D_800E1DAC[0]);
-        D_800E1DAC[0] = NULL;
+    if (gWoodPanelTriangles[0] != NULL) {
+        free_from_memory_pool(gWoodPanelTriangles[0]);
+        gWoodPanelTriangles[0] = NULL;
     }
-    D_800E1DAC[1] = NULL;
+    gWoodPanelTriangles[1] = NULL;
     D_80126C2C = NULL;
-    D_800E1DA4[0] = NULL;
-    D_800E1DA4[1] = NULL;
-    D_800E1DB8 = 0;
+    gWoodPanelVertices[0] = NULL;
+    gWoodPanelVertices[1] = NULL;
+    gWoodPanelCount = 0;
     D_800E1DBC = 0;
 }
 
 GLOBAL_ASM("asm/non_matchings/menu/func_8007FFEC.s")
 
 void func_80080518(f32 arg0, f32 arg1) {
-    D_800E1DC0 = (s32) (arg0 * 32.0f);
-    D_800E1DC4 = (s32) (arg1 * 32.0f);
+    gWoodPanelTexScaleU = (s32) (arg0 * 32.0f);
+    gWoodPanelTexScaleV = (s32) (arg1 * 32.0f);
 }
 
 //https://decomp.me/scratch/W0adv
@@ -1786,53 +1786,53 @@ void func_80080580(Gfx** dlist, s32 startX, s32 startY, s32 width, s32 height, s
     s32 i;
     s32 texEnabled;
 
-    //((unk80080BC8*)((u8*)D_80126C2C[D_800E1DB8] + (D_800E1DB4 * 4)))->texture = tex;
-    ((unk80080BC8*)((u8*)D_80126C2C + (D_800E1DB8 << 5) + (D_800E1DB4 * 4)))->texture = tex;
-    //(&(*D_80126C2C)[D_800E1DB8] + (D_800E1DB4 * 4))->texture = tex;
-    //D_80126C2C[D_800E1DB8][D_800E1DB4].texture = tex;
+    //((unk80080BC8*)((u8*)D_80126C2C[gWoodPanelCount] + (D_800E1DB4 * 4)))->texture = tex;
+    ((unk80080BC8*)((u8*)D_80126C2C + (gWoodPanelCount << 5) + (D_800E1DB4 * 4)))->texture = tex;
+    //(&(*D_80126C2C)[gWoodPanelCount] + (D_800E1DB4 * 4))->texture = tex;
+    //D_80126C2C[gWoodPanelCount][D_800E1DB4].texture = tex;
     if (tex != NULL) {
         uVals[0] = 0;
         vVals[0] = 0;
-        uVals[1] = D_800E1DC0 * borderWidth;
-        uVals[2] = (width - borderWidth) * D_800E1DC0;
-        uVals[3] = D_800E1DC0 * width;
-        vVals[1] = D_800E1DC4 * borderHeight;
-        vVals[2] = (height - borderHeight) * D_800E1DC4;
-        vVals[3] = D_800E1DC4 * height;
-        tris = ((unk80080BC8*)((u8*)D_80126C2C + (D_800E1DB8 << 5) + (D_800E1DB4 * 4)))->triangles;
+        uVals[1] = gWoodPanelTexScaleU * borderWidth;
+        uVals[2] = (width - borderWidth) * gWoodPanelTexScaleU;
+        uVals[3] = gWoodPanelTexScaleU * width;
+        vVals[1] = gWoodPanelTexScaleV * borderHeight;
+        vVals[2] = (height - borderHeight) * gWoodPanelTexScaleV;
+        vVals[3] = gWoodPanelTexScaleV * height;
+        tris = ((unk80080BC8*)((u8*)D_80126C2C + (gWoodPanelCount << 5) + (D_800E1DB4 * 4)))->triangles;
         for (i = 0; i < 5; i++) {
-            tris[i*2].uv0.u = uVals[D_800E1CF0[i][0]];
-            tris[i*2].uv0.v = vVals[D_800E1CF0[i][1]];
-            tris[i*2].uv1.u = uVals[D_800E1CF0[i][2]];
-            tris[i*2].uv1.v = vVals[D_800E1CF0[i][3]];
-            tris[i*2].uv2.u = uVals[D_800E1CF0[i][4]];
-            tris[i*2].uv2.v = vVals[D_800E1CF0[i][5]];
-            tris[i*2+1].uv0.u = uVals[D_800E1CF0[i][6]];
-            tris[i*2+1].uv0.v = vVals[D_800E1CF0[i][7]];
-            tris[i*2+1].uv1.u = uVals[D_800E1CF0[i][8]];
-            tris[i*2+1].uv1.v = vVals[D_800E1CF0[i][9]];
-            tris[i*2+1].uv2.u = uVals[D_800E1CF0[i][10]];
-            tris[i*2+1].uv2.v = vVals[D_800E1CF0[i][11]];
+            tris[i*2].uv0.u = uVals[gWoodPanelTexCoords[i][0]];
+            tris[i*2].uv0.v = vVals[gWoodPanelTexCoords[i][1]];
+            tris[i*2].uv1.u = uVals[gWoodPanelTexCoords[i][2]];
+            tris[i*2].uv1.v = vVals[gWoodPanelTexCoords[i][3]];
+            tris[i*2].uv2.u = uVals[gWoodPanelTexCoords[i][4]];
+            tris[i*2].uv2.v = vVals[gWoodPanelTexCoords[i][5]];
+            tris[i*2+1].uv0.u = uVals[gWoodPanelTexCoords[i][6]];
+            tris[i*2+1].uv0.v = vVals[gWoodPanelTexCoords[i][7]];
+            tris[i*2+1].uv1.u = uVals[gWoodPanelTexCoords[i][8]];
+            tris[i*2+1].uv1.v = vVals[gWoodPanelTexCoords[i][9]];
+            tris[i*2+1].uv2.u = uVals[gWoodPanelTexCoords[i][10]];
+            tris[i*2+1].uv2.v = vVals[gWoodPanelTexCoords[i][11]];
         }
     }
-    verts = ((unk80080BC8*)((u8*)D_80126C2C + (D_800E1DB8 << 5) + (D_800E1DB4 * 4)))->vertices;
+    verts = ((unk80080BC8*)((u8*)D_80126C2C + (gWoodPanelCount << 5) + (D_800E1DB4 * 4)))->vertices;
     for (i = 0; i < 5; i++) {
         for(j = 0; j < 4; j++) {
             verts[j].x = startX;
             verts[j].y = startY;
-            verts[j].x += (D_800E1D2C[j][0] * width);
-            verts[j].x += (D_800E1D2C[j][1] * borderWidth);
-            verts[j].y += (D_800E1D2C[j][2] * height);
-            verts[j].y += (D_800E1D2C[j][3] * borderHeight);
+            verts[j].x += (gWoodPanelVertCoords[j][0] * width);
+            verts[j].x += (gWoodPanelVertCoords[j][1] * borderWidth);
+            verts[j].y += (gWoodPanelVertCoords[j][2] * height);
+            verts[j].y += (gWoodPanelVertCoords[j][3] * borderHeight);
             verts[j].z = 0;
-            verts[j].r = (s32) (D_800E1D7C[i][0] * ((colour >> 24) & 0xFF)) >> 8;
-            verts[j].g = (s32) (D_800E1D7C[i][1] * ((colour >> 16) & 0xFF)) >> 8;
-            verts[j].b = (s32) (D_800E1D7C[i][2] * ((colour >> 8) & 0xFF)) >> 8;
-            verts[j].a = (s32) (D_800E1D7C[i][3] * (colour & 0xFF)) >> 8;
+            verts[j].r = (s32) (gWoodPanelVertColours[i][0] * ((colour >> 24) & 0xFF)) >> 8;
+            verts[j].g = (s32) (gWoodPanelVertColours[i][1] * ((colour >> 16) & 0xFF)) >> 8;
+            verts[j].b = (s32) (gWoodPanelVertColours[i][2] * ((colour >> 8) & 0xFF)) >> 8;
+            verts[j].a = (s32) (gWoodPanelVertColours[i][3] * (colour & 0xFF)) >> 8;
         }
     }
     if (dlist != NULL) {
-        ((unk80080BC8*)((u8*)D_80126C2C + (D_800E1DB8 << 5) + (D_800E1DB4 * 4)))->unk18 = 1;
+        ((unk80080BC8*)((u8*)D_80126C2C + (gWoodPanelCount << 5) + (D_800E1DB4 * 4)))->unk18 = 1;
         gSPDisplayList((*dlist)++, &dMenuHudSettings); 
         if (tex != NULL) {
             texEnabled = TRUE;
@@ -1846,22 +1846,22 @@ void func_80080580(Gfx** dlist, s32 startX, s32 startY, s32 width, s32 height, s
         /*
         temp_v0_6 = *dlist;
         *dlist = temp_v0_6 + 8;
-        temp_v0_6->words.w0 = (((((*(D_80126C2C + (D_800E1DB8 << 5) + (D_800E1DB4 * 4)) + 0x80000000) & 6) | 0x98) & 0xFF) << 0x10) | 0x04000000 | 0x170;
-        temp_v0_6->words.w1 = *(D_80126C2C + (D_800E1DB8 << 5) + (D_800E1DB4 * 4)) + 0x80000000;
+        temp_v0_6->words.w0 = (((((*(D_80126C2C + (gWoodPanelCount << 5) + (D_800E1DB4 * 4)) + 0x80000000) & 6) | 0x98) & 0xFF) << 0x10) | 0x04000000 | 0x170;
+        temp_v0_6->words.w1 = *(D_80126C2C + (gWoodPanelCount << 5) + (D_800E1DB4 * 4)) + 0x80000000;
         */
         gSPVertexDKR((*dlist)++, OS_K0_TO_PHYSICAL(((unk80080BC8*)((u8*)D_80126C2C + (i * 32) + (D_800E1DB4 * 4)))->vertices), 20, 0); 
         /* 
         temp_v0_7 = *dlist;
         *dlist = temp_v0_7 + 8;
         temp_v0_7->words.w0 = (((texEnabled | 0x90) & 0xFF) << 0x10) | 0x05000000 | 0xA0;
-        temp_v0_7->words.w1 = (D_80126C2C + (D_800E1DB8 << 5) + (D_800E1DB4 * 4))->unk8 + 0x80000000;
+        temp_v0_7->words.w1 = (D_80126C2C + (gWoodPanelCount << 5) + (D_800E1DB4 * 4))->unk8 + 0x80000000;
         */
         gSPPolygon((*dlist)++, OS_K0_TO_PHYSICAL(((unk80080BC8*)((u8*)D_80126C2C + (i * 32) + (D_800E1DB4 * 4)))->triangles), 10, texEnabled);
         reset_render_settings(dlist);
     } else {
-        ((unk80080BC8*)((u8*)D_80126C2C + (D_800E1DB8 * 32) + (D_800E1DB4 * 4)))->unk18 = 0;
+        ((unk80080BC8*)((u8*)D_80126C2C + (gWoodPanelCount * 32) + (D_800E1DB4 * 4)))->unk18 = 0;
     }
-    D_800E1DB8++;
+    gWoodPanelCount++;
 }
 #else
 GLOBAL_ASM("asm/non_matchings/menu/func_80080580.s")
@@ -1880,7 +1880,7 @@ void func_80080BC8(Gfx** dlist) {
     var_t0 = -1;
     lastTex = NULL;
     
-    for (i = 0; i < D_800E1DB8; i++) {
+    for (i = 0; i < gWoodPanelCount; i++) {
         //((unk80080BC8*)((u8*)D_80126C2C + (i << 5) + (D_800E1DB4 * 4)))->texture
         if (!D_80126C2C[i][D_800E1DB4].unk18) {
             tex = D_80126C2C[i][D_800E1DB4].texture;
@@ -1902,7 +1902,7 @@ void func_80080BC8(Gfx** dlist) {
             gSPPolygon((*dlist)++, OS_K0_TO_PHYSICAL((&D_80126C2C[i][D_800E1DB4])->triangles), 10, 0);
         }
     }
-    D_800E1DB8 = 0;
+    gWoodPanelCount = 0;
     D_800E1DB4 = 1 - D_800E1DB4;
     reset_render_settings(dlist);
 }
@@ -1911,7 +1911,7 @@ GLOBAL_ASM("asm/non_matchings/menu/func_80080BC8.s")
 #endif
 
 void func_80080E6C(void) {
-    D_800E1DB8 = 0;
+    gWoodPanelCount = 0;
     D_800E1DB4 = (s32)(1 - D_800E1DB4);
 }
 
@@ -1949,7 +1949,7 @@ void func_80081218(void) {
     gMenuText = allocate_from_main_pool_safe(1024 * sizeof(char *), COLOUR_TAG_WHITE);
     load_menu_text(LANGUAGE_ENGLISH);
     for (i = 0; i < 128; i++) {
-        gMenuTextures[i] = NULL;
+        gMenuObjects[i] = NULL;
     }
 }
 #else
@@ -2268,14 +2268,14 @@ void func_80081C04(s32 number, s32 x, s32 y, s32 r, s32 g, s32 b, s32 a, UNUSED 
 }
 
 void func_80081E54(MenuElement *arg0, f32 arg1, f32 arg2, f32 arg3, s32 arg4, s32 arg5) {
-    D_800DF798 = arg0;
-    D_800DF794 = 0;
+    gTrophyRankingsMenuElements = arg0;
+    gTrophyRankingsState = 0;
     D_80126858 = arg1 * 60.0f;
     D_8012685C = arg2 * 60.0f;
     D_80126860 = arg3 * 60.0f;
     D_80126854 = 0;
-    D_800DF79C = arg4;
-    D_800DF7A0 = arg5;
+    gDrawMenuElementsYOffset = arg4;
+    gDrawMenuElementsYOffset2 = arg5;
     if (D_80126858 > 0) {
         play_sound_global(SOUND_WHOOSH1, NULL);
     }
@@ -2290,7 +2290,7 @@ s32 func_80081F4C(s32 updateRate) {
     ret = 1;
     var_f20 = -1.0f;
     buttonsPressedAllPlayers = 0;
-    if (D_800DF794 != 4) {
+    if (gTrophyRankingsState != 4) {
         if (gIgnorePlayerInputTime == 0) {
             for (i = 0; i < gNumberOfActivePlayers; i++) {
                 buttonsPressedAllPlayers |= get_buttons_pressed_from_player(i);
@@ -2298,16 +2298,16 @@ s32 func_80081F4C(s32 updateRate) {
         }
         D_80126854 += updateRate;
         do {
-            switch (D_800DF794) {
+            switch (gTrophyRankingsState) {
                 case 0:
                     if (buttonsPressedAllPlayers & (A_BUTTON | START_BUTTON)) {
                         D_80126854 = 0;
-                        D_800DF794 = 1;
+                        gTrophyRankingsState = 1;
                         buttonsPressedAllPlayers = 0;
                     } else {
                         if (D_80126854 >= D_80126858) {
                             D_80126854 -= D_80126858;
-                            D_800DF794 = 1;
+                            gTrophyRankingsState = 1;
                         } else {
                             var_f20 = (f32) D_80126854 / (f32) D_80126858;
                         }
@@ -2319,7 +2319,7 @@ s32 func_80081F4C(s32 updateRate) {
                     }
                     if (buttonsPressedAllPlayers & (A_BUTTON | START_BUTTON)) {
                         D_80126854 = 0;
-                        D_800DF794 = 2;
+                        gTrophyRankingsState = 2;
                         buttonsPressedAllPlayers = 0;
                         if (D_80126860 > D_80126854) {
                             play_sound_global(SOUND_WHOOSH1, NULL);
@@ -2327,7 +2327,7 @@ s32 func_80081F4C(s32 updateRate) {
                     } else {
                         if (D_80126854 >= D_8012685C) {
                             D_80126854 -= D_8012685C;
-                            D_800DF794 = 2;
+                            gTrophyRankingsState = 2;
                             if (D_80126854 < D_80126860) {
                                 play_sound_global(SOUND_WHOOSH1, NULL);
                             }
@@ -2338,16 +2338,16 @@ s32 func_80081F4C(s32 updateRate) {
                     break;
                 case 2:
                     if ((buttonsPressedAllPlayers & (A_BUTTON | START_BUTTON)) || (D_80126854 >= D_80126860)) {
-                        D_800DF794 = 4;
+                        gTrophyRankingsState = 4;
                     } else {
                         var_f20 = (f32) D_80126854 / (f32) D_80126860;
                     }
                     break;
             }
-        } while ((var_f20 < 0.0f) && (D_800DF794 != 4));
+        } while ((var_f20 < 0.0f) && (gTrophyRankingsState != 4));
 
-        if (D_800DF794 != 4) {
-            draw_menu_elements(D_800DF794, D_800DF798, var_f20);
+        if (gTrophyRankingsState != 4) {
+            draw_menu_elements(gTrophyRankingsState, gTrophyRankingsMenuElements, var_f20);
             ret = 0;
         }
     }
@@ -2393,7 +2393,7 @@ void draw_menu_elements(s32 arg0, MenuElement *elem, f32 arg2) {
                             elem->details.background.backgroundAlpha);
                         set_text_colour(elem->filterRed, elem->filterGreen, elem->filterBlue, elem->filterAlpha, elem->opacity);
                         set_text_font(elem->textFont);
-                        draw_text(&sMenuCurrDisplayList, xPos, yPos + D_800DF79C, elem->unk14_a.asciiText, elem->textAlignFlags);
+                        draw_text(&sMenuCurrDisplayList, xPos, yPos + gDrawMenuElementsYOffset, elem->unk14_a.asciiText, elem->textAlignFlags);
                         break;
                     case 1:
                         if (s5) {
@@ -2404,7 +2404,7 @@ void draw_menu_elements(s32 arg0, MenuElement *elem, f32 arg2) {
                         show_timestamp(
                             *elem->unk14_a.numberU16,
                             xPos - 160,
-                            (-yPos - D_800DF7A0) + 120,
+                            (-yPos - gDrawMenuElementsYOffset2) + 120,
                             elem->filterRed,
                             elem->filterGreen,
                             elem->filterBlue,
@@ -2418,7 +2418,7 @@ void draw_menu_elements(s32 arg0, MenuElement *elem, f32 arg2) {
                         func_80081C04(
                             *elem->unk14_a.number,
                             xPos - 160,
-                            (-yPos - D_800DF7A0) + 120,
+                            (-yPos - gDrawMenuElementsYOffset2) + 120,
                             elem->filterRed,
                             elem->filterGreen,
                             elem->filterBlue,
@@ -2431,7 +2431,7 @@ void draw_menu_elements(s32 arg0, MenuElement *elem, f32 arg2) {
                             &sMenuCurrDisplayList,
                             elem->unk14_a.texture,
                             xPos,
-                            yPos + D_800DF79C,
+                            yPos + gDrawMenuElementsYOffset,
                             elem->filterRed,
                             elem->filterGreen,
                             elem->filterBlue,
@@ -2443,7 +2443,7 @@ void draw_menu_elements(s32 arg0, MenuElement *elem, f32 arg2) {
                             &sMenuCurrDisplayList,
                             elem->unk14_a.element,
                             xPos,
-                            yPos + D_800DF79C,
+                            yPos + gDrawMenuElementsYOffset,
                             elem->details.texture.width / 256.0f,
                             elem->details.texture.height / 256.0f,
                             (elem->filterRed << 24) | (elem->filterGreen << 16) | (elem->filterBlue << 8) | elem->opacity,
@@ -2458,7 +2458,7 @@ void draw_menu_elements(s32 arg0, MenuElement *elem, f32 arg2) {
                         func_80068508(1);
                         sprite_opaque(FALSE);
                         gMenuImageStack[elem->unk14_a.value].unkC = xPos - 160;
-                        gMenuImageStack[elem->unk14_a.value].unk10 = (-yPos - D_800DF7A0) + 120;
+                        gMenuImageStack[elem->unk14_a.value].unk10 = (-yPos - gDrawMenuElementsYOffset2) + 120;
                         gMenuImageStack[elem->unk14_a.value].unk18 = elem->textFont;
                         gMenuImageStack[elem->unk14_a.value].unk4 = elem->details.background.backgroundRed;
                         gMenuImageStack[elem->unk14_a.value].unk2 = elem->details.background.backgroundGreen;
@@ -2467,7 +2467,7 @@ void draw_menu_elements(s32 arg0, MenuElement *elem, f32 arg2) {
                         sMenuGuiColourR = elem->filterRed;
                         sMenuGuiColourG = elem->filterGreen;
                         sMenuGuiColourB = elem->filterBlue;
-                        D_800DF4B0 = elem->filterAlpha;
+                        sMenuGuiColourA = elem->filterAlpha;
                         sMenuGuiOpacity = elem->opacity;
                         func_8009CA60(elem->unk14_a.value);
                         func_80068508(0);
@@ -2477,7 +2477,7 @@ void draw_menu_elements(s32 arg0, MenuElement *elem, f32 arg2) {
                         func_80080E90(
                             &sMenuCurrDisplayList,
                             xPos,
-                            yPos + D_800DF7A0,
+                            yPos + gDrawMenuElementsYOffset2,
                             elem->details.texture.width,
                             elem->details.texture.height,
                             elem->details.texture.borderWidth,
@@ -2491,7 +2491,7 @@ void draw_menu_elements(s32 arg0, MenuElement *elem, f32 arg2) {
                         func_80080580(
                             &sMenuCurrDisplayList,
                             xPos,
-                            yPos + D_800DF7A0,
+                            yPos + gDrawMenuElementsYOffset2,
                             elem->details.texture.width,
                             elem->details.texture.height,
                             elem->details.texture.borderWidth,
@@ -2509,7 +2509,7 @@ void draw_menu_elements(s32 arg0, MenuElement *elem, f32 arg2) {
         sMenuGuiColourR = 0xFF;
         sMenuGuiColourG = 0xFF;
         sMenuGuiColourB = 0xFF;
-        D_800DF4B0 = 0;
+        sMenuGuiColourA = 0;
         sMenuGuiOpacity = 0xFF;
     }
 }
@@ -2548,9 +2548,9 @@ void func_800828B8(void) {
 void print_missing_controller_text(Gfx **dl, s32 updateRate) {
     s32 posY;
 
-    D_800DF46C += updateRate;
+    gMissingControllerDelay += updateRate;
 
-    if (D_800DF46C & 0x10) {
+    if (gMissingControllerDelay & 0x10) {
         load_menu_text(get_language());
         set_text_font(ASSET_FONTS_FUNFONT);
         set_text_colour(255, 255, 255, 0, 0xFF);
@@ -2593,14 +2593,14 @@ s32 menu_logo_screen_loop(s32 updateRate) {
     if (osTvType == TV_TYPE_PAL) {
         yOffset = 26;
         if (sBootScreenTimer < 2.6f && gMenuDelay == 0) {
-            transition_begin(&D_800E1DE8);
+            transition_begin(&gFadeLogoToTitleScreen);
             gMenuDelay = 1;
         }
         sBootScreenTimer -= updateRate / 50.0f;
     } else {
         yOffset = 0;
         if (sBootScreenTimer < 2.17f && gMenuDelay == 0) {
-            transition_begin(&D_800E1DE8);
+            transition_begin(&gFadeLogoToTitleScreen);
             gMenuDelay = 1;
         }
         sBootScreenTimer -= updateRate / 60.0f;
@@ -2681,21 +2681,21 @@ void func_80083098(f32 arg0) {
     yPos = 0;
     text = NULL;
     if (D_801268E0 < 10) {
-        introCharData = &D_800DF83C[D_801268E0];
+        introCharData = &gTitleCinematicText[D_801268E0];
         D_801268D8 += arg0;
         set_text_font(ASSET_FONTS_BIGFONT);
         set_text_background_colour(0, 0, 0, 0);
         i = 0;
-        while (i < D_800DF9F4) {
-            // set_text_colour(D_800DF9F8[D_80126878[i].colourIndex].red, D_800DF9F8[D_80126878[i].colourIndex].green, D_800DF9F8[D_80126878[i].colourIndex].blue, D_800DF9F8[D_80126878[i].colourIndex].alpha, D_800DF9F8[D_80126878[i].colourIndex].opacity);
+        while (i < gTitleCinematicTextColourCount) {
+            // set_text_colour(gTitleCinematicTextColours[D_80126878[i].colourIndex].red, gTitleCinematicTextColours[D_80126878[i].colourIndex].green, gTitleCinematicTextColours[D_80126878[i].colourIndex].blue, gTitleCinematicTextColours[D_80126878[i].colourIndex].alpha, gTitleCinematicTextColours[D_80126878[i].colourIndex].opacity);
             j = D_80126878[i].colourIndex; // This seems super fake, but I can't do any better.
-            set_text_colour(D_800DF9F8[j].red, D_800DF9F8[j].green, D_800DF9F8[j].blue, D_800DF9F8[j].alpha, D_800DF9F8[j].opacity);
+            set_text_colour(gTitleCinematicTextColours[j].red, gTitleCinematicTextColours[j].green, gTitleCinematicTextColours[j].blue, gTitleCinematicTextColours[j].alpha, gTitleCinematicTextColours[j].opacity);
             draw_text(&sMenuCurrDisplayList, D_80126878[i].x, D_80126878[i].y, D_80126878[i].text, ALIGN_MIDDLE_CENTER);
             D_80126878[i].colourIndex++;
             if (D_80126878[i].colourIndex >= 4) {
                 j = i;
-                D_800DF9F4--;
-                while(j < D_800DF9F4) {
+                gTitleCinematicTextColourCount--;
+                while(j < gTitleCinematicTextColourCount) {
                     D_80126878[j].text = D_80126878[j+1].text;
                     D_80126878[j].x = D_80126878[j+1].x;
                     D_80126878[j].y = D_80126878[j+1].y;
@@ -2727,17 +2727,17 @@ void func_80083098(f32 arg0) {
                 text = introCharData->unk0;
                 didUpdate = TRUE;
             } else {
-                if (!D_800DF9F8){} // Fake
+                if (!gTitleCinematicTextColours){} // Fake
                 D_801268E0++;
             }
         }
         if (didUpdate) {
-            if (D_800DF9F4 < 4) {
-                D_80126878[D_800DF9F4].colourIndex = 0;
-                D_80126878[D_800DF9F4].text = text;
-                D_80126878[D_800DF9F4].x = xPos;
-                D_80126878[D_800DF9F4].y = yPos;
-                D_800DF9F4++;
+            if (gTitleCinematicTextColourCount < 4) {
+                D_80126878[gTitleCinematicTextColourCount].colourIndex = 0;
+                D_80126878[gTitleCinematicTextColourCount].text = text;
+                D_80126878[gTitleCinematicTextColourCount].x = xPos;
+                D_80126878[gTitleCinematicTextColourCount].y = yPos;
+                gTitleCinematicTextColourCount++;
             }
             set_text_colour(255, 255, 255, 0, 255);
             draw_text(&sMenuCurrDisplayList, xPos, yPos, text, ALIGN_MIDDLE_CENTER);
@@ -2757,7 +2757,7 @@ void menu_title_screen_init(void) {
     s32 i;
     s32 numberOfPlayers;
 
-    D_800DF488 = 1;
+    gTitleScreenLoaded = 1;
     gOptionBlinkTimer = 0;
     gMenuDelay = 0;
     reset_character_id_slots();
@@ -2777,7 +2777,7 @@ void menu_title_screen_init(void) {
     gMenuOptionCount = 0;
     func_8009C674(sGameTitleTileTextures);
     for (i = 0; i < 11; i++) {
-        sGameTitleTileOffsets[i].texture = gMenuTextures[sGameTitleTileTextures[i]];
+        sGameTitleTileOffsets[i].texture = gMenuObjects[sGameTitleTileTextures[i]];
     }
     set_music_player_voice_limit(27);
     func_800660C0();
@@ -2797,7 +2797,7 @@ void menu_title_screen_init(void) {
     D_801268D8 = 0;
     D_801268E0 = 0;
     D_801268DC = 0;
-    D_800DF9F4 = 0;
+    gTitleCinematicTextColourCount = 0;
     gOpacityDecayTimer = 0;
     gIsInTracksMode = FALSE;
 }
@@ -2886,7 +2886,7 @@ s32 menu_title_screen_loop(s32 updateRate) {
         if (gTitleDemoTimer < 60 && gTitleDemoTimer + updateRate >= 60) {
             set_music_fade_timer(-768);
             sp28 = 0;
-            transition_begin(&D_800E1E08);
+            transition_begin(&gFadeTitleScreenDemo);
         }
         if (gTitleDemoTimer <= 0) {
             sp28 = 1;
@@ -2916,7 +2916,7 @@ s32 menu_title_screen_loop(s32 updateRate) {
             D_801268D8 = 0.0f;
             D_801268E0 = 0;
             D_801268DC = 0;
-            D_800DF9F4 = 0;
+            gTitleCinematicTextColourCount = 0;
             gOpacityDecayTimer = 0;
         }
     }
@@ -2996,7 +2996,7 @@ s32 menu_title_screen_loop(s32 updateRate) {
             menu_init(MENU_CHARACTER_SELECT);
             return MENU_RESULT_CONTINUE;
         }
-        D_800DF460 = 0;
+        gMenuCurIndex = 0;
         load_level_for_menu(ASSET_LEVEL_OPTIONSBACKGROUND, -1, 0);
         menu_init(MENU_OPTIONS);
         return MENU_RESULT_CONTINUE;
@@ -3050,7 +3050,7 @@ void render_options_menu_ui(UNUSED s32 updateRate) {
     set_text_font(ASSET_FONTS_FUNFONT);
 
     while (gOptionMenuStrings[optionMenuTextIndex] != NULL) {
-        if (optionMenuTextIndex == D_800DF460) {
+        if (optionMenuTextIndex == gMenuCurIndex) {
             alpha = gOptionBlinkTimer * 8;
             if (gOptionBlinkTimer >= 32) {
                 alpha = 511 - alpha;
@@ -3101,18 +3101,18 @@ s32 menu_options_loop(s32 updateRate) {
             analogueY += *(yAxisPtr++);
         }
     }
-    if ((buttonsPressed & B_BUTTON) || ((buttonsPressed & (A_BUTTON | START_BUTTON)) && D_800DF460 == 5)) {
+    if ((buttonsPressed & B_BUTTON) || ((buttonsPressed & (A_BUTTON | START_BUTTON)) && gMenuCurIndex == 5)) {
         // Leave the option menu
         set_music_fade_timer(-128);
         gMenuDelay = -1;
         transition_begin(&sMenuTransitionFadeIn);
         play_sound_global(SOUND_MENU_BACK3, NULL);
-    } else if ((buttonsPressed & (A_BUTTON | START_BUTTON)) && D_800DF460 >= 2) {
+    } else if ((buttonsPressed & (A_BUTTON | START_BUTTON)) && gMenuCurIndex >= 2) {
         // Go to a sub-menu
         gMenuDelay = 31;
         play_sound_global(SOUND_SELECT2, NULL);
         
-    } else if (D_800DF460 == 0 && analogueX != 0) {
+    } else if (gMenuCurIndex == 0 && analogueX != 0) {
         switch ((u64) get_language()) {
             case LANGUAGE_ENGLISH:
                  set_language(LANGUAGE_FRENCH);
@@ -3122,7 +3122,7 @@ s32 menu_options_loop(s32 updateRate) {
                 break;
         }
         play_sound_global(SOUND_MENU_PICK2, NULL);
-    } else if (D_800DF460 == 1 && analogueX != 0) {
+    } else if (gMenuCurIndex == 1 && analogueX != 0) {
         if (sEepromSettings & 0x2000000) {
             //0x2000000 SUBTITLES ENABLED?
             play_sound_global(SOUND_MENU_PICK2, NULL);
@@ -3136,31 +3136,31 @@ s32 menu_options_loop(s32 updateRate) {
             gOptionMenuStrings[1] = gMenuText[ASSET_MENU_TEXT_SUBTITLESON];
         }
     } else {
-        s32 prev_D_800DF460 = D_800DF460;
+        s32 prev_D_800DF460 = gMenuCurIndex;
         if (analogueY < 0) {
-            D_800DF460++;
-            if (D_800DF460 >= 6) {
-                D_800DF460 = 5;
+            gMenuCurIndex++;
+            if (gMenuCurIndex >= 6) {
+                gMenuCurIndex = 5;
             }
         }
         if (analogueY > 0) {
-            D_800DF460--;
-            if (D_800DF460 < 0) {
-                D_800DF460 = 0;
+            gMenuCurIndex--;
+            if (gMenuCurIndex < 0) {
+                gMenuCurIndex = 0;
             }
         }
-        if (prev_D_800DF460 != D_800DF460) {
+        if (prev_D_800DF460 != gMenuCurIndex) {
             play_sound_global(SOUND_MENU_PICK2, NULL);
         }
     }
     if (gMenuDelay > 30) {
         // Change screen to a sub-menu
-        if (D_800DF460 == 2) {
+        if (gMenuCurIndex == 2) {
             unload_big_font_1();
             menu_init(MENU_AUDIO_OPTIONS);
             return MENU_RESULT_CONTINUE;
         }
-        if (D_800DF460 == 3) {
+        if (gMenuCurIndex == 3) {
             unload_big_font_1();
             menu_init(MENU_SAVE_OPTIONS);
             return MENU_RESULT_CONTINUE;
@@ -3280,17 +3280,17 @@ s32 menu_audio_options_loop(s32 updateRate) {
                 sp30 = 1;
             } else if (gOptionsMenuItemIndex == 0 && contX != 0) {
                 if (contX < 0) {                        
-                    D_800DFAC8--;
+                    gAudioOutputType--;
                 } else {
-                    D_800DFAC8++;
+                    gAudioOutputType++;
                 }
-                if (D_800DFAC8 < 0) {
-                    D_800DFAC8 = 2;
+                if (gAudioOutputType < 0) {
+                    gAudioOutputType = 2;
                 }
-                if (D_800DFAC8 >= 3) {
-                    D_800DFAC8 = 0;
+                if (gAudioOutputType >= 3) {
+                    gAudioOutputType = 0;
                 }
-                set_stereo_pan_mode(D_800DFAC8);
+                set_stereo_pan_mode(gAudioOutputType);
                 sp30 = 1;
             } else if (contXAxis && (gOptionsMenuItemIndex == 1 || gOptionsMenuItemIndex == 2)) {
                 if (gOptionsMenuItemIndex == 1) {
@@ -3312,7 +3312,7 @@ s32 menu_audio_options_loop(s32 updateRate) {
                     if (!music_is_playing()) {
                         if (gOpacityDecayTimer >= 0) {
                             func_80000B28();
-                            play_music(D_800DFABC);
+                            play_music(gMusicTestSongIndex);
                         } else {
                             func_80000B28();
                             set_music_player_voice_limit(24);
@@ -3322,20 +3322,20 @@ s32 menu_audio_options_loop(s32 updateRate) {
                     }
                 }
             } else if (gMenuOptionCount >= 5 && gOptionsMenuItemIndex == 3) {
-                if (contX < 0 && D_800DFABC > 0) {
-                    D_800DFABC--;
+                if (contX < 0 && gMusicTestSongIndex > 0) {
+                    gMusicTestSongIndex--;
                     sp30 = 1;
                 } else if (contX > 0) {
-                    if (D_800DFABC < (ALSeqFile_80115CF8_GetSeqCount() - 1)) {
-                        D_800DFABC++;
+                    if (gMusicTestSongIndex < (ALSeqFile_80115CF8_GetSeqCount() - 1)) {
+                        gMusicTestSongIndex++;
                         sp30 = 1;
                     }
                 }
                 if (buttonsPressed & (A_BUTTON | START_BUTTON)) {
                     func_80000B28();
                     set_music_player_voice_limit(24);
-                    play_music(D_800DFABC);
-                    gOpacityDecayTimer = D_800DFABC;
+                    play_music(gMusicTestSongIndex);
+                    gOpacityDecayTimer = gMusicTestSongIndex;
                 }
             }
             if (gOptionsMenuItemIndex == 1) {
@@ -3396,16 +3396,16 @@ void menu_save_options_init(void) {
     D_80126A00 = 0;
     D_80126BE4 = 0;
     D_80126BEC = 0.0f;
-    func_8009C674(D_800DFC78);
-    allocate_menu_images(D_800DFCAC);
+    func_8009C674(gSaveMenuObjectIndices);
+    allocate_menu_images(gSaveMenuImageIndices);
     func_8007FFEC(0xA);
     load_font(ASSET_FONTS_BIGFONT);
-    D_800DFC10[0].texture = gMenuTextures[TEXTURE_ICON_SAVE_N64];
-    D_800DFC20[0].texture = gMenuTextures[TEXTURE_ICON_SAVE_TT];
-    D_800DFC30[0].texture = gMenuTextures[TEXTURE_ICON_SAVE_GHOSTS];
-    D_800DFC40[0].texture = gMenuTextures[TEXTURE_ICON_SAVE_FILECABINET];
-    D_800DFC50[0].texture = gMenuTextures[TEXTURE_ICON_SAVE_CPAK];
-    D_800DFC60[0].texture = gMenuTextures[TEXTURE_ICON_SAVE_BIN];
+    D_800DFC10[0].texture = gMenuObjects[TEXTURE_ICON_SAVE_N64];
+    D_800DFC20[0].texture = gMenuObjects[TEXTURE_ICON_SAVE_TT];
+    D_800DFC30[0].texture = gMenuObjects[TEXTURE_ICON_SAVE_GHOSTS];
+    D_800DFC40[0].texture = gMenuObjects[TEXTURE_ICON_SAVE_FILECABINET];
+    D_800DFC50[0].texture = gMenuObjects[TEXTURE_ICON_SAVE_CPAK];
+    D_800DFC60[0].texture = gMenuObjects[TEXTURE_ICON_SAVE_BIN];
     assign_menu_arrow_textures();
     mark_read_all_save_files();
     transition_begin(&sMenuTransitionFadeOut);
@@ -3428,7 +3428,7 @@ void func_800853D0(unk800861C8 *arg0, s32 x, s32 y) {
     switch (arg0->saveFileType) {
         case SAVE_FILE_TYPE_UNK1:
             drawTexture = D_800DFC10;
-            texture = gMenuTextures[TEXTURE_SURFACE_BUTTON_WOOD];
+            texture = gMenuObjects[TEXTURE_SURFACE_BUTTON_WOOD];
             colour = COLOUR_RGBA32(176, 224, 192, 255);
             if (!gSavefileData[arg0->controllerIndex]->newGame) {
                 decompress_filename_string(gSavefileData[arg0->controllerIndex]->filename, buffer, 3);
@@ -3447,20 +3447,20 @@ void func_800853D0(unk800861C8 *arg0, s32 x, s32 y) {
             break;
         case SAVE_FILE_TYPE_UNK2:
             drawTexture = D_800DFC20;
-            texture = gMenuTextures[TEXTURE_SURFACE_BUTTON_WOOD];
+            texture = gMenuObjects[TEXTURE_SURFACE_BUTTON_WOOD];
             colour = COLOUR_RGBA32(176, 224, 192, 255);
             text2 = gMenuText[ASSET_MENU_TEXT_TIMES];
             text = gMenuText[ASSET_MENU_TEXT_GAMEPAK];
             break;
         case SAVE_FILE_TYPE_GAME_DATA:
             drawTexture = D_800DFC10;
-            texture = gMenuTextures[TEXTURE_UNK_44];
-            colour = D_800DFACC[arg0->controllerIndex];
+            texture = gMenuObjects[TEXTURE_UNK_44];
+            colour = gContPakSaveBgColours[arg0->controllerIndex];
             text2 = buffer;
             decompress_filename_string(arg0->compressedFilename, buffer, 3);
-            // char *D_800E1E10 = " (ADV.";
-            for (i = 0; D_800E1E10[i] != '\0'; i++) {
-                buffer[i+3] = D_800E1E10[i];
+            // char *gConPakAdvSavePrefix = " (ADV.";
+            for (i = 0; gConPakAdvSavePrefix[i] != '\0'; i++) {
+                buffer[i+3] = gConPakAdvSavePrefix[i];
             }
             buffer[i+3] = arg0->unk8[0];
             buffer[i+4] = ')';
@@ -3474,35 +3474,35 @@ void func_800853D0(unk800861C8 *arg0, s32 x, s32 y) {
             break;
         case SAVE_FILE_TYPE_TIME_DATA:
             drawTexture = D_800DFC20;
-            texture = gMenuTextures[TEXTURE_UNK_44];
-            colour = D_800DFACC[arg0->controllerIndex];
+            texture = gMenuObjects[TEXTURE_UNK_44];
+            colour = gContPakSaveBgColours[arg0->controllerIndex];
             text2 = arg0->unk8;
             text = gMenuText[ASSET_MENU_TEXT_CONTPAK1 + arg0->controllerIndex];
             break;
         case SAVE_FILE_TYPE_GHOST_DATA:
             drawTexture = D_800DFC30;
-            texture = gMenuTextures[TEXTURE_UNK_44];
-            colour = D_800DFACC[arg0->controllerIndex];
+            texture = gMenuObjects[TEXTURE_UNK_44];
+            colour = gContPakSaveBgColours[arg0->controllerIndex];
             text2 = gMenuText[ASSET_MENU_TEXT_GHOSTS];
             text = gMenuText[ASSET_MENU_TEXT_CONTPAK1 + arg0->controllerIndex];
             break;
         case SAVE_FILE_TYPE_UNKNOWN:
             drawTexture = D_800DFC40;
-            texture = gMenuTextures[TEXTURE_UNK_44];
-            colour = D_800DFACC[arg0->controllerIndex];
+            texture = gMenuObjects[TEXTURE_UNK_44];
+            colour = gContPakSaveBgColours[arg0->controllerIndex];
             text2 = arg0->unk8;
             text = gMenuText[ASSET_MENU_TEXT_CONTPAK1 + arg0->controllerIndex];
             break;
         case SAVE_FILE_TYPE_UNK8:
             drawTexture = D_800DFC50;
-            texture = gMenuTextures[TEXTURE_UNK_44];
-            colour = D_800DFACC[arg0->controllerIndex];
+            texture = gMenuObjects[TEXTURE_UNK_44];
+            colour = gContPakSaveBgColours[arg0->controllerIndex];
             text2 = gMenuText[ASSET_MENU_TEXT_EMPTYSLOT];
             text = gMenuText[ASSET_MENU_TEXT_CONTPAK1 + arg0->controllerIndex];
             break;
         case SAVE_FILE_TYPE_UNK9:
             drawTexture = D_800DFC30;
-            texture = gMenuTextures[TEXTURE_UNK_45];
+            texture = gMenuObjects[TEXTURE_UNK_45];
             colour = -1;
             text2 = gMenuText[ASSET_MENU_TEXT_VIEWGHOSTS];
             text = NULL;
@@ -3510,13 +3510,13 @@ void func_800853D0(unk800861C8 *arg0, s32 x, s32 y) {
         case SAVE_FILE_TYPE_UNKA:
             drawTexture = D_800DFC10;
             text2 = gMenuText[ASSET_MENU_TEXT_GAMEPAKBONUSES];
-            texture = gMenuTextures[TEXTURE_SURFACE_BUTTON_WOOD];
+            texture = gMenuObjects[TEXTURE_SURFACE_BUTTON_WOOD];
             colour = COLOUR_RGBA32(176, 224, 192, 255);
             text = gMenuText[ASSET_MENU_TEXT_GAMEPAK];
             break;
         default:
             drawTexture = D_800DFC60;
-            texture = gMenuTextures[TEXTURE_UNK_45];
+            texture = gMenuObjects[TEXTURE_UNK_45];
             colour = COLOUR_RGBA32(128, 128, 128, 255);
             text2 = gMenuText[ASSET_MENU_TEXT_ERASE];
             text = NULL;
@@ -4180,7 +4180,7 @@ s32 menu_save_options_loop(s32 updateRate) {
 void func_80087EB8(void) {
     unload_font(ASSET_FONTS_BIGFONT);
     func_8007FF88();
-    func_8009C4A8(D_800DFC78);
+    func_8009C4A8(gSaveMenuObjectIndices);
     assign_dialogue_box_id(7);
     free_from_memory_pool((void *)D_80126A0C);
     free_from_memory_pool((void *)D_80126A64);
@@ -4389,7 +4389,7 @@ void menu_boot_init(void) {
 
     // Sets up the 11 texture pointers for the "Diddy Kong Racing" logo.
     for (i = 0; i < 11; i++) {
-        sGameTitleTileOffsets[i].texture = gMenuTextures[sGameTitleTileTextures[i]];
+        sGameTitleTileOffsets[i].texture = gMenuObjects[sGameTitleTileTextures[i]];
     }
 
     // Reset variables for menu_boot_loop()
@@ -4486,7 +4486,7 @@ void func_800887E8(void) {
     if (sControllerPakError == PAK_ERROR_NONE && !gShowControllerPakMenu) {
         gMenuDelay = 20;
     }
-    D_800DF460 = 0;
+    gMenuCurIndex = 0;
     gOpacityDecayTimer = 0;
     func_8009C6D4(63);
     assign_menu_arrow_textures();
@@ -4527,7 +4527,7 @@ void render_controller_pak_ui(UNUSED s32 updateRate) {
         assign_dialogue_box_id(6);
         set_current_dialogue_box_coords(6, 58, yPos, 262, yPos + 30);
 
-        if (D_800DF460 == -1) {
+        if (gMenuCurIndex == -1) {
             set_current_dialogue_background_colour(6, 255, 255, 255, (alpha >> 1) + 128);
         } else {
             set_current_dialogue_background_colour(6, 96, 192, 92, 224);
@@ -4556,7 +4556,7 @@ void render_controller_pak_ui(UNUSED s32 updateRate) {
                 pagesText = gMenuText[ASSET_MENU_TEXT_PAGES]; //PAGES
                 numberOfPages = 1;
             } else {
-                if (D_800DF460 == (i + gOpacityDecayTimer)) {
+                if (gMenuCurIndex == (i + gOpacityDecayTimer)) {
                     //White background for currently selected row
                     set_current_dialogue_background_colour(6, 255, 255, 255, (alpha >> 1) + 128);
                 } else {
@@ -4582,7 +4582,7 @@ void render_controller_pak_ui(UNUSED s32 updateRate) {
             }
         } else {
             set_text_font(ASSET_FONTS_FUNFONT);
-            if (D_800DF460 == 16) {
+            if (gMenuCurIndex == 16) {
                 set_text_colour(255, 255, 255, alpha, 255);
             } else {
                 set_text_colour(255, 255, 255, 0, 255);
@@ -4614,7 +4614,7 @@ void render_controller_pak_ui(UNUSED s32 updateRate) {
                 //ASSET_MENU_TEXT_DELETENOTEX  - DELETE NOTE ~ ?
                 //ASSET_MENU_TEXT_DELETE       - DELETE
                 //ASSET_MENU_TEXT_CANCELDELETE - CANCEL
-                render_dialogue_text(6, POS_CENTRED, yPos, gMenuText[ASSET_MENU_TEXT_DELETENOTEX + i], D_800DF460 + 1, HORZ_ALIGN_CENTER);
+                render_dialogue_text(6, POS_CENTRED, yPos, gMenuText[ASSET_MENU_TEXT_DELETENOTEX + i], gMenuCurIndex + 1, HORZ_ALIGN_CENTER);
 
                 if (i != 0) {
                     yPos += 16;
@@ -4676,7 +4676,7 @@ s32 menu_controller_pak_loop(s32 updateRate) {
                 if (D_80126C10 != 0) {
                     D_80126C10--;
                     if (D_80126C10 == 0) {
-                        if (delete_file(gMenuOption, D_800DF460) != CONTROLLER_PAK_GOOD) {
+                        if (delete_file(gMenuOption, gMenuCurIndex) != CONTROLLER_PAK_GOOD) {
                             //Failed to delete the file
                             playCancelSound = TRUE;
                             gMenuDelay = 1;
@@ -4709,30 +4709,30 @@ s32 menu_controller_pak_loop(s32 updateRate) {
                     gMenuOptionCount = 2;
                     playMoveSound = TRUE;
                 }
-            } else if ((pressedButtons & B_BUTTON) || (D_800DF460 == 16 && (pressedButtons & (A_BUTTON | START_BUTTON)))) {
+            } else if ((pressedButtons & B_BUTTON) || (gMenuCurIndex == 16 && (pressedButtons & (A_BUTTON | START_BUTTON)))) {
                 playCancelSound = 1;
                 gMenuDelay = 1;
                 transition_begin(&sMenuTransitionFadeIn);
             } else {
-                //D_800DF460 = selected menu index?
-                switch (D_800DF460) {
+                //gMenuCurIndex = selected menu index?
+                switch (gMenuCurIndex) {
                 case -1:
                     if (yStick < 0) {
                         if(!xStick){} // Fakematch
-                        D_800DF460 = 0;
+                        gMenuCurIndex = 0;
                         playMoveSound = TRUE;
                     }
                     break;
                 case 16:
                     if (yStick > 0) {
-                        D_800DF460 = 15;
+                        gMenuCurIndex = 15;
                         playMoveSound = TRUE;
                     }
                     break;
                 default:
                     if (pressedButtons & (A_BUTTON | START_BUTTON)) {
                         //Check if the selected menu item is a file or blank
-                        if ((sCurrentControllerPakAllFileTypes[D_800DF460] >= SAVE_FILE_TYPE_GAME_DATA) && (sCurrentControllerPakAllFileTypes[D_800DF460] <= SAVE_FILE_TYPE_UNKNOWN)) {
+                        if ((sCurrentControllerPakAllFileTypes[gMenuCurIndex] >= SAVE_FILE_TYPE_GAME_DATA) && (sCurrentControllerPakAllFileTypes[gMenuCurIndex] <= SAVE_FILE_TYPE_UNKNOWN)) {
                             D_80126C10 = 0;
                             gMenuOptionCount = 2;
                             playSelectedSound = TRUE;
@@ -4742,22 +4742,22 @@ s32 menu_controller_pak_loop(s32 updateRate) {
                         }
                     } else {
                         if (yStick > 0) {
-                            D_800DF460--;
-                            if (D_800DF460 < 0) {
-                                D_800DF460 = 0;
+                            gMenuCurIndex--;
+                            if (gMenuCurIndex < 0) {
+                                gMenuCurIndex = 0;
                             } else {
                                 playMoveSound = TRUE;
                             }
                         } else if (yStick < 0) {
-                            D_800DF460++;
+                            gMenuCurIndex++;
                             playMoveSound = TRUE;
                         }
                     }
-                    if (D_800DF460 >= (gOpacityDecayTimer + sControllerPakMenuNumberOfRows)) {
-                        gOpacityDecayTimer = (D_800DF460 - sControllerPakMenuNumberOfRows) + 1;
+                    if (gMenuCurIndex >= (gOpacityDecayTimer + sControllerPakMenuNumberOfRows)) {
+                        gOpacityDecayTimer = (gMenuCurIndex - sControllerPakMenuNumberOfRows) + 1;
                     }
-                    if (D_800DF460 < gOpacityDecayTimer) {
-                        gOpacityDecayTimer = D_800DF460;
+                    if (gMenuCurIndex < gOpacityDecayTimer) {
+                        gOpacityDecayTimer = gMenuCurIndex;
                     }
                     temp_v1_2 = 16 - sControllerPakMenuNumberOfRows;
                     if (temp_v1_2 < gOpacityDecayTimer) {
@@ -5456,15 +5456,15 @@ s16 D_800E1E40[10] = {
 void func_8008AEB4(s32 arg0, s32 *arg1) {
     switch (arg0) {
         default:
-            D_800DFFD0 = 0;
+            gEnteredCharSelectFrom = 0;
             return;
         case 1:
         case 3:
-            D_800DFFD0 = 1;
+            gEnteredCharSelectFrom = 1;
             return;
         case 2:
-            D_800DFFD0 = 2;
-            D_800DFFD4 = *arg1;
+            gEnteredCharSelectFrom = 2;
+            unused_800DFFD4 = *arg1;
             return;
     }
 }
@@ -5532,7 +5532,7 @@ void menu_character_select_init(void) {
     D_801263B8.unk1 = 0;
     play_music(SEQUENCE_CHOOSE_YOUR_RACER);
     for (i = 0; i < NUM_CHARACTERS; i++) {
-        channelVolumes = D_800DFDB4[i];
+        channelVolumes = gCharacterVolumes[i];
         if (i != gMenuCurrentCharacter.channelIndex) {
             func_80001114(channelVolumes[0]);
             func_80001114(channelVolumes[1]);
@@ -5540,8 +5540,8 @@ void menu_character_select_init(void) {
     }
     func_80001114(6);
     func_80000B18();
-    func_8009C674(D_800DFDC8);
-    allocate_menu_images(D_800DFDCC);
+    func_8009C674(gCharSelectObjectIndices);
+    allocate_menu_images(gCharSelectImageIndices);
     transition_begin(&sMenuTransitionFadeOut);
     load_font(ASSET_FONTS_BIGFONT);
 }
@@ -5631,7 +5631,7 @@ void func_8008B4C8(void) {
             func_8000488C(D_80126808[characterSelected]);
         }
         play_sound_global(((*gCurrCharacterSelectData)[gPlayersCharacterArray[characterSelected]].voiceID + SOUND_VOICE_CHARACTER_SELECTED), &D_80126808[characterSelected]);
-        if ((gNumberOfActivePlayers > 2) || ((gNumberOfActivePlayers > 1) && !(gActiveMagicCodes & CHEAT_TWO_PLAYER_ADVENTURE)) || (D_800DFFD0 == 1)) {
+        if ((gNumberOfActivePlayers > 2) || ((gNumberOfActivePlayers > 1) && !(gActiveMagicCodes & CHEAT_TWO_PLAYER_ADVENTURE)) || (gEnteredCharSelectFrom == 1)) {
             set_music_fade_timer(-128);
         }
     } else {
@@ -5789,7 +5789,7 @@ s32 menu_character_select_loop(s32 updateRate) {
         gMenuDelay += updateRate;
         if (gMenuDelay >= 31) {
             phi_t3 = 0;
-            if (D_800DFFD0 == 0) {
+            if (gEnteredCharSelectFrom == 0) {
                 phi_t3++;
                 if ((gActiveMagicCodes << 7) < 0) {
                     phi_t3++;
@@ -5868,11 +5868,11 @@ void func_8008BFE8(s32 arg0, s8 *arg1, s32 arg2, u16 menuPickSoundId, u16 menuPi
 }
 
 void func_8008C128(void) {
-    func_8009C4A8(D_800DFDC8);
+    func_8009C4A8(gCharSelectObjectIndices);
     set_free_queue_state(0);
     unload_font(ASSET_FONTS_BIGFONT);
     set_free_queue_state(2);
-    D_800DFFD0 = 0;
+    gEnteredCharSelectFrom = 0;
 }
 
 void func_8008C168(s32 updateRate) {
@@ -5880,8 +5880,8 @@ void func_8008C168(s32 updateRate) {
         gMenuCurrentCharacter.unk1 = gMenuCurrentCharacter.unk1 - updateRate;
         if (gMenuCurrentCharacter.unk1 <= 0) {
             if (D_801263B8.channelIndex >= 0) {
-                func_80001114(D_800DFDB4[D_801263B8.channelIndex][0]);
-                func_80001114(D_800DFDB4[0][D_801263B8.channelIndex * 2 + 1]);
+                func_80001114(gCharacterVolumes[D_801263B8.channelIndex][0]);
+                func_80001114(gCharacterVolumes[0][D_801263B8.channelIndex * 2 + 1]);
             }
             D_801263B8.channelIndex = gMenuSelectedCharacter.channelIndex;
             if (gMenuSelectedCharacter.channelIndex >= 0) {
@@ -5890,8 +5890,8 @@ void func_8008C168(s32 updateRate) {
             gMenuSelectedCharacter.channelIndex = gMenuCurrentCharacter.channelIndex;
             if (gMenuSelectedCharacter.channelIndex >= 0) {
                 gMenuSelectedCharacter.unk2 = gMenuCurrentCharacter.unk2;
-                func_80001170(D_800DFDB4[gMenuSelectedCharacter.channelIndex][0]);
-                func_80001170(D_800DFDB4[0][gMenuSelectedCharacter.channelIndex * 2 + 1]);
+                func_80001170(gCharacterVolumes[gMenuSelectedCharacter.channelIndex][0]);
+                func_80001170(gCharacterVolumes[0][gMenuSelectedCharacter.channelIndex * 2 + 1]);
             }
         }
     }
@@ -5900,18 +5900,18 @@ void func_8008C168(s32 updateRate) {
         if (gMenuSelectedCharacter.unk2 > 127) {
             gMenuSelectedCharacter.unk2 = 127;
         }
-        func_80001268(D_800DFDB4[gMenuSelectedCharacter.channelIndex][0], gMenuSelectedCharacter.unk2);
-        func_80001268(D_800DFDB4[0][gMenuSelectedCharacter.channelIndex * 2 + 1], gMenuSelectedCharacter.unk3);
+        func_80001268(gCharacterVolumes[gMenuSelectedCharacter.channelIndex][0], gMenuSelectedCharacter.unk2);
+        func_80001268(gCharacterVolumes[0][gMenuSelectedCharacter.channelIndex * 2 + 1], gMenuSelectedCharacter.unk3);
     }
     if (D_801263B8.channelIndex >= 0) {
         D_801263B8.unk2 -= updateRate * 4;
         if (D_801263B8.channelIndex != gMenuSelectedCharacter.channelIndex) {
             if (D_801263B8.unk2 < 0) {
-                func_80001114(D_800DFDB4[D_801263B8.channelIndex][0]);
-                func_80001114(D_800DFDB4[0][D_801263B8.channelIndex * 2 + 1]);
+                func_80001114(gCharacterVolumes[D_801263B8.channelIndex][0]);
+                func_80001114(gCharacterVolumes[0][D_801263B8.channelIndex * 2 + 1]);
             } else {
-                func_80001268(D_800DFDB4[D_801263B8.channelIndex][0], D_801263B8.unk2);
-                func_80001268(D_800DFDB4[0][D_801263B8.channelIndex * 2 + 1], D_801263B8.unk3);
+                func_80001268(gCharacterVolumes[D_801263B8.channelIndex][0], D_801263B8.unk2);
+                func_80001268(gCharacterVolumes[0][D_801263B8.channelIndex * 2 + 1], D_801263B8.unk3);
             }
         }
         if (D_801263B8.unk2 < 0) {
@@ -5973,7 +5973,7 @@ void menu_game_select_init(void) {
 
     gMenuDelay = 0;
     gOptionBlinkTimer = 0;
-    D_800DF460 = 0;
+    gMenuCurIndex = 0;
     gMenuOptionCount = 2;
     transition_begin(&sMenuTransitionFadeOut);
     mark_read_all_save_files();
@@ -5986,8 +5986,8 @@ void menu_game_select_init(void) {
 
     for (i = 0; i < NUM_CHARACTERS; i++) {
         if (i != gMenuSelectedCharacter.channelIndex) {
-            func_80001114(D_800DFDB4[i][0]);
-            func_80001114(D_800DFDB4[i][1]);
+            func_80001114(gCharacterVolumes[i][0]);
+            func_80001114(gCharacterVolumes[i][1]);
         }
     }
 
@@ -6003,7 +6003,7 @@ void menu_game_select_init(void) {
 
     for (i = 0; i <= gMenuOptionCount; i++) {
         //Fakematch? What's the (i ^ 0)?
-        gGameSelectElements[((i ^ 0) * 2) + 2].unk14_a.texture = gMenuTextures[TEXTURE_SURFACE_BUTTON_WOOD];
+        gGameSelectElements[((i ^ 0) * 2) + 2].unk14_a.texture = gMenuObjects[TEXTURE_SURFACE_BUTTON_WOOD];
     }
 }
 
@@ -6022,7 +6022,7 @@ void func_8008C698(UNUSED s32 updateRate) {
 
         for (i = 0; i <= gMenuOptionCount; i++) {
             filterAlpha = 0;
-            if (i == D_800DF460) {
+            if (i == gMenuCurIndex) {
                 filterAlpha = fade;
             }
             //Fakematch? What's the (i ^ 0)?
@@ -6030,11 +6030,11 @@ void func_8008C698(UNUSED s32 updateRate) {
         }
 
         if (osTvType == TV_TYPE_PAL) {
-            D_800DF79C = 12;
-            D_800DF7A0 = 0;
+            gDrawMenuElementsYOffset = 12;
+            gDrawMenuElementsYOffset2 = 0;
         } else {
-            D_800DF79C = 0;
-            D_800DF7A0 = 0;
+            gDrawMenuElementsYOffset = 0;
+            gDrawMenuElementsYOffset2 = 0;
         }
 
         draw_menu_elements(1, gGameSelectElements, 1.0f);
@@ -6067,14 +6067,14 @@ s32 menu_game_select_loop(s32 updateRate) {
     }
     if (gMenuDelay > 30) {
         func_8008CACC();
-        if (D_800DF460 == gMenuOptionCount) {
+        if (gMenuCurIndex == gMenuOptionCount) {
             func_80000B28();
             gIsInTracksMode = TRUE;
             init_racer_headers();
             load_level_for_menu((s32)SPECIAL_MAP_ID_NO_LEVEL, -1, 0);
             menu_init(MENU_TRACK_SELECT);
         } else {
-            gIsInAdventureTwo = D_800DF460;
+            gIsInAdventureTwo = gMenuCurIndex;
             gIsInTracksMode = FALSE;
             gPlayerSelectVehicle[PLAYER_ONE] = VEHICLE_CAR;
             set_level_default_vehicle(VEHICLE_CAR);
@@ -6105,7 +6105,7 @@ s32 menu_game_select_loop(s32 updateRate) {
                 playerYDir += gControllersYAxisDirection[1];
             }
             if (playerInputs & (A_BUTTON | START_BUTTON)) {
-                if (D_800DF460 == gMenuOptionCount) {
+                if (gMenuCurIndex == gMenuOptionCount) {
                     set_music_fade_timer(-0x80);
                 }
                 transition_begin(&sMenuTransitionFadeIn);
@@ -6116,14 +6116,14 @@ s32 menu_game_select_loop(s32 updateRate) {
                 gMenuDelay = -1;
             } else {
                 if (playerYDir < 0) {
-                    if (D_800DF460 < gMenuOptionCount) {
-                        D_800DF460++;
+                    if (gMenuCurIndex < gMenuOptionCount) {
+                        gMenuCurIndex++;
                         play_sound_global(SOUND_MENU_PICK2, NULL);
                     }
                 }
                 if (playerYDir > 0) {
-                    if (D_800DF460 > 0) {
-                        D_800DF460--;
+                    if (gMenuCurIndex > 0) {
+                        gMenuCurIndex--;
                         play_sound_global(SOUND_MENU_PICK2, NULL);
                     }
                 }
@@ -6150,8 +6150,8 @@ void menu_file_select_init(void) {
     UNUSED s32 numWorlds;
 
     get_number_of_levels_and_worlds(&numLevels, &numWorlds); // Unused
-    func_8009C674(D_800E0398);
-    allocate_menu_images(D_800E03A4);
+    func_8009C674(gFileSelectObjectIndices);
+    allocate_menu_images(gFileSelectImageIndices);
     func_8007FFEC(6);
     mark_read_all_save_files();
     gOpacityDecayTimer = 1;
@@ -6167,8 +6167,8 @@ void menu_file_select_init(void) {
     play_music(SEQUENCE_CHOOSE_YOUR_RACER);
     for (i = 0; i < NUM_CHARACTERS; i++) {
         if (i != gMenuSelectedCharacter.channelIndex) {
-            func_80001114(D_800DFDB4[i][0]);
-            func_80001114(D_800DFDB4[i][1]);
+            func_80001114(gCharacterVolumes[i][0]);
+            func_80001114(gCharacterVolumes[i][1]);
         }
     }
     func_80001114(6);
@@ -6228,7 +6228,7 @@ void render_file_select_menu(UNUSED s32 updateRate) {
             color = COLOUR_RGBA32(106, 144, 115, 255);
         }
         func_80080580(NULL, gFileSelectButtons[i].x - 160, 120 - gFileSelectButtons[i].y, gFileSelectButtons[i].width,
-            gFileSelectButtons[i].height, gFileSelectButtons[i].borderWidth, gFileSelectButtons[i].borderHeight, color, gMenuTextures[TEXTURE_SURFACE_BUTTON_WOOD]);
+            gFileSelectButtons[i].height, gFileSelectButtons[i].borderWidth, gFileSelectButtons[i].borderHeight, color, gMenuObjects[TEXTURE_SURFACE_BUTTON_WOOD]);
     }
     func_80080BC8(&sMenuCurrDisplayList);
     if (gOpacityDecayTimer == 0) {
@@ -6644,7 +6644,7 @@ s32 menu_file_select_loop(s32 updateRate) {
             func_8008DC7C(updateRate);
         } else if (D_80126CC0 != 0) {
             buttonsPressed = get_buttons_pressed_from_player(PLAYER_ONE);
-            if ((buttonsPressed & B_BUTTON) && (D_800E0FA0 == 0)) {
+            if ((buttonsPressed & B_BUTTON) && (gCurrentFilenameChars == 0)) {
                 unload_big_font_4();
                 D_80126CC0 = 0;
                 gSavefileInfo[i].name[0] = 'D';
@@ -6676,13 +6676,13 @@ s32 menu_file_select_loop(s32 updateRate) {
                         set_music_fade_timer(-128);
                     } else {
                         D_80126CC0 = 1;
-                        D_800E0FB0 = 0;
+                        gIndexOfCurInputCharacter = 0;
                         i = 0;
                         if (osTvType == TV_TYPE_PAL) {
                             i = 12;
                         }
                         func_80097874(i + 187, gFileSelectButtons[gSaveFileIndex].x + gFileSelectElementPos[0],
-                            gFileSelectButtons[gSaveFileIndex].y + gFileSelectElementPos[1] + i, 0, &D_800E0FB0, gSavefileInfo[gSaveFileIndex].name, 3);
+                            gFileSelectButtons[gSaveFileIndex].y + gFileSelectElementPos[1] + i, 0, &gIndexOfCurInputCharacter, gSavefileInfo[gSaveFileIndex].name, 3);
                         currentMenuDelay = 0;
                     }
                 }
@@ -6735,7 +6735,7 @@ s32 menu_file_select_loop(s32 updateRate) {
 }
 
 void func_8008E428(void) {
-    func_8009C4A8(D_800E0398);
+    func_8009C4A8(gFileSelectObjectIndices);
     func_8007FF88();
     unload_font(ASSET_FONTS_BIGFONT);
 }
@@ -6744,22 +6744,22 @@ void func_8008E428(void) {
  * Set the texture IDs of the vehicle ID elements.
 */
 void assign_vehicle_icon_textures(void) {
-    gRaceSelectionCarTex[0].texture = gMenuTextures[TEXTURE_ICON_VEHICLE_CAR_TOP];
-    gRaceSelectionCarTex[1].texture = gMenuTextures[TEXTURE_ICON_VEHICLE_CAR_BOTTOM];
-    gRaceSelectionHoverTex[0].texture = gMenuTextures[TEXTURE_ICON_VEHICLE_HOVERCRAFT_TOP];
-    gRaceSelectionHoverTex[1].texture = gMenuTextures[TEXTURE_ICON_VEHICLE_HOVERCRAFT_BOTTOM];
-    gRaceSelectionPlaneTex[0].texture = gMenuTextures[TEXTURE_ICON_VEHICLE_PLANE_TOP];
-    gRaceSelectionPlaneTex[1].texture = gMenuTextures[TEXTURE_ICON_VEHICLE_PLANE_BOTTOM];
+    gRaceSelectionCarTex[0].texture = gMenuObjects[TEXTURE_ICON_VEHICLE_CAR_TOP];
+    gRaceSelectionCarTex[1].texture = gMenuObjects[TEXTURE_ICON_VEHICLE_CAR_BOTTOM];
+    gRaceSelectionHoverTex[0].texture = gMenuObjects[TEXTURE_ICON_VEHICLE_HOVERCRAFT_TOP];
+    gRaceSelectionHoverTex[1].texture = gMenuObjects[TEXTURE_ICON_VEHICLE_HOVERCRAFT_BOTTOM];
+    gRaceSelectionPlaneTex[0].texture = gMenuObjects[TEXTURE_ICON_VEHICLE_PLANE_TOP];
+    gRaceSelectionPlaneTex[1].texture = gMenuObjects[TEXTURE_ICON_VEHICLE_PLANE_BOTTOM];
 }
 
 /**
  * Set the texture IDs of the menu arrow elements.
 */
 void assign_menu_arrow_textures(void) {
-    gMenuSelectionArrowUp[0].texture = gMenuTextures[TEXTURE_ICON_ARROW_UP];
-    gMenuSelectionArrowLeft[0].texture = gMenuTextures[TEXTURE_ICON_ARROW_LEFT];
-    gMenuSelectionArrowDown[0].texture = gMenuTextures[TEXTURE_ICON_ARROW_DOWN];
-    gMenuSelectionArrowRight[0].texture = gMenuTextures[TEXTURE_ICON_ARROW_RIGHT];
+    gMenuSelectionArrowUp[0].texture = gMenuObjects[TEXTURE_ICON_ARROW_UP];
+    gMenuSelectionArrowLeft[0].texture = gMenuObjects[TEXTURE_ICON_ARROW_LEFT];
+    gMenuSelectionArrowDown[0].texture = gMenuObjects[TEXTURE_ICON_ARROW_DOWN];
+    gMenuSelectionArrowRight[0].texture = gMenuObjects[TEXTURE_ICON_ARROW_RIGHT];
 }
 
 void func_8008E4EC(void) {
@@ -6797,7 +6797,7 @@ void func_8008E4EC(void) {
 }
 
 UNUSED s32 func_8008E790(void) {
-    return D_800E097C;
+    return gIsInTracksMenu;
 }
 
 #ifdef NON_EQUIVALENT
@@ -6825,12 +6825,12 @@ void menu_track_select_init(void) {
     settings = get_settings();
     get_number_of_levels_and_worlds(&levelCount, &worldCount);
     trackMenuIds = (s8 **) get_misc_asset(ASSET_MISC_TRACKS_MENU_IDS);
-    if (D_800DF488 != 0) {
+    if (gTitleScreenLoaded != 0) {
         D_801269C8 = 0;
         D_801269CC = 0;
-        D_800E0414 = 0;
-        D_800E0418 = 0;
-        D_800DF488 = 0;
+        gTracksMenuTimeTrialHighlightIndex = 0;
+        gTracksMenuAdventureHighlightIndex = 0;
+        gTitleScreenLoaded = 0;
     }
     videoWidthAndHeight = get_video_width_and_height_as_s32();
     gTrackSelectViewPortX = GET_VIDEO_WIDTH(videoWidthAndHeight);
@@ -6850,58 +6850,58 @@ void menu_track_select_init(void) {
     enable_new_screen_transitions();
     set_background_fill_colour(50, 105, 223);
     for (var_a1 = 0; var_a1 != 5; var_a1++) {
-        temp_a0 = D_800E0710[(var_a1 * 3)];
-        var_s0 = (TextureHeader **) D_800E0730[var_a1];
+        temp_a0 = gTracksMenuBgTextureIndices[(var_a1 * 3)];
+        var_s0 = (TextureHeader **) gTracksMenuBgTextures[var_a1];
         if (temp_a0 != -1) {
             func_8009C6D4(temp_a0);
-            var_s0[0] = gMenuTextures[D_800E0710[(var_a1 * 3)]];
+            var_s0[0] = gMenuObjects[gTracksMenuBgTextureIndices[(var_a1 * 3)]];
         } else {
             var_s0[0] = NULL;
         }
-        temp_a0_2 = D_800E0710[(var_a1 * 3) + 1];
+        temp_a0_2 = gTracksMenuBgTextureIndices[(var_a1 * 3) + 1];
         if (temp_a0_2 != -1) {
             func_8009C6D4(temp_a0_2);
-            var_s0[1] = (TextureHeader *) gMenuTextures[D_800E0710[(var_a1 * 3)]];
+            var_s0[1] = (TextureHeader *) gMenuObjects[gTracksMenuBgTextureIndices[(var_a1 * 3)]];
         } else {
             var_s0[1] = NULL;
         }
     }
-    D_800E0970 = (Triangle *) allocate_from_main_pool_safe(2880, COLOUR_TAG_YELLOW);
-    D_800E0974 = (s32) (&D_800E0970[40]); //640 bytes forward
-    D_800E096C = (s32) (&D_800E0970[80]); //1280 bytes forward
-    //D_800E096C = (s32) (&D_800E0968[80]); //800 bytes past D_800E0968
+    gTrackSelectBgTriangles = (Triangle *) allocate_from_main_pool_safe(2880, COLOUR_TAG_YELLOW);
+    D_800E0974 = (s32) (&gTrackSelectBgTriangles[40]); //640 bytes forward
+    D_800E096C = (s32) (&gTrackSelectBgTriangles[80]); //1280 bytes forward
+    //D_800E096C = (s32) (&gTrackSelectBgVertices[80]); //800 bytes past gTrackSelectBgVertices
     var_a0 = -160;
     var_v0 = 0;
     for (var_v0 = 0; var_v0 < 80; var_v0++) {
-        D_800E0968[var_v0].x = var_a0;
+        gTrackSelectBgVertices[var_v0].x = var_a0;
         var_a0 = -var_a0;
-        D_800E0968[var_v0].z = -1024;
-        D_800E0968[var_v0].r = 0xFF;
-        D_800E0968[var_v0].g = 0xFF;
-        D_800E0968[var_v0].b = 0xFF;
+        gTrackSelectBgVertices[var_v0].z = -1024;
+        gTrackSelectBgVertices[var_v0].r = 0xFF;
+        gTrackSelectBgVertices[var_v0].g = 0xFF;
+        gTrackSelectBgVertices[var_v0].b = 0xFF;
     }
     for (var_v0 = 0; var_v0 < 40; var_v0++) {
-        D_800E0970[var_v0].flags = 0x40; // 0x40 = Draw backface
-        D_800E0970[var_v0].vi0 = 0;
-        D_800E0970[var_v0].vi1 = 2;
-        D_800E0970[var_v0].vi2 = 1;
+        gTrackSelectBgTriangles[var_v0].flags = 0x40; // 0x40 = Draw backface
+        gTrackSelectBgTriangles[var_v0].vi0 = 0;
+        gTrackSelectBgTriangles[var_v0].vi1 = 2;
+        gTrackSelectBgTriangles[var_v0].vi2 = 1;
     }
     D_80126924 = 0;
     set_background_draw_function(func_8008F618);
     resize_viewport(0, 80, gTrackSelectViewPortHalfY - (gTrackSelectViewPortHalfY >> 1), SCREEN_HEIGHT, (gTrackSelectViewPortHalfY >> 1) + gTrackSelectViewPortHalfY);
     copy_viewports_to_stack();
     camEnableUserView(0, 0);
-    D_800E097C = 1;
-    func_8009C674(D_800E07C4);
-    allocate_menu_images(D_800E07E0);
+    gIsInTracksMenu = 1;
+    func_8009C674(gTrackSelectObjectIndices);
+    allocate_menu_images(gTrackSelectImageIndices);
     assign_menu_arrow_textures();
 
-    D_800E05D4[0].texture = gMenuTextures[TEXTURE_UNK_08];
-    D_800E05D4[1].texture = gMenuTextures[TEXTURE_UNK_09];
-    D_800E05D4[2].texture = gMenuTextures[TEXTURE_UNK_0A];
-    D_800E05F4[0].texture = gMenuTextures[TEXTURE_UNK_0B];
-    D_800E05F4[1].texture = gMenuTextures[TEXTURE_UNK_0C];
-    D_800E05F4[2].texture = gMenuTextures[TEXTURE_UNK_0D];
+    D_800E05D4[0].texture = gMenuObjects[TEXTURE_UNK_08];
+    D_800E05D4[1].texture = gMenuObjects[TEXTURE_UNK_09];
+    D_800E05D4[2].texture = gMenuObjects[TEXTURE_UNK_0A];
+    D_800E05F4[0].texture = gMenuObjects[TEXTURE_UNK_0B];
+    D_800E05F4[1].texture = gMenuObjects[TEXTURE_UNK_0C];
+    D_800E05F4[2].texture = gMenuObjects[TEXTURE_UNK_0D];
 
     for (idx = 0; idx < 4; idx++) {
         var_s2 = D_801268E8[idx];
@@ -6961,7 +6961,7 @@ void menu_track_select_init(void) {
     set_relative_volume_for_music(sMenuMusicVolume);
     func_80000B18();
     set_D_800DD430(1); // Set an interrupt?
-    gIsInAdventureTwo = D_800E0418;
+    gIsInAdventureTwo = gTracksMenuAdventureHighlightIndex;
     gMultiplayerSelectedNumberOfRacersCopy = gMultiplayerSelectedNumberOfRacers;
 }
 #else
@@ -6974,7 +6974,7 @@ void func_8008F00C(s32 arg0) {
     s32 temp;
 
     if ((D_801267D0 != -1) && (D_801267D0 != 0) && (D_801267D0 == 1)) {
-        func_8009C4A8(D_800E07E8);
+        func_8009C4A8(gTrackSelectPreviewObjectIndices);
     }
     
     D_801267D0 = arg0;
@@ -6994,30 +6994,30 @@ void func_8008F00C(s32 arg0) {
                 }
                 gNumberOfReadyPlayers = 0;
                 gTrackNameVoiceDelay = 1;
-                func_8009C674(D_800E07E8);
-                allocate_menu_images(D_800E0830);
+                func_8009C674(gTrackSelectPreviewObjectIndices);
+                allocate_menu_images(gTrackSelectPreviewImageIndices);
                 assign_vehicle_icon_textures();
-                gRaceSelectionTTOn[0].texture = gMenuTextures[TEXTURE_ICON_TIMETRIAL_ON_TOP];
-                gRaceSelectionTTOn[1].texture = gMenuTextures[TEXTURE_ICON_TIMETRIAL_ON_BOTTOM];
-                gRaceSelectionTTOff[0].texture = gMenuTextures[TEXTURE_ICON_TIMETRIAL_OFF_TOP];
-                gRaceSelectionTTOff[1].texture = gMenuTextures[TEXTURE_ICON_TIMETRIAL_OFF_BOTTOM];
-                gRaceSelectionCarOptHighlight[0].texture = gMenuTextures[TEXTURE_ICON_VEHICLE_SELECT_CAR_HIGHLIGHT];
-                gRaceSelectionCarOpt[0].texture = gMenuTextures[TEXTURE_ICON_VEHICLE_SELECT_CAR];
-                gRaceSelectionHoverOptHighlight[0].texture = gMenuTextures[TEXTURE_ICON_VEHICLE_SELECT_HOVERCRAFT_HIGHLIGHT];
-                gRaceSelectionHoverOpt[0].texture = gMenuTextures[TEXTURE_ICON_VEHICLE_SELECT_HOVERCRAFT];
-                gRaceSelectionPlaneOptHighlight[0].texture = gMenuTextures[TEXTURE_ICON_VEHICLE_SELECT_PLANE_HIGHLIGHT];
-                gRaceSelectionPlaneOpt[0].texture = gMenuTextures[TEXTURE_ICON_VEHICLE_SELECT_PLANE];
-                gRaceSelectionTTOnOptHighlight[0].texture = gMenuTextures[TEXTURE_ICON_TIMETRIAL_OPT_ON];
-                gRaceSelectionTTOffOptHighlight[0].texture = gMenuTextures[TEXTURE_ICON_TIMETRIAL_OPT_ON_HIGHLIGHT];
-                gRaceSelectionTTOnOpt[0].texture = gMenuTextures[TEXTURE_ICON_TIMETRIAL_OPT_OFF];
-                gRaceSelectionTTOffOpt[0].texture = gMenuTextures[TEXTURE_ICON_TIMETRIAL_OPT_OFF_HIGHLIGHT];
-                gRaceSelectionPlayer1Texture[0].texture = gMenuTextures[TEXTURE_ICON_PLAYER_1];
-                gRaceSelectionPlayer2Texture[0].texture = gMenuTextures[TEXTURE_ICON_PLAYER_2];
-                gRaceSelectionPlayer3Texture[0].texture = gMenuTextures[TEXTURE_ICON_PLAYER_3];
-                gRaceSelectionPlayer4Texture[0].texture = gMenuTextures[TEXTURE_ICON_PLAYER_4];
-                gRaceSelectionVehicleTitleTexture[0].texture = gMenuTextures[TEXTURE_ICON_VEHICLE_TITLE];
-                gRaceSelectionTTTitleTexture[0].texture = gMenuTextures[TEXTURE_ICON_TT_TITLE];
-                gRaceSelectionTTTexture[0].texture = gMenuTextures[TEXTURE_ICON_TT_HEAD];
+                gRaceSelectionTTOn[0].texture = gMenuObjects[TEXTURE_ICON_TIMETRIAL_ON_TOP];
+                gRaceSelectionTTOn[1].texture = gMenuObjects[TEXTURE_ICON_TIMETRIAL_ON_BOTTOM];
+                gRaceSelectionTTOff[0].texture = gMenuObjects[TEXTURE_ICON_TIMETRIAL_OFF_TOP];
+                gRaceSelectionTTOff[1].texture = gMenuObjects[TEXTURE_ICON_TIMETRIAL_OFF_BOTTOM];
+                gRaceSelectionCarOptHighlight[0].texture = gMenuObjects[TEXTURE_ICON_VEHICLE_SELECT_CAR_HIGHLIGHT];
+                gRaceSelectionCarOpt[0].texture = gMenuObjects[TEXTURE_ICON_VEHICLE_SELECT_CAR];
+                gRaceSelectionHoverOptHighlight[0].texture = gMenuObjects[TEXTURE_ICON_VEHICLE_SELECT_HOVERCRAFT_HIGHLIGHT];
+                gRaceSelectionHoverOpt[0].texture = gMenuObjects[TEXTURE_ICON_VEHICLE_SELECT_HOVERCRAFT];
+                gRaceSelectionPlaneOptHighlight[0].texture = gMenuObjects[TEXTURE_ICON_VEHICLE_SELECT_PLANE_HIGHLIGHT];
+                gRaceSelectionPlaneOpt[0].texture = gMenuObjects[TEXTURE_ICON_VEHICLE_SELECT_PLANE];
+                gRaceSelectionTTOnOptHighlight[0].texture = gMenuObjects[TEXTURE_ICON_TIMETRIAL_OPT_ON];
+                gRaceSelectionTTOffOptHighlight[0].texture = gMenuObjects[TEXTURE_ICON_TIMETRIAL_OPT_ON_HIGHLIGHT];
+                gRaceSelectionTTOnOpt[0].texture = gMenuObjects[TEXTURE_ICON_TIMETRIAL_OPT_OFF];
+                gRaceSelectionTTOffOpt[0].texture = gMenuObjects[TEXTURE_ICON_TIMETRIAL_OPT_OFF_HIGHLIGHT];
+                gRaceSelectionPlayer1Texture[0].texture = gMenuObjects[TEXTURE_ICON_PLAYER_1];
+                gRaceSelectionPlayer2Texture[0].texture = gMenuObjects[TEXTURE_ICON_PLAYER_2];
+                gRaceSelectionPlayer3Texture[0].texture = gMenuObjects[TEXTURE_ICON_PLAYER_3];
+                gRaceSelectionPlayer4Texture[0].texture = gMenuObjects[TEXTURE_ICON_PLAYER_4];
+                gRaceSelectionVehicleTitleTexture[0].texture = gMenuObjects[TEXTURE_ICON_VEHICLE_TITLE];
+                gRaceSelectionTTTitleTexture[0].texture = gMenuObjects[TEXTURE_ICON_TT_TITLE];
+                gRaceSelectionTTTexture[0].texture = gMenuObjects[TEXTURE_ICON_TT_HEAD];
                 break;
         }
     }
@@ -7065,7 +7065,7 @@ s32 menu_track_select_loop(s32 updateRate) {
     }
     if (D_801267D0 < 0) {
         func_8008F534();
-        D_800DF478 = 0;
+        unused_800DF478 = 0;
         if (gNumberOfActivePlayers >= 3 || (gNumberOfActivePlayers == 2 && (gActiveMagicCodes << 7) >= 0)) {
             cutsceneId = 0;
             if (is_drumstick_unlocked()) {
@@ -7091,11 +7091,11 @@ s32 menu_track_select_loop(s32 updateRate) {
             }
         }
         if (D_801269C8 != 4) {
-            D_800DF478 = 1;
+            unused_800DF478 = 1;
             return gNumberOfActivePlayers;
         }
         gTrophyRaceWorldId = D_801269CC + 1;
-        D_800DF450 = 0;
+        gInAdvModeTrophyRace = 0;
         gTrophyRaceRound = 0;
         menu_init(MENU_TROPHY_RACE_ROUND);
         return MENU_RESULT_CONTINUE;
@@ -7108,16 +7108,16 @@ void func_8008F534(void) {
     s32 i;
 
     camDisableUserView(0, FALSE);
-    func_8009C4A8(D_800E07C4);
+    func_8009C4A8(gTrackSelectObjectIndices);
     set_free_queue_state(0);
-    free_from_memory_pool(D_800E0970);
+    free_from_memory_pool(gTrackSelectBgTriangles);
     set_free_queue_state(2);
     for (i = 0; i < 15; i += 3) {
-        if (D_800E0710[i] != -1) {
-            func_8009C508(D_800E0710[i]);
+        if (gTracksMenuBgTextureIndices[i] != -1) {
+            func_8009C508(gTracksMenuBgTextureIndices[i]);
         }
-        if (D_800E0710[i + 1] != -1) {
-            func_8009C508(D_800E0710[i + 1]);
+        if (gTracksMenuBgTextureIndices[i + 1] != -1) {
+            func_8009C508(gTracksMenuBgTextureIndices[i + 1]);
         }
     }
     unload_font(ASSET_FONTS_BIGFONT);
@@ -7165,13 +7165,13 @@ s32 func_8008F618(Gfx **dlist, MatrixS **mtx) {
     yPos = gTrackSelectViewPortHalfY + temp2;
     gDPSetPrimColor((*dlist)++, 0, 0, 255, 255, 255, 255);
     gDPSetEnvColor((*dlist)++, 255, 255, 255, 0);
-    vertices = (&D_800E0968)[D_80126924];
-    triangles = (&D_800E0970)[D_80126924];
-    for (index = 0; D_800E0840[index] < temp; index += 5) {}
+    vertices = (&gTrackSelectBgVertices)[D_80126924];
+    triangles = (&gTrackSelectBgTriangles)[D_80126924];
+    for (index = 0; gTrackSelectBgData[index] < temp; index += 5) {}
     
-    data = &D_800E0840[index];
+    data = &gTrackSelectBgData[index];
     while ((yPos >= -gTrackSelectViewPortHalfY) && (data[0] < 42) && (numVertices < 64)) {
-        bgTexture = D_800E0730[data[1]];
+        bgTexture = gTracksMenuBgTextures[data[1]];
         vertices[0].y = yPos;
         vertices[1].y = yPos;
         vertices[0].a = data[2];
@@ -7308,13 +7308,13 @@ void render_track_select(s32 x, s32 y, char *hubName, char *trackName, s32 rectO
     gMenuImageStack[imageId].unkC = x;
     gMenuImageStack[imageId].unk10 = y;
     if (osTvType == TV_TYPE_PAL) {
-        D_800DF454 = 1.2f;
-        offsets = D_800E06D4;
+        gTrackSelectWoodFrameHeightScale = 1.2f;
+        offsets = gTracksMenuArrowPositionsPAL;
     } else {
-        offsets = D_800E06C4;
+        offsets = gTracksMenuArrowPositionsNTSC;
     }
     func_8009CA60(imageId);
-    D_800DF454 = 1.0f;
+    gTrackSelectWoodFrameHeightScale = 1.0f;
     for(i = 0; i < 4; i++) {
         if ((1 << i) & arg8) {
             render_textured_rectangle(&sMenuCurrDisplayList, gMenuSelectionArrows[i], offsets[(i << 1)] + xTemp + 1, offsets[(i << 1) + 1] + yTemp + 1, 0, 0, 0, 128);
@@ -7504,7 +7504,7 @@ void func_80090918(s32 updateRate) {
         }
         if (gMenuDelay < -22) {
             set_background_draw_function(NULL);
-            D_800E097C = 0;
+            gIsInTracksMenu = 0;
         }
         if (gMenuDelay > 30) {
             if ((is_adventure_two_unlocked()) && (D_801269C8 != 5)) {
@@ -7569,7 +7569,7 @@ void func_80090918(s32 updateRate) {
 }
 
 void func_80090ED8(UNUSED s32 updateRate) {
-    if (gMenuOptionCount == 1 && D_800E0414 == 0 && D_80126840 == 0) {
+    if (gMenuOptionCount == 1 && gTracksMenuTimeTrialHighlightIndex == 0 && D_80126840 == 0) {
         play_sound_global(SOUND_VOICE_TT_SNORE, &D_80126840);
     }
 }
@@ -7614,10 +7614,10 @@ void render_track_select_setup_ui(s32 updateRate) {
         gMenuImageStack[sp84].unkC = 0.0f;
         gMenuImageStack[sp84].unk10 = 0.0f;
         if (osTvType == TV_TYPE_PAL) {
-            D_800DF454 = 1.2f;
+            gTrackSelectWoodFrameHeightScale = 1.2f;
         }
         func_8009CA60(sp84);
-        D_800DF454 = 1.0f;
+        gTrackSelectWoodFrameHeightScale = 1.0f;
     }
     if ((gMenuDelay >= -22) && (gMenuDelay < 31)) {
         if (gMenuDelay < 0) {
@@ -7644,16 +7644,16 @@ void render_track_select_setup_ui(s32 updateRate) {
             if (s4 < temp) {
                 s4 = temp;
             }
-            if (s4 < D_800E0700.width) {
-                s4 = D_800E0700.width;
+            if (s4 < gTracksMenuAdventureButton.width) {
+                s4 = gTracksMenuAdventureButton.width;
             } else {
                 s4 += 0xC;
             }
-            func_80080580(&sMenuCurrDisplayList, -(s4 >> 1), 0x78 - D_800E0700.y, s4, D_800E0700.height,
-                D_800E0700.borderWidth, D_800E0700.borderHeight, sMenuGuiOpacity + 0xB0E0C000, gMenuTextures[43]);
+            func_80080580(&sMenuCurrDisplayList, -(s4 >> 1), 0x78 - gTracksMenuAdventureButton.y, s4, gTracksMenuAdventureButton.height,
+                gTracksMenuAdventureButton.borderWidth, gTracksMenuAdventureButton.borderHeight, sMenuGuiOpacity + 0xB0E0C000, gMenuObjects[43]);
             func_80080E6C();
             set_text_font(ASSET_FONTS_FUNFONT);
-            s7 = D_800E0700.colourMax + D_800E0700.y + sp80;
+            s7 = gTracksMenuAdventureButton.colourMax + gTracksMenuAdventureButton.y + sp80;
             s7++;
             for (i = 0; i < 2; i++) {
                 for (j = 0; j < 4; j += 2) {
@@ -7661,7 +7661,7 @@ void render_track_select_setup_ui(s32 updateRate) {
                         set_text_colour(0, 0, 0, 255, sMenuGuiOpacity >> 1);
                     } else {
                         s32 alpha = i;
-                        if (i == D_800E0418) {
+                        if (i == gTracksMenuAdventureHighlightIndex) {
                             alpha = sp84;
                         }
                         set_text_colour(255, 255, 255, alpha, sMenuGuiOpacity);
@@ -7695,7 +7695,7 @@ void render_track_select_setup_ui(s32 updateRate) {
                         render_textured_rectangle(&sMenuCurrDisplayList, &gRaceSelectionTTTitleTexture, 136, sp80 + 114, 255, 255, 255, sMenuGuiOpacity);
                         for (i = 0; i < 2; i++) {
                             s32 yTemp = 0x97 + sp80 + (i * 0x18);
-                            if (i == D_800E0414) {
+                            if (i == gTracksMenuTimeTrialHighlightIndex) {
                                 render_textured_rectangle(&sMenuCurrDisplayList, D_800E0648[(i * 3) + 1], 0x68, yTemp, 0xFF, 0xFF, 0xFF, sMenuGuiOpacity);
                             } else {
                                 render_textured_rectangle(&sMenuCurrDisplayList, D_800E0648[(i * 3) + 2], 0x68, yTemp, 0xFF, 0xFF, 0xFF, sMenuGuiOpacity);
@@ -7708,15 +7708,15 @@ void render_track_select_setup_ui(s32 updateRate) {
                         for (i = 0; i < gNumberOfActivePlayers; i++) {
 
                             if (((gNumberOfActivePlayers == 1) && (i == gMenuOptionCount)) || ((gNumberOfActivePlayers >= 2) && (D_801269C4[i] == 0))) {
-                                s32 temp_v0_9 = D_800E0688[s3 + (i * 2)];
-                                s32 temp_v1 = D_800E0688[s3 + (i * 2) + 1] + sp80;
+                                s32 temp_v0_9 = gTracksMenuPlayerNamePositions[s3 + (i * 2)];
+                                s32 temp_v1 = gTracksMenuPlayerNamePositions[s3 + (i * 2) + 1] + sp80;
                                 // Glow effect around Player image
                                 set_current_dialogue_box_coords(7, temp_v0_9 - 2, temp_v1 - 2, temp_v0_9 + 0x32, temp_v1 + 0x17);
                                 render_dialogue_box(&sMenuCurrDisplayList, 0, 0, 7);
                             }
 
                             // "Player" text image
-                            render_textured_rectangle(&sMenuCurrDisplayList, D_800E0660[i], D_800E0688[s3 + (i * 2)], D_800E0688[s3 + (i * 2) + 1] + sp80, 0xFF, 0xFF, 0xFF, sMenuGuiOpacity);
+                            render_textured_rectangle(&sMenuCurrDisplayList, D_800E0660[i], gTracksMenuPlayerNamePositions[s3 + (i * 2)], gTracksMenuPlayerNamePositions[s3 + (i * 2) + 1] + sp80, 0xFF, 0xFF, 0xFF, sMenuGuiOpacity);
                         }
                     }
                 }
@@ -7732,13 +7732,13 @@ void render_track_select_setup_ui(s32 updateRate) {
                                     for (j = 0; j < gNumberOfActivePlayers; j++) {
                                         if (i == gPlayerSelectVehicle[j]) {
                                             // Highlighted
-                                            render_textured_rectangle(&sMenuCurrDisplayList, gRaceSelectionImages[(i * 3) + 1], D_800E06B0[s3 + j], yTemp, 0xFF, 0xFF, 0xFF, sMenuGuiOpacity);
+                                            render_textured_rectangle(&sMenuCurrDisplayList, gRaceSelectionImages[(i * 3) + 1], gTracksMenuVehicleNamePositions[s3 + j], yTemp, 0xFF, 0xFF, 0xFF, sMenuGuiOpacity);
                                         } else if (settings->courseFlagsPtr[gTrackIdForPreview] & 2) {
                                             // Not highlighted
-                                            render_textured_rectangle(&sMenuCurrDisplayList, gRaceSelectionImages[(i * 3) + 2], D_800E06B0[s3 + j], yTemp, 0xFF, 0xFF, 0xFF, sMenuGuiOpacity);
+                                            render_textured_rectangle(&sMenuCurrDisplayList, gRaceSelectionImages[(i * 3) + 2], gTracksMenuVehicleNamePositions[s3 + j], yTemp, 0xFF, 0xFF, 0xFF, sMenuGuiOpacity);
                                         } else {
                                             // Not available (Ghosted out)
-                                            render_textured_rectangle(&sMenuCurrDisplayList, gRaceSelectionImages[(i * 3) + 2], D_800E06B0[s3 + j], yTemp, 0xFF, 0xFF, 0xFF, sMenuGuiOpacity / 2);
+                                            render_textured_rectangle(&sMenuCurrDisplayList, gRaceSelectionImages[(i * 3) + 2], gTracksMenuVehicleNamePositions[s3 + j], yTemp, 0xFF, 0xFF, 0xFF, sMenuGuiOpacity / 2);
                                         }
                                     }
                                 }
@@ -7758,7 +7758,7 @@ void render_track_select_setup_ui(s32 updateRate) {
                         render_textured_rectangle(&sMenuCurrDisplayList, gRaceSelectionImages[gPlayerSelectVehicle[PLAYER_ONE] * 3], 0x95, s7, 0xFF, 0xFF, 0xFF, sMenuGuiOpacity);
                     } else {
                         // Draw T.T. image for one player
-                        render_textured_rectangle(&sMenuCurrDisplayList, D_800E0648[D_800E0414 * 3], 0x95, sp80, 0xFF, 0xFF, 0xFF, sMenuGuiOpacity);
+                        render_textured_rectangle(&sMenuCurrDisplayList, D_800E0648[gTracksMenuTimeTrialHighlightIndex * 3], 0x95, sp80, 0xFF, 0xFF, 0xFF, sMenuGuiOpacity);
                     }
                 }
                 if ((gNumberOfActivePlayers == 2) && (!sp74)) {
@@ -7797,7 +7797,7 @@ void render_track_select_setup_ui(s32 updateRate) {
                     } else {
                         s4 = gTwoPlayerRacerCountMenu.width;
                     }
-                    func_80080580(&sMenuCurrDisplayList, -(s4 >> 1), 0x78 - gTwoPlayerRacerCountMenu.y, s4, gTwoPlayerRacerCountMenu.height, gTwoPlayerRacerCountMenu.textPos[0], gTwoPlayerRacerCountMenu.textPos[1], 0xB0E0C0FF, gMenuTextures[43]);
+                    func_80080580(&sMenuCurrDisplayList, -(s4 >> 1), 0x78 - gTwoPlayerRacerCountMenu.y, s4, gTwoPlayerRacerCountMenu.height, gTwoPlayerRacerCountMenu.textPos[0], gTwoPlayerRacerCountMenu.textPos[1], 0xB0E0C0FF, gMenuObjects[43]);
                     func_80080E6C();
                     set_text_font(ASSET_FONTS_FUNFONT);
                     set_text_colour(0, 0, 0, 0xFF, 0x80);
@@ -7935,17 +7935,17 @@ void menu_adventure_track_init(void) {
         play_music(SEQUENCE_MAIN_MENU);
         func_80000B18();
         gMenuOptionCount = 0;
-        func_8009C674(D_800E0FB4);
-        allocate_menu_images(D_800E0FD8);
+        func_8009C674(gAdvTrackInitObjectIndices);
+        allocate_menu_images(gAdvTrackInitImageIndices);
         assign_vehicle_icon_textures();
-        gRaceSelectionCarOptHighlight[0].texture = gMenuTextures[TEXTURE_ICON_VEHICLE_SELECT_CAR_HIGHLIGHT];
-        gRaceSelectionCarOpt[0].texture = gMenuTextures[TEXTURE_ICON_VEHICLE_SELECT_CAR];
-        gRaceSelectionHoverOptHighlight[0].texture = gMenuTextures[TEXTURE_ICON_VEHICLE_SELECT_HOVERCRAFT_HIGHLIGHT];
-        gRaceSelectionHoverOpt[0].texture = gMenuTextures[TEXTURE_ICON_VEHICLE_SELECT_HOVERCRAFT];
-        gRaceSelectionPlaneOptHighlight[0].texture = gMenuTextures[TEXTURE_ICON_VEHICLE_SELECT_PLANE_HIGHLIGHT];
-        gRaceSelectionPlaneOpt[0].texture = gMenuTextures[TEXTURE_ICON_VEHICLE_SELECT_PLANE];
-        gRaceSelectionVehicleTitleTexture[0].texture = gMenuTextures[TEXTURE_ICON_VEHICLE_TITLE];
-        gRaceSelectionTTTexture[0].texture = gMenuTextures[TEXTURE_ICON_TT_HEAD];
+        gRaceSelectionCarOptHighlight[0].texture = gMenuObjects[TEXTURE_ICON_VEHICLE_SELECT_CAR_HIGHLIGHT];
+        gRaceSelectionCarOpt[0].texture = gMenuObjects[TEXTURE_ICON_VEHICLE_SELECT_CAR];
+        gRaceSelectionHoverOptHighlight[0].texture = gMenuObjects[TEXTURE_ICON_VEHICLE_SELECT_HOVERCRAFT_HIGHLIGHT];
+        gRaceSelectionHoverOpt[0].texture = gMenuObjects[TEXTURE_ICON_VEHICLE_SELECT_HOVERCRAFT];
+        gRaceSelectionPlaneOptHighlight[0].texture = gMenuObjects[TEXTURE_ICON_VEHICLE_SELECT_PLANE_HIGHLIGHT];
+        gRaceSelectionPlaneOpt[0].texture = gMenuObjects[TEXTURE_ICON_VEHICLE_SELECT_PLANE];
+        gRaceSelectionVehicleTitleTexture[0].texture = gMenuObjects[TEXTURE_ICON_VEHICLE_TITLE];
+        gRaceSelectionTTTexture[0].texture = gMenuObjects[TEXTURE_ICON_TT_HEAD];
 
         transition_begin(&sMenuTransitionFadeOut);
         gOptionBlinkTimer = 0;
@@ -8188,7 +8188,7 @@ s32 menu_adventure_track_loop(s32 updateRate) {
 }
 
 void func_80093A0C(void) {
-    func_8009C4A8((s16 *)&D_800E0FB4);
+    func_8009C4A8((s16 *)&gAdvTrackInitObjectIndices);
     unload_font(ASSET_FONTS_BIGFONT);
     func_80000B28();
 }
@@ -8201,15 +8201,15 @@ void func_80093A40(void) {
 
     func_80072298(0);
     settings = get_settings();
-    D_800E098C = -1;
+    gLastPlayerWhoPaused = -1;
 
-    for (i = 0; ((get_active_player_count() > i) && (D_800E098C < 0)); i++) {
+    for (i = 0; ((get_active_player_count() > i) && (gLastPlayerWhoPaused < 0)); i++) {
         if (get_buttons_held_from_player(i) & START_BUTTON) {
-            D_800E098C = i;
+            gLastPlayerWhoPaused = i;
         }
     }
-    if (D_800E098C < 0) {
-        D_800E098C = 0;
+    if (gLastPlayerWhoPaused < 0) {
+        gLastPlayerWhoPaused = 0;
     }
     gMenuOptionText[0] = gMenuText[ASSET_MENU_TEXT_CONTINUE];
     gMenuOptionCap = 1;
@@ -8276,11 +8276,11 @@ void func_80093D40(UNUSED s32 updateRate) {
     halfTemp = temp >> 1;
     halfX = x >> 1;
     set_current_dialogue_box_coords(7, SCREEN_WIDTH_HALF - halfX, y - halfTemp, halfX + 160, halfTemp + y);
-    colour = &D_800E0990[get_player_id(D_800E098C)];
+    colour = &gPlayerPauseBgColour[get_player_id(gLastPlayerWhoPaused)];
     set_current_dialogue_background_colour(7, colour->r, colour->g, colour->b, colour->a);
     set_dialogue_font(7, ASSET_FONTS_FUNFONT);
     set_current_text_background_colour(7, 128, 128, 255, 0);
-    colour = &D_800E09A0[get_player_id(D_800E098C)];
+    colour = &gPlayerPauseOptionsTextColour[get_player_id(gLastPlayerWhoPaused)];
     set_current_text_colour(7, colour->r, colour->g, colour->b, colour->a, 255);
     alpha = gOptionBlinkTimer * 8;
     if (alpha > 255) {
@@ -8306,8 +8306,8 @@ void func_80093D40(UNUSED s32 updateRate) {
         }
         render_dialogue_text(7, POS_CENTRED, i + 44, gMenuText[ASSET_MENU_TEXT_CANCEL], 1, ALIGN_MIDDLE_CENTER);
     } else {
-        i = D_800E098C + 1; // Fakematch. Seems to fix stuff?
-        render_dialogue_text(7, POS_CENTRED, 12, gMenuText[ASSET_MENU_TEXT_PAUSEOPTIONS], D_800E098C + 1, ALIGN_MIDDLE_CENTER);
+        i = gLastPlayerWhoPaused + 1; // Fakematch. Seems to fix stuff?
+        render_dialogue_text(7, POS_CENTRED, 12, gMenuText[ASSET_MENU_TEXT_PAUSEOPTIONS], gLastPlayerWhoPaused + 1, ALIGN_MIDDLE_CENTER);
         for (i = 0, y = 32; i < gMenuOptionCap; i++, y += 16) {
             if (i == gMenuOption) {
                 set_current_text_colour(7, 255, 255, 255, alpha, 255);
@@ -8342,7 +8342,7 @@ s32 render_pause_menu(UNUSED Gfx **dl, s32 updateRate) {
 
     buttonsPressed = 0;
     if (gIgnorePlayerInputTime == 0) {
-        buttonsPressed = get_buttons_pressed_from_player(D_800E098C);
+        buttonsPressed = get_buttons_pressed_from_player(gLastPlayerWhoPaused);
     }
 
     if (gMenuDelay == 0) {
@@ -8359,7 +8359,7 @@ s32 render_pause_menu(UNUSED Gfx **dl, s32 updateRate) {
                 gMenuSubOption = 0;
             } else {
                 temp = gMenuSubOption;
-                playerId = D_800E098C;
+                playerId = gLastPlayerWhoPaused;
                 if (gControllersYAxisDirection[playerId] != 0) {
                     gMenuSubOption = 3 - gMenuSubOption;
                 }
@@ -8377,7 +8377,7 @@ s32 render_pause_menu(UNUSED Gfx **dl, s32 updateRate) {
             }
         } else {
             temp = gMenuOption;
-            playerId = D_800E098C;
+            playerId = gLastPlayerWhoPaused;
             buttonsPressed = gControllersYAxisDirection[playerId];
             if (buttonsPressed < 0) {
                 gMenuOption++;
@@ -8456,16 +8456,16 @@ void n_alSeqpDelete(void) {
  * Set the racer portrait element textures for their respective characters.
 */
 void assign_racer_portrait_textures(void) {
-    gMenuPortraitKrunch[0].texture = gMenuTextures[TEXTURE_ICON_PORTRAIT_KRUNCH];
-    gMenuPortraitDiddy[0].texture = gMenuTextures[TEXTURE_ICON_PORTRAIT_DIDDY];
-    gMenuPortraitDrumstick[0].texture = gMenuTextures[TEXTURE_ICON_PORTRAIT_DRUMSTICK];
-    gMenuPortraitBanjo[0].texture = gMenuTextures[TEXTURE_ICON_PORTRAIT_BANJO];
-    gMenuPortraitBumper[0].texture = gMenuTextures[TEXTURE_ICON_PORTRAIT_BUMPER];
-    gMenuPortraitConker[0].texture = gMenuTextures[TEXTURE_ICON_PORTRAIT_CONKER];
-    gMenuPortraitTiptup[0].texture = gMenuTextures[TEXTURE_ICON_PORTRAIT_TIPTUP];
-    gMenuPortraitTT[0].texture = gMenuTextures[TEXTURE_ICON_PORTRAIT_TT];
-    gMenuPortraitPipsy[0].texture = gMenuTextures[TEXTURE_ICON_PORTRAIT_PIPSY];
-    gMenuPortraitTimber[0].texture = gMenuTextures[TEXTURE_ICON_PORTRAIT_TIMBER];
+    gMenuPortraitKrunch[0].texture = gMenuObjects[TEXTURE_ICON_PORTRAIT_KRUNCH];
+    gMenuPortraitDiddy[0].texture = gMenuObjects[TEXTURE_ICON_PORTRAIT_DIDDY];
+    gMenuPortraitDrumstick[0].texture = gMenuObjects[TEXTURE_ICON_PORTRAIT_DRUMSTICK];
+    gMenuPortraitBanjo[0].texture = gMenuObjects[TEXTURE_ICON_PORTRAIT_BANJO];
+    gMenuPortraitBumper[0].texture = gMenuObjects[TEXTURE_ICON_PORTRAIT_BUMPER];
+    gMenuPortraitConker[0].texture = gMenuObjects[TEXTURE_ICON_PORTRAIT_CONKER];
+    gMenuPortraitTiptup[0].texture = gMenuObjects[TEXTURE_ICON_PORTRAIT_TIPTUP];
+    gMenuPortraitTT[0].texture = gMenuObjects[TEXTURE_ICON_PORTRAIT_TT];
+    gMenuPortraitPipsy[0].texture = gMenuObjects[TEXTURE_ICON_PORTRAIT_PIPSY];
+    gMenuPortraitTimber[0].texture = gMenuObjects[TEXTURE_ICON_PORTRAIT_TIMBER];
 }
 
 void func_80094688(s32 arg0, s32 arg1) {
@@ -8506,7 +8506,7 @@ void func_80094688(s32 arg0, s32 arg1) {
     gOptionBlinkTimer = 0;
     gOpacityDecayTimer = 0;
     gMenuDelay = 0;
-    D_800DF460 = 0;
+    gMenuCurIndex = 0;
     gMenuOption = 0;
     gIgnorePlayerInputTime = 1;
     D_80126C54.unk0_s32 = -1;
@@ -8533,16 +8533,16 @@ void func_80094688(s32 arg0, s32 arg1) {
     if ((gNumberOfActivePlayers == 1) && (gTrophyRaceWorldId == 0)) {
         D_80126C54.unk0_s32 = 0;
         arg1 = (s8) header->world - 1;
-        var_v1 = &D_800E0710[arg1 * 3];
+        var_v1 = &gTracksMenuBgTextureIndices[arg1 * 3];
         if (var_v1[0] != -1) {
             func_8009C6D4(var_v1[0]);
-            D_80126BB8 = gMenuTextures[var_v1[0]];
+            D_80126BB8 = gMenuObjects[var_v1[0]];
         } else {
             D_80126BB8 = 0;
         }
         if (var_v1[1] != -1) {
             func_8009C6D4(var_v1[1]);
-            D_80126BBC = gMenuTextures[var_v1[1]];
+            D_80126BBC = gMenuObjects[var_v1[1]];
         } else {
             D_80126BBC = 0;
         }
@@ -8570,24 +8570,24 @@ void func_80094A5C(void) {
         }
         temp_a0 = D_800E0A10[D_80126C54.unk0_s32];
         if (temp_a0 == -1) {
-            allocate_menu_images(D_800E0A40);
+            allocate_menu_images(gRaceResultsImageIndices);
             assign_racer_portrait_textures();
             settings = get_settings();
-            D_800E0BEC->unk14_a.element = gRacerPortraits[settings->racers[settings->timeTrialRacer].character];
+            gRaceResultsMenuElements->unk14_a.element = gRacerPortraits[settings->racers[settings->timeTrialRacer].character];
             if (!is_time_trial_enabled()) {
                 for (i = 0; i < 8; i++) {
                     for (j = 0; j < 8; j++) {
                         if (i == settings->racers[j].starting_position) {
-                            D_800E0CEC[7 - i].unk14_a.element = gRacerPortraits[settings->racers[j].character];
+                            gRaceOrderMenuElements[7 - i].unk14_a.element = gRacerPortraits[settings->racers[j].character];
                         }
                     }
                 }
                 if (is_in_two_player_adventure()) {
                     for (i = 0; i < 6; i++) {
-                        D_800E0CEC[i + 1].unk14_a.element = D_800E0CEC[i + 2].unk14_a.element;
+                        gRaceOrderMenuElements[i + 1].unk14_a.element = gRaceOrderMenuElements[i + 2].unk14_a.element;
                     }
-                    D_800E0CEC[7].unk14_a.element = &D_80126850;
-                    D_800E0CEC[0].unk14_a.element = &D_80126850;
+                    gRaceOrderMenuElements[7].unk14_a.element = &D_80126850;
+                    gRaceOrderMenuElements[0].unk14_a.element = &D_80126850;
                 }
             }
             D_80126C54.unk0_s32 = -1;
@@ -8603,11 +8603,11 @@ void func_80094C14(s32 updateRate) {
     D_80126A94 += updateRate;
     if (gOpacityDecayTimer >= 0) {
         gOpacityDecayTimer += updateRate;
-        switch (D_800DF460) {
+        switch (gMenuCurIndex) {
             case 0:
                 if (normalise_time(240) < gOpacityDecayTimer) {
                     set_music_fade_timer(-256);
-                    D_800DF460 = 1;
+                    gMenuCurIndex = 1;
                 }
                 break;
             case 1:
@@ -8663,21 +8663,21 @@ void func_80094D28(UNUSED s32 updateRate) {
         case 2:
             for(i = 0; i < 3; i++) {
                 if (settings->display_times && settings->racers[0].best_times & (1 << i)) {
-                    D_800E0BEC[i+3].filterGreen = 192 - ((textAlpha * 3) >> 2);
-                    D_800E0BEC[i+3].filterBlue = 255 - textAlpha;
+                    gRaceResultsMenuElements[i+3].filterGreen = 192 - ((textAlpha * 3) >> 2);
+                    gRaceResultsMenuElements[i+3].filterBlue = 255 - textAlpha;
                 } else {
-                    D_800E0BEC[i+3].filterGreen = 192;
-                    D_800E0BEC[i+3].filterBlue = 255;
+                    gRaceResultsMenuElements[i+3].filterGreen = 192;
+                    gRaceResultsMenuElements[i+3].filterBlue = 255;
                 }
             }
             if (settings->display_times && settings->racers[0].best_times & (1 << 7)) {
-                D_800E0BEC[6].filterRed = (textAlpha >> 1) + 128;
-                D_800E0BEC[6].filterGreen = 255 - textAlpha;
-                D_800E0BEC[6].filterBlue = 255 - textAlpha;
+                gRaceResultsMenuElements[6].filterRed = (textAlpha >> 1) + 128;
+                gRaceResultsMenuElements[6].filterGreen = 255 - textAlpha;
+                gRaceResultsMenuElements[6].filterBlue = 255 - textAlpha;
             } else {
-                D_800E0BEC[6].filterRed = 128;
-                D_800E0BEC[6].filterGreen = 255;
-                D_800E0BEC[6].filterBlue = 255;
+                gRaceResultsMenuElements[6].filterRed = 128;
+                gRaceResultsMenuElements[6].filterGreen = 255;
+                gRaceResultsMenuElements[6].filterBlue = 255;
             }
             break;
         case 3:
@@ -8694,29 +8694,29 @@ void func_80094D28(UNUSED s32 updateRate) {
                     sp3C = (textAlpha >> 1) + 128;
                 }
                 if (y){} // Fake
-                D_800E0CEC[7 - j].filterRed = sp3C;
-                D_800E0CEC[7 - j].filterGreen = sp3C;
-                D_800E0CEC[7 - j].filterBlue = sp3C;
+                gRaceOrderMenuElements[7 - j].filterRed = sp3C;
+                gRaceOrderMenuElements[7 - j].filterGreen = sp3C;
+                gRaceOrderMenuElements[7 - j].filterBlue = sp3C;
             }
             break;
         case 5:
             if (settings->display_times && settings->racers[0].best_times & (s8) ~(1 << 7)) {
-                D_800E0E4C[6].filterRed = 255;
-                D_800E0E4C[6].filterGreen = 192 - ((textAlpha * 3) >> 2);
-                D_800E0E4C[6].filterBlue = 255 - textAlpha;
+                gRecordTimesMenuElements[6].filterRed = 255;
+                gRecordTimesMenuElements[6].filterGreen = 192 - ((textAlpha * 3) >> 2);
+                gRecordTimesMenuElements[6].filterBlue = 255 - textAlpha;
             } else {
-                D_800E0E4C[6].filterRed = 255;
-                D_800E0E4C[6].filterGreen = 192;
-                D_800E0E4C[6].filterBlue = 255;
+                gRecordTimesMenuElements[6].filterRed = 255;
+                gRecordTimesMenuElements[6].filterGreen = 192;
+                gRecordTimesMenuElements[6].filterBlue = 255;
             }
             if (settings->display_times && settings->racers[0].best_times & (1 << 7)) {
-                D_800E0E4C[3].filterRed = (textAlpha >> 1) + 128;
-                D_800E0E4C[3].filterGreen = 255 - textAlpha;
-                D_800E0E4C[3].filterBlue = 255 - textAlpha;
+                gRecordTimesMenuElements[3].filterRed = (textAlpha >> 1) + 128;
+                gRecordTimesMenuElements[3].filterGreen = 255 - textAlpha;
+                gRecordTimesMenuElements[3].filterBlue = 255 - textAlpha;
             } else {
-                D_800E0E4C[3].filterRed = 128;
-                D_800E0E4C[3].filterGreen = 255;
-                D_800E0E4C[3].filterBlue = 255;
+                gRecordTimesMenuElements[3].filterRed = 128;
+                gRecordTimesMenuElements[3].filterGreen = 255;
+                gRecordTimesMenuElements[3].filterBlue = 255;
             }
             break;
         case 6:
@@ -8788,12 +8788,12 @@ void func_80094D28(UNUSED s32 updateRate) {
         if (gTrophyRaceWorldId == 0) {
             camEnableUserView(0, TRUE);
             if (osTvType == TV_TYPE_PAL) {
-                D_800DF454 = 1.2f;
+                gTrackSelectWoodFrameHeightScale = 1.2f;
             }
             if (gMenuOptionCount > 0) {
                 func_8009CA60(4);
             }
-            D_800DF454 = 1.0f;
+            gTrackSelectWoodFrameHeightScale = 1.0f;
         }
     }
 }
@@ -8907,15 +8907,15 @@ s32 func_80095728(Gfx **dlist, MatrixS **matrices, Vertex **vertices, s32 update
                 if (get_map_race_type(settings->courseId) & RACETYPE_CHALLENGE) {
                     gMenuOptionCount = 6;
                 } else if (!settings->display_times) {
-                    func_80081E54(D_800E0CEC, 0.5f, 15.0f, 0.5f, sp38, sp34);
+                    func_80081E54(gRaceOrderMenuElements, 0.5f, 15.0f, 0.5f, sp38, sp34);
                     gMenuOptionCount = 3;
                 } else {
                     racer = &settings->racers[settings->timeTrialRacer];
-                    D_800E0BEC[3].unk14_a.numberU16 = &racer->lap_times[0];
-                    D_800E0BEC[4].unk14_a.numberU16 = &racer->lap_times[1];
-                    D_800E0BEC[5].unk14_a.numberU16 = &racer->lap_times[2];
-                    D_800E0BEC[6].unk14_a.numberU16 = &racer->course_time;
-                    func_80081E54(D_800E0BEC, 0.5f, 15.0f, 0.5f, sp38, sp34);
+                    gRaceResultsMenuElements[3].unk14_a.numberU16 = &racer->lap_times[0];
+                    gRaceResultsMenuElements[4].unk14_a.numberU16 = &racer->lap_times[1];
+                    gRaceResultsMenuElements[5].unk14_a.numberU16 = &racer->lap_times[2];
+                    gRaceResultsMenuElements[6].unk14_a.numberU16 = &racer->course_time;
+                    func_80081E54(gRaceResultsMenuElements, 0.5f, 15.0f, 0.5f, sp38, sp34);
                     gMenuOptionCount = 2;
                 }
             }
@@ -8927,24 +8927,24 @@ s32 func_80095728(Gfx **dlist, MatrixS **matrices, Vertex **vertices, s32 update
                     transition_begin(&sMenuTransitionFadeIn);
                     gMenuOptionCount = 8;
                 } else if (settings->display_times) {
-                    D_800E0E4C[3].unk14_a.numberU16 = &settings->courseTimesPtr[*gPlayerSelectVehicle][settings->courseId];
-                    D_800E0E4C[6].unk14_a.numberU16 = &settings->flapTimesPtr[*gPlayerSelectVehicle][settings->courseId];
+                    gRecordTimesMenuElements[3].unk14_a.numberU16 = &settings->courseTimesPtr[*gPlayerSelectVehicle][settings->courseId];
+                    gRecordTimesMenuElements[6].unk14_a.numberU16 = &settings->flapTimesPtr[*gPlayerSelectVehicle][settings->courseId];
                     decompress_filename_string(settings->courseInitialsPtr[*gPlayerSelectVehicle][settings->courseId], D_80126390, 3);
                     decompress_filename_string(settings->flapInitialsPtr[*gPlayerSelectVehicle][settings->courseId], D_80126394, 3);
                     if (settings->racers[0].best_times != 0) {
                         gMenuOptionCount = 4;
                         if ((gIsInTracksMode == 0) && (D_800E0FAC)) {
-                            decompress_filename_string(settings->filename, D_800E0FA8, 3);
+                            decompress_filename_string(settings->filename, gCheckAdvEnterInitials, 3);
                             D_800E0FAC = 0;
                         }
-                        func_80097874(sp38 + 196, 160, sp38 + 120, 2, &D_800E0FA4, D_800E0FA8, 3);
+                        func_80097874(sp38 + 196, 160, sp38 + 120, 2, &D_800E0FA4, gCheckAdvEnterInitials, 3);
                     } else {
-                        func_80081E54(D_800E0E4C, 0.5f, 15.0f, 0.5f, sp38, sp34);
+                        func_80081E54(gRecordTimesMenuElements, 0.5f, 15.0f, 0.5f, sp38, sp34);
                         gMenuOptionCount = 5;
                     }
                 } else {
                     gMenuOptionCount = 3;
-                    func_80081E54(D_800E0CEC, 0.5f, 15.0f, 0.5f, sp38, sp34);
+                    func_80081E54(gRaceOrderMenuElements, 0.5f, 15.0f, 0.5f, sp38, sp34);
                 }
             }
             break;
@@ -8956,14 +8956,14 @@ s32 func_80095728(Gfx **dlist, MatrixS **matrices, Vertex **vertices, s32 update
         case 4:
             if (menu_enter_filename_loop(updateRate) != 0) {
                 if (settings->racers[0].best_times & 0x7F) {
-                    settings->flapInitialsPtr[*gPlayerSelectVehicle][settings->courseId] = compress_filename_string(D_800E0FA8, 3);
+                    settings->flapInitialsPtr[*gPlayerSelectVehicle][settings->courseId] = compress_filename_string(gCheckAdvEnterInitials, 3);
                     decompress_filename_string(settings->flapInitialsPtr[*gPlayerSelectVehicle][settings->courseId], D_80126394, 3);
                 }
                 if (settings->racers[0].best_times & 0x80) {
-                    settings->courseInitialsPtr[*gPlayerSelectVehicle][settings->courseId] = compress_filename_string(D_800E0FA8, 3);
+                    settings->courseInitialsPtr[*gPlayerSelectVehicle][settings->courseId] = compress_filename_string(gCheckAdvEnterInitials, 3);
                     decompress_filename_string(settings->courseInitialsPtr[*gPlayerSelectVehicle][settings->courseId], D_80126390, 3);
                 }
-                func_80081E54(D_800E0E4C, 0.5f, 15.0f, 0.5f, sp38, sp34);
+                func_80081E54(gRecordTimesMenuElements, 0.5f, 15.0f, 0.5f, sp38, sp34);
                 gMenuOptionCount = 5;
             }
             break;
@@ -9149,16 +9149,16 @@ void func_80096790(void) {
     s8 *temp2;
 
     temp2 = (s8 *)get_current_level_header();
-    func_8009C4A8(D_800E0A24);
+    func_8009C4A8(gRaceResultsObjectIndices);
     temp = *temp2 - 1;
 
     if (D_80126BB8) {
-        func_8009C508(D_800E0710[temp * 3]);
+        func_8009C508(gTracksMenuBgTextureIndices[temp * 3]);
     }
     D_80126BB8 = 0;
 
     if (D_80126BBC) {
-        func_8009C508(D_800E0710[(temp * 3) + 1]);
+        func_8009C508(gTracksMenuBgTextureIndices[(temp * 3) + 1]);
     }
     D_80126BBC = 0;
 
@@ -9197,8 +9197,8 @@ void menu_results_init(void) {
     gMenuOption = 0;
     gIgnorePlayerInputTime = 1;
     gMenuSubOption = 0;
-    func_8009C674(D_800E0A24);
-    allocate_menu_images(D_800E0A40);
+    func_8009C674(gRaceResultsObjectIndices);
+    allocate_menu_images(gRaceResultsImageIndices);
     assign_racer_portrait_textures();
     load_font(ASSET_FONTS_BIGFONT);
     transition_begin(&sMenuTransitionFadeOut);
@@ -9320,7 +9320,7 @@ s32 menu_results_loop(s32 updateRate) {
 }
 
 void func_800976CC(void) {
-    func_8009C4A8(D_800E0A24);
+    func_8009C4A8(gRaceResultsObjectIndices);
     unload_font(ASSET_FONTS_BIGFONT);
 }
 
@@ -9422,14 +9422,14 @@ void trim_filename_string(char* input, char* output) {
 }
 
 void func_80097874(s32 arg0, s32 arg1, s32 arg2, s32 arg3, s32 *arg4, char *fileName, s32 fileNameLength) {
-    D_800E0F90 = arg0;
-    D_800E0F94 = arg1;
-    D_800E0F98 = arg2;
-    D_800E0F9C = arg3;
+    gEnterInitalsY = arg0;
+    gFilenameX = arg1;
+    gFilenameY = arg2;
+    gFilenameFont = arg3;
     D_80126C6C = arg4;
     D_80126C74 = fileName;
     D_80126C78 = fileNameLength;
-    D_800E0FA0 = 0;
+    gCurrentFilenameChars = 0;
     D_80126C50 = (f32) *D_80126C6C;
     D_80126C48 = FALSE;
     D_80126C3C = 0;
@@ -9461,13 +9461,13 @@ void render_enter_filename_ui(UNUSED s32 updateRate) {
 
     // Draw "Enter Initials" shadow
     set_text_colour(0, 0, 0, 255, 128);
-    draw_text(&sMenuCurrDisplayList, SCREEN_WIDTH_HALF + 2, D_800E0F90 - 22, gMenuText[ASSET_MENU_TEXT_ENTERINITIALS], ALIGN_MIDDLE_CENTER);
+    draw_text(&sMenuCurrDisplayList, SCREEN_WIDTH_HALF + 2, gEnterInitalsY - 22, gMenuText[ASSET_MENU_TEXT_ENTERINITIALS], ALIGN_MIDDLE_CENTER);
 
     // Draw "Enter Initials" text
     set_text_colour(255, 128, 255, 96, 255);
-    draw_text(&sMenuCurrDisplayList, SCREEN_WIDTH_HALF, D_800E0F90 - 24, gMenuText[ASSET_MENU_TEXT_ENTERINITIALS], ALIGN_MIDDLE_CENTER);
+    draw_text(&sMenuCurrDisplayList, SCREEN_WIDTH_HALF, gEnterInitalsY - 24, gMenuText[ASSET_MENU_TEXT_ENTERINITIALS], ALIGN_MIDDLE_CENTER);
 
-    y = D_800E0F90;
+    y = gEnterInitalsY;
     
     // Doesn't match with a for loop.
     i = 0;
@@ -9497,8 +9497,8 @@ void render_enter_filename_ui(UNUSED s32 updateRate) {
             }
             if (charIndex < 28) {
                 set_text_font(ASSET_FONTS_BIGFONT);
-                D_800E0F8C = gFileNameValidChars[charIndex];
-                draw_text(&sMenuCurrDisplayList, x, y, &D_800E0F8C, ALIGN_MIDDLE_CENTER);
+                gCurFilenameCharBeingDrawn = gFileNameValidChars[charIndex];
+                draw_text(&sMenuCurrDisplayList, x, y, &gCurFilenameCharBeingDrawn, ALIGN_MIDDLE_CENTER);
             } else {
                 set_text_font(ASSET_FONTS_FUNFONT);
                 if (charIndex == 28) {
@@ -9518,11 +9518,11 @@ void render_enter_filename_ui(UNUSED s32 updateRate) {
     trim_filename_string(D_80126C74, trimmedTextPtr);
 
     if (trimmedTextPtr != NULL) {
-        set_text_font(D_800E0F9C);
+        set_text_font(gFilenameFont);
         set_text_colour(0, 0, 0, 255, 128);
-        draw_text(&sMenuCurrDisplayList, D_800E0F94 + 1, D_800E0F98 + 3, trimmedTextBuffer, ALIGN_MIDDLE_CENTER);
+        draw_text(&sMenuCurrDisplayList, gFilenameX + 1, gFilenameY + 3, trimmedTextBuffer, ALIGN_MIDDLE_CENTER);
         set_text_colour(255, 255, 255, 0, 255);
-        draw_text(&sMenuCurrDisplayList, D_800E0F94, D_800E0F98, trimmedTextBuffer, ALIGN_MIDDLE_CENTER);
+        draw_text(&sMenuCurrDisplayList, gFilenameX, gFilenameY, trimmedTextBuffer, ALIGN_MIDDLE_CENTER);
     }
 }
 
@@ -9599,25 +9599,25 @@ s32 menu_enter_filename_loop(s32 updateRate) {
             } while (D_80126C50 < 0.0f);
         }
     }
-    if (D_800E0FA0 < D_80126C78) {
+    if (gCurrentFilenameChars < D_80126C78) {
         if (buttonsPressed & (A_BUTTON | START_BUTTON)) {
             if (*temp_a1 < 29) {
-                D_80126C74[D_800E0FA0] = gFileNameValidChars[*temp_a1];
-                D_800E0FA0++;
-                D_80126C74[D_800E0FA0] = '\0';
+                D_80126C74[gCurrentFilenameChars] = gFileNameValidChars[*temp_a1];
+                gCurrentFilenameChars++;
+                D_80126C74[gCurrentFilenameChars] = '\0';
                 play_sound_global(SOUND_SELECT2, NULL);
-                if (D_800E0FA0 >= D_80126C78) {
+                if (gCurrentFilenameChars >= D_80126C78) {
                     *D_80126C6C = 30;
                 }
             } else if (*temp_a1 == 29) {
-                if (D_800E0FA0 > 0) {
-                    D_800E0FA0--;
-                    D_80126C74[D_800E0FA0] = '\0';
+                if (gCurrentFilenameChars > 0) {
+                    gCurrentFilenameChars--;
+                    D_80126C74[gCurrentFilenameChars] = '\0';
                 }
                 play_sound_global(SOUND_MENU_BACK3, NULL);
             } else {
-                if ((D_800E0FA0 != 0) || (D_80126C74[0] == '\0')) {
-                    for (var_v1 = D_800E0FA0; var_v1 < D_80126C78; var_v1++) {
+                if ((gCurrentFilenameChars != 0) || (D_80126C74[0] == '\0')) {
+                    for (var_v1 = gCurrentFilenameChars; var_v1 < D_80126C78; var_v1++) {
                         D_80126C74[var_v1] = 32;
                     }
                 }
@@ -9626,10 +9626,10 @@ s32 menu_enter_filename_loop(s32 updateRate) {
                 D_80126C48 = TRUE;
             }
         } else if (buttonsPressed & B_BUTTON) {
-            if (D_800E0FA0 > 0) {
-                D_800E0FA0--;
+            if (gCurrentFilenameChars > 0) {
+                gCurrentFilenameChars--;
             }
-            D_80126C74[D_800E0FA0] = '\0';
+            D_80126C74[gCurrentFilenameChars] = '\0';
             play_sound_global(SOUND_MENU_BACK3, NULL);
         } else {
             var_v0_2 = *temp_a1;
@@ -9654,8 +9654,8 @@ s32 menu_enter_filename_loop(s32 updateRate) {
         play_sound_global(SOUND_SELECT2, NULL);
         D_80126C48 = TRUE;
     } else if (buttonsPressed & B_BUTTON) {
-        D_800E0FA0--;
-        D_80126C74[D_800E0FA0] = '\0';
+        gCurrentFilenameChars--;
+        D_80126C74[gCurrentFilenameChars] = '\0';
         play_sound_global(SOUND_MENU_BACK3, NULL);
     }
     render_enter_filename_ui(updateRate);
@@ -9677,7 +9677,7 @@ void func_80098208(void) {
     settings->unk4C->unk0 = settings->courseId;
     settings->unk4C->unkF = 0;
     settings->unk4C->unk1 = 0;
-    D_800DF450 = 1;
+    gInAdvModeTrophyRace = 1;
     set_time_trial_enabled(0);
 }
 
@@ -9789,7 +9789,7 @@ s32 menu_trophy_race_round_loop(s32 updateRate) {
     if (gMenuDelay >= 31) {
         unload_big_font_5();
         gTrackIdToLoad = trackMenuIds[(((gTrophyRaceWorldId - 1) * 6) + gTrophyRaceRound)];
-        D_800DF478 = 1;
+        unused_800DF478 = 1;
         return gNumberOfActivePlayers;
     }
     gIgnorePlayerInputTime = 0;
@@ -9828,8 +9828,8 @@ void menu_trophy_race_rankings_init(void) {
     gOptionBlinkTimer = 0;
     gOpacityDecayTimer = 0;
     reset_controller_sticks();
-    func_8009C674(D_800E1024);
-    allocate_menu_images(D_800E1040);
+    func_8009C674(gGhostDataObjectIndices);
+    allocate_menu_images(gGhostDataImageIndices);
     gPrevTrophyRaceRound = gTrophyRaceRound;
     do {
         if(++gTrophyRaceRound >= 4) break;
@@ -9903,7 +9903,7 @@ void menu_trophy_race_rankings_init(void) {
     play_music(SEQUENCE_MAIN_MENU);
     set_music_fade_timer(256);
     func_80098774(0);
-    func_80081E54(*D_800E1048, 0.5f, 20.0f, 0.5f, 0, 0);
+    func_80081E54(*gTrophyRankingsTitle, 0.5f, 20.0f, 0.5f, 0, 0);
 }
 
 void func_80098EBC(s32 arg0) {
@@ -9922,13 +9922,13 @@ void func_80098EBC(s32 arg0) {
         if ((gNumberOfActivePlayers < 3) && (((gMenuOptionCount == 0) && D_80126418[i]) || ((gMenuOptionCount != 0) && D_80126420[i]))) {
             fade = (test >> 1) + 0x80;
         }
-        D_800E1088[i][0].filterRed = fade;
-        D_800E1088[i][0].filterGreen = fade;
-        D_800E1088[i][0].filterBlue = fade;
+        gTrophyRankingsCharDetails[i][0].filterRed = fade;
+        gTrophyRankingsCharDetails[i][0].filterGreen = fade;
+        gTrophyRankingsCharDetails[i][0].filterBlue = fade;
     }
     new_var2 = gMenuOptionCount;
     if ((new_var2 == 2) || (new_var2 == 3)) {
-        draw_menu_elements(1, D_800E1048[0], 1.0f);
+        draw_menu_elements(1, gTrophyRankingsTitle[0], 1.0f);
     }
 }
 
@@ -9956,13 +9956,13 @@ s32 menu_trophy_race_rankings_loop(s32 updateRate) {
         if (func_80081F4C(updateRate) != 0) {
             gMenuOptionCount = 1;
             func_80098774(1);
-            func_80081E54(*D_800E1048, 0.5f, 0.0f, 0.0f, 0, 0);
+            func_80081E54(*gTrophyRankingsTitle, 0.5f, 0.0f, 0.0f, 0, 0);
         }
         break;
     case 1:
         if (func_80081F4C(updateRate) != 0) {
             gMenuOptionCount = 2;
-            draw_menu_elements(1, *D_800E1048, 1.0f);
+            draw_menu_elements(1, *gTrophyRankingsTitle, 1.0f);
         }
         break;
     case 2:
@@ -10047,8 +10047,8 @@ s32 menu_trophy_race_rankings_loop(s32 updateRate) {
                 } else {
                     ret = MENU_RESULT_RETURN_TO_GAME;
                     settings->courseId = get_hub_area_id(settings->worldId);
-                    if (D_800DF450 != 0) {
-                        D_800DF450 = 0;
+                    if (gInAdvModeTrophyRace != 0) {
+                        gInAdvModeTrophyRace = 0;
                         ret = settings->courseId | MENU_RESULT_FLAGS_200;
                         if (sp34 < 3) {
                             temp0 = settings->worldId - 1;
@@ -10080,7 +10080,7 @@ s32 menu_trophy_race_rankings_loop(s32 updateRate) {
 }
 
 void func_80099600(void) {
-    func_8009C4A8(D_800E1024);
+    func_8009C4A8(gGhostDataObjectIndices);
     unload_font(ASSET_FONTS_BIGFONT);
 }
 
@@ -10148,36 +10148,36 @@ void menu_ghost_data_init(void) {
     func_8009C674(&D_800E1708);
     allocate_menu_images(&D_800E174C);
     load_font(ASSET_FONTS_BIGFONT);
-    D_800E153C[0].texture = gMenuTextures[TEXTURE_BACKGROUND_DINO_DOMAIN_TOP];
-    D_800E153C[5].texture = gMenuTextures[TEXTURE_BACKGROUND_DINO_DOMAIN_BOTTOM];
-    D_800E1594[0].texture = gMenuTextures[TEXTURE_BACKGROUND_SHERBERT_ISLAND_TOP];
-    D_800E1594[5].texture = gMenuTextures[TEXTURE_BACKGROUND_SHERBERT_ISLAND_BOTTOM];
-    D_800E15EC[0].texture = gMenuTextures[TEXTURE_BACKGROUND_SNOWFLAKE_MOUNTAIN_TOP];
-    D_800E15EC[5].texture = gMenuTextures[TEXTURE_BACKGROUND_SNOWFLAKE_MOUNTAIN_BOTTOM];
-    D_800E1644[0].texture = gMenuTextures[TEXTURE_BACKGROUND_DRAGON_FOREST_TOP];
-    D_800E1644[5].texture = gMenuTextures[TEXTURE_BACKGROUND_DRAGON_FOREST_BOTTOM];
-    D_800E169C[0].texture = gMenuTextures[TEXTURE_BACKGROUND_FUTURE_FUN_LAND_TOP];
-    D_800E169C[5].texture = gMenuTextures[TEXTURE_BACKGROUND_FUTURE_FUN_LAND_BOTTOM];
+    gDrawTexDinoDomainGhostBg[0].texture = gMenuObjects[TEXTURE_BACKGROUND_DINO_DOMAIN_TOP];
+    gDrawTexDinoDomainGhostBg[5].texture = gMenuObjects[TEXTURE_BACKGROUND_DINO_DOMAIN_BOTTOM];
+    gDrawTexSherbetIslandGhostBg[0].texture = gMenuObjects[TEXTURE_BACKGROUND_SHERBERT_ISLAND_TOP];
+    gDrawTexSherbetIslandGhostBg[5].texture = gMenuObjects[TEXTURE_BACKGROUND_SHERBERT_ISLAND_BOTTOM];
+    gDrawTexSnowflakeMountainGhostBg[0].texture = gMenuObjects[TEXTURE_BACKGROUND_SNOWFLAKE_MOUNTAIN_TOP];
+    gDrawTexSnowflakeMountainGhostBg[5].texture = gMenuObjects[TEXTURE_BACKGROUND_SNOWFLAKE_MOUNTAIN_BOTTOM];
+    gDrawTexDragonForestGhostBg[0].texture = gMenuObjects[TEXTURE_BACKGROUND_DRAGON_FOREST_TOP];
+    gDrawTexDragonForestGhostBg[5].texture = gMenuObjects[TEXTURE_BACKGROUND_DRAGON_FOREST_BOTTOM];
+    gDrawTexFutureFunLandGhostBg[0].texture = gMenuObjects[TEXTURE_BACKGROUND_FUTURE_FUN_LAND_TOP];
+    gDrawTexFutureFunLandGhostBg[5].texture = gMenuObjects[TEXTURE_BACKGROUND_FUTURE_FUN_LAND_BOTTOM];
     for (i = 0; i < 4; i++) {
-        D_800E153C[i + 1].texture = D_800E153C[0].texture;
-        D_800E153C[i + 6].texture = D_800E153C[5].texture;
+        gDrawTexDinoDomainGhostBg[i + 1].texture = gDrawTexDinoDomainGhostBg[0].texture;
+        gDrawTexDinoDomainGhostBg[i + 6].texture = gDrawTexDinoDomainGhostBg[5].texture;
         if (i & 1 == 1) {
-            D_800E1594[i + 1].texture = D_800E1594[0].texture;
-            D_800E1594[i + 6].texture = D_800E1594[5].texture;
+            gDrawTexSherbetIslandGhostBg[i + 1].texture = gDrawTexSherbetIslandGhostBg[0].texture;
+            gDrawTexSherbetIslandGhostBg[i + 6].texture = gDrawTexSherbetIslandGhostBg[5].texture;
         } else {
-            D_800E1594[i + 1].texture = D_800E1594[5].texture;
-            D_800E1594[i + 6].texture = D_800E1594[0].texture;
+            gDrawTexSherbetIslandGhostBg[i + 1].texture = gDrawTexSherbetIslandGhostBg[5].texture;
+            gDrawTexSherbetIslandGhostBg[i + 6].texture = gDrawTexSherbetIslandGhostBg[0].texture;
         }
-        D_800E15EC[i + 1].texture = D_800E15EC[0].texture;
-        D_800E15EC[i + 6].texture = D_800E15EC[5].texture;
-        D_800E1644[i + 1].texture = D_800E1644[0].texture;
-        D_800E1644[i + 6].texture = D_800E1644[5].texture;
+        gDrawTexSnowflakeMountainGhostBg[i + 1].texture = gDrawTexSnowflakeMountainGhostBg[0].texture;
+        gDrawTexSnowflakeMountainGhostBg[i + 6].texture = gDrawTexSnowflakeMountainGhostBg[5].texture;
+        gDrawTexDragonForestGhostBg[i + 1].texture = gDrawTexDragonForestGhostBg[0].texture;
+        gDrawTexDragonForestGhostBg[i + 6].texture = gDrawTexDragonForestGhostBg[5].texture;
         if (i & 1 == 1) {
-            D_800E169C[i + 1].texture = D_800E169C[0].texture;
-            D_800E169C[i + 6].texture = D_800E169C[5].texture;
+            gDrawTexFutureFunLandGhostBg[i + 1].texture = gDrawTexFutureFunLandGhostBg[0].texture;
+            gDrawTexFutureFunLandGhostBg[i + 6].texture = gDrawTexFutureFunLandGhostBg[5].texture;
         } else {
-            D_800E169C[i + 1].texture = D_800E169C[5].texture;
-            D_800E169C[i + 6].texture = D_800E169C[0].texture;
+            gDrawTexFutureFunLandGhostBg[i + 1].texture = gDrawTexFutureFunLandGhostBg[5].texture;
+            gDrawTexFutureFunLandGhostBg[i + 6].texture = gDrawTexFutureFunLandGhostBg[0].texture;
         }
     }
     assign_vehicle_icon_textures();
@@ -10239,7 +10239,7 @@ void func_80099E8C(UNUSED s32 updateRate) {
     set_text_font(FONT_SMALL);
     x = 40;
     while (spE4 < D_801264D4 && spE8 > 0) {
-        if (((!D_800E1754) && (!D_800E1754)) && (!D_800E1754)){} // Fakematch
+        if (((!gGhostDataElementPositions) && (!gGhostDataElementPositions)) && (!gGhostDataElementPositions)){} // Fakematch
 
         currentWorldId = get_map_world_id(D_80126508[spE4]) - 1;
         if (currentWorldId < 0 || currentWorldId >= 5) {
@@ -10253,18 +10253,18 @@ void func_80099E8C(UNUSED s32 updateRate) {
             }
         }
         textBuffer[i] = '\0'; // Set NULL terminator
-        render_texture_rectangle_scaled(&sMenuCurrDisplayList, D_800E16F4[currentWorldId], x, y, 0.75f, 0.8125f, COLOUR_RGBA32(255, 255, 255, 255), 0);
+        render_texture_rectangle_scaled(&sMenuCurrDisplayList, gDrawTexWorldBgs[currentWorldId], x, y, 0.75f, 0.8125f, COLOUR_RGBA32(255, 255, 255, 255), 0);
         func_80080E90(&sMenuCurrDisplayList, 40, y, 240, 52, 4, 4, 32, 80, 176, 128);
         if (spE4 == D_80126498) {
             func_80080E90(&sMenuCurrDisplayList, 40, y, 240, 52, 4, 4, colourIntensity, colourIntensity, colourIntensity, colourIntensity);
         }
         set_text_colour(0, 0, 0, 255, 255);
         for(i = 0; i < 4; i++) {
-            draw_text(&sMenuCurrDisplayList, D_800E1754[0] + 40 + D_800E1E20[(i<<1)], y + D_800E1754[1] + D_800E1E20[(i<<1)+1], textBuffer, ALIGN_MIDDLE_CENTER);
+            draw_text(&sMenuCurrDisplayList, gGhostDataElementPositions[0] + 40 + D_800E1E20[(i<<1)], y + gGhostDataElementPositions[1] + D_800E1E20[(i<<1)+1], textBuffer, ALIGN_MIDDLE_CENTER);
         }
         set_text_colour(200, 228, 80, 255, 255);
-        draw_text(&sMenuCurrDisplayList, D_800E1754[0] + 40, D_800E1754[1] + y, textBuffer, ALIGN_MIDDLE_CENTER);
-        render_textured_rectangle(&sMenuCurrDisplayList, gRacerPortraits[D_80126510[spE4]], D_800E1754[2] + 40, D_800E1754[3] + y, 255, 255, 255, 255);
+        draw_text(&sMenuCurrDisplayList, gGhostDataElementPositions[0] + 40, gGhostDataElementPositions[1] + y, textBuffer, ALIGN_MIDDLE_CENTER);
+        render_textured_rectangle(&sMenuCurrDisplayList, gRacerPortraits[D_80126510[spE4]], gGhostDataElementPositions[2] + 40, gGhostDataElementPositions[3] + y, 255, 255, 255, 255);
         switch (D_80126518[spE4]) {
             case 1:
                 vehicleSelectTex = gRaceSelectionHoverTex;
@@ -10276,17 +10276,17 @@ void func_80099E8C(UNUSED s32 updateRate) {
                 vehicleSelectTex = gRaceSelectionCarTex;
                 break;
         }
-        render_texture_rectangle_scaled(&sMenuCurrDisplayList, vehicleSelectTex, (D_800E1754[4] + 40), (D_800E1754[5] + y), 0.625f, 0.625f, COLOUR_RGBA32(255, 255, 255, 255), 0);
+        render_texture_rectangle_scaled(&sMenuCurrDisplayList, vehicleSelectTex, (gGhostDataElementPositions[4] + 40), (gGhostDataElementPositions[5] + y), 0.625f, 0.625f, COLOUR_RGBA32(255, 255, 255, 255), 0);
         reset_render_settings(&sMenuCurrDisplayList);
-        gMenuImageStack[7].unkC = (D_800E1754[6] - SCREEN_HEIGHT_HALF);
-        gMenuImageStack[7].unk10 = ((-D_800E1754[7] - y) + heightAdjust + SCREEN_HEIGHT_HALF);
+        gMenuImageStack[7].unkC = (gGhostDataElementPositions[6] - SCREEN_HEIGHT_HALF);
+        gMenuImageStack[7].unk10 = ((-gGhostDataElementPositions[7] - y) + heightAdjust + SCREEN_HEIGHT_HALF);
         gMenuImageStack[7].unk8 = 0.075f;
         func_8009CA60(7);
         sMenuGuiOpacity = 128;
         //Timestamp Shadow gets drawn first
-        show_timestamp(D_80126520[spE4], D_800E1754[8] - (SCREEN_HEIGHT_HALF - 1), (-D_800E1754[9] - y) + heightAdjust + (SCREEN_HEIGHT_HALF - 1), 0, 0, 0, FONT_COLOURFUL);
+        show_timestamp(D_80126520[spE4], gGhostDataElementPositions[8] - (SCREEN_HEIGHT_HALF - 1), (-gGhostDataElementPositions[9] - y) + heightAdjust + (SCREEN_HEIGHT_HALF - 1), 0, 0, 0, FONT_COLOURFUL);
         sMenuGuiOpacity = 255;
-        show_timestamp(D_80126520[spE4], D_800E1754[8] - (SCREEN_HEIGHT_HALF + 1), (-D_800E1754[9] - y) + heightAdjust + (SCREEN_HEIGHT_HALF + 1), 255, 192, 255, FONT_COLOURFUL);
+        show_timestamp(D_80126520[spE4], gGhostDataElementPositions[8] - (SCREEN_HEIGHT_HALF + 1), (-gGhostDataElementPositions[9] - y) + heightAdjust + (SCREEN_HEIGHT_HALF + 1), 255, 192, 255, FONT_COLOURFUL);
         spE4++;
         spE8--;
         y += 54;
@@ -10467,7 +10467,7 @@ void func_8009ABD8(s8 *arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4, s8 *arg5) {
 
 void menu_cinematic_init(void) {
     if (D_80126804 != NULL) {
-        func_8009C674(D_800E1768);
+        func_8009C674(gIntroCinematicObjectIndices);
         assign_racer_portrait_textures();
     }
     load_level_for_menu(D_801267EC[0], D_801267EC[1], D_801267EC[2]);
@@ -10518,7 +10518,7 @@ s32 menu_cinematic_loop(UNUSED s32 updateRate) {
 
 void func_8009AF18(void) {
     if (D_80126804 != NULL) {
-        func_8009C4A8(D_800E1768);
+        func_8009C4A8(gIntroCinematicObjectIndices);
     }
 }
 
@@ -10538,7 +10538,7 @@ void menu_credits_init(void) {
     D_80126BCC = 0;
     gMenuOptionCount = 0;
     gOpacityDecayTimer = 40;
-    D_800DF460 = 0;
+    gMenuCurIndex = 0;
     D_80126BD0 = 0;
     D_80126BD8 = 0;
     D_80126BE0 = 0;
@@ -10552,8 +10552,8 @@ void menu_credits_init(void) {
     }
     copy_viewports_to_stack();
     camEnableUserView(0, 1);
-    func_8009C674(D_800E17D8);
-    allocate_menu_images(D_800E17F0);
+    func_8009C674(gCreditsObjectIndices);
+    allocate_menu_images(gCreditsImageIndices);
     assign_racer_portrait_textures();
     load_font(ASSET_FONTS_BIGFONT);
     set_music_player_voice_limit(24);
@@ -10621,7 +10621,7 @@ void func_8009BCF0(void) {
     disable_new_screen_transitions();
     camDisableUserView(0, FALSE);
     set_viewport_properties(0, VIEWPORT_AUTO, VIEWPORT_AUTO, VIEWPORT_AUTO, VIEWPORT_AUTO);
-    func_8009C4A8(D_800E17D8);
+    func_8009C4A8(gCreditsObjectIndices);
     unload_font(ASSET_FONTS_BIGFONT);
     set_D_800DD430(0);
 }
@@ -10769,14 +10769,14 @@ s32 get_save_file_index(void) {
  */
 s32 get_track_id_to_load(void) {
     Settings *settings = get_settings();
-    if (!gIsInTracksMode && D_800DF478 == 0) {
+    if (!gIsInTracksMode && unused_800DF478 == 0) {
         if (settings->newGame) {
             return 0;
         } else {
             return settings->courseId;
         }
     }
-    D_800DF478 = 0;
+    unused_800DF478 = 0;
     return gTrackIdToLoad;
 }
 
@@ -10919,7 +10919,7 @@ Settings **get_all_save_files_ptr(void) {
 }
 
 UNUSED void func_8009C49C(void) {
-    D_800DF488 = 0;
+    gTitleScreenLoaded = 0;
 }
 
 void func_8009C4A8(s16 *arg0) {
@@ -10931,29 +10931,29 @@ void func_8009C4A8(s16 *arg0) {
 
 void func_8009C508(s32 arg0) {
     if (D_80126750[arg0] != 0) {
-        if (gMenuTextures[arg0] != 0) {
-            if ((((*gAssetsMenuElementIds)[arg0] & 0xC000) == 0xC000) && (gMenuTextures[arg0] != 0)) {
+        if (gMenuObjects[arg0] != 0) {
+            if ((((*gAssetsMenuElementIds)[arg0] & 0xC000) == 0xC000) && (gMenuObjects[arg0] != 0)) {
                 set_free_queue_state(0);
-                free_texture(gMenuTextures[arg0]);
+                free_texture(gMenuObjects[arg0]);
                 set_free_queue_state(2);
             } else {
                 if ((*gAssetsMenuElementIds)[arg0] & 0x8000) {
-                    free_sprite((Sprite *) (u32) gMenuTextures[arg0]);
+                    free_sprite((Sprite *) (u32) gMenuObjects[arg0]);
                 } else {
                     if ((*gAssetsMenuElementIds)[arg0] & 0x4000) {
-                        free_object((Object *) (u32) gMenuTextures[arg0]);
+                        free_object((Object *) (u32) gMenuObjects[arg0]);
                     } else {
-                        func_8005FF40((ObjectModel**)(u32)gMenuTextures[arg0]);
+                        func_8005FF40((ObjectModel**)(u32)gMenuObjects[arg0]);
                     }
                 }
             }
         }
-        gMenuTextures[arg0] = 0;
+        gMenuObjects[arg0] = 0;
         D_80126750[arg0] = 0;
-        D_800DF758--;
+        gMenuObjectsCount--;
         gParticlePtrList_flush();
     }
-    if (D_800DF758 == 0) {
+    if (gMenuObjectsCount == 0) {
         if (gMenuImageStack != NULL) {
             free_from_memory_pool(gMenuImageStack);
             gMenuImageStack = NULL;
@@ -10961,7 +10961,7 @@ void func_8009C508(s32 arg0) {
         if (*gAssetsMenuElementIds != NULL) {
             free_from_memory_pool(*gAssetsMenuElementIds);
             *gAssetsMenuElementIds = NULL;
-            D_800DF754 = (u16)0;
+            gMenuElementIdCount = (u16)0;
         }
     }
 }
@@ -10979,9 +10979,9 @@ void func_8009C6D4(s32 arg0) {
     
     if (*gAssetsMenuElementIds == NULL) {
         *gAssetsMenuElementIds = (s16 *) load_asset_section_from_rom(ASSET_MENU_ELEMENT_IDS);
-        for(D_800DF754 = 0; (*gAssetsMenuElementIds)[D_800DF754] != -1; D_800DF754++){}
-        D_800DF758 = 0;
-        for(i = 0; i < D_800DF754; i++) {
+        for(gMenuElementIdCount = 0; (*gAssetsMenuElementIds)[gMenuElementIdCount] != -1; gMenuElementIdCount++){}
+        gMenuObjectsCount = 0;
+        for(i = 0; i < gMenuElementIdCount; i++) {
             D_80126750[i] = FALSE;
         }
     }
@@ -10991,23 +10991,23 @@ void func_8009C6D4(s32 arg0) {
         if (((!arg0) && (!arg0)) && (!arg0)){} // Fakematch
         
         if ((i & 0xC000) == 0xC000) {
-            gMenuTextures[arg0] = load_texture(i & 0x3FFF);
+            gMenuObjects[arg0] = load_texture(i & 0x3FFF);
         } else if (i & 0x8000) {
-            gMenuTextures[arg0] = func_8007C12C(i & 0x3FFF, 0);
+            gMenuObjects[arg0] = func_8007C12C(i & 0x3FFF, 0);
         } else if (i & 0x4000) {
-            if (D_800DF754){} // Fakematch
+            if (gMenuElementIdCount){} // Fakematch
             entry.objectID = i & 0xFFFF;
             entry.size = 8;
             entry.x = 0;
             entry.y = 0;
             entry.z = 0;
-            gMenuTextures[arg0] = spawn_object(&entry, 0);
+            gMenuObjects[arg0] = spawn_object(&entry, 0);
         } else {
-            gMenuTextures[arg0] = func_8005F99C(i & 0x3FFF, 0);
+            gMenuObjects[arg0] = func_8005F99C(i & 0x3FFF, 0);
         }
 
         D_80126750[arg0] = TRUE;
-        D_800DF758++;
+        gMenuObjectsCount++;
     }
 }
 
@@ -11048,11 +11048,11 @@ void func_8009CA60(s32 stackIndex) {
     Sprite *sprite;
     ObjectModel **temp;
     
-    if (gMenuTextures[gMenuImageStack[stackIndex].unk6] != 0) {
+    if (gMenuObjects[gMenuImageStack[stackIndex].unk6] != 0) {
         if (((*gAssetsMenuElementIds)[gMenuImageStack[stackIndex].unk6] & 0xC000) != 0xC000) {
             if ((*gAssetsMenuElementIds)[gMenuImageStack[stackIndex].unk6] & 0x4000) {
                 if (0) {} // Fakematch
-                new_var = (Object*)gMenuTextures[gMenuImageStack[stackIndex].unk6];
+                new_var = (Object*)gMenuObjects[gMenuImageStack[stackIndex].unk6];
                 new_var2 = (unk8009CA602 *) &gMenuImageStack[stackIndex];
                 new_var->segment.trans.y_rotation = new_var2->trans.y_rotation;
                 new_var->segment.trans.x_rotation = new_var2->trans.x_rotation;
@@ -11061,7 +11061,7 @@ void func_8009CA60(s32 stackIndex) {
                 new_var->segment.trans.y_position = new_var2->trans.y_position;
                 new_var->segment.trans.z_position = new_var2->trans.z_position;
                 new_var->segment.trans.scale = new_var2->trans.scale;
-                if (D_800DF468 == 0) {
+                if (ununsed_800DF468 == 0) {
                     new_var->segment.animFrame = new_var2->unk1D;
                     new_var->segment.object.modelIndex = new_var2->unk18;
                 }
@@ -11069,10 +11069,10 @@ void func_8009CA60(s32 stackIndex) {
                 render_object(&sMenuCurrDisplayList, &sMenuCurrHudMat, &sMenuCurrHudVerts, new_var);
             } else {
                 if ((*gAssetsMenuElementIds)[gMenuImageStack[stackIndex].unk6] & 0x8000) {
-                    sprite = (Sprite *) gMenuTextures[gMenuImageStack[stackIndex].unk6];
+                    sprite = (Sprite *) gMenuObjects[gMenuImageStack[stackIndex].unk6];
                     gDPSetPrimColor(sMenuCurrDisplayList++, 0, 0, sMenuGuiColourR, sMenuGuiColourG, sMenuGuiColourB, sMenuGuiOpacity);
                     gDPSetEnvColor(sMenuCurrDisplayList++, 255, 255, 255, 0);
-                    render_ortho_triangle_image(&sMenuCurrDisplayList, &sMenuCurrHudMat, &sMenuCurrHudVerts, (ObjectSegment *)(&gMenuImageStack[stackIndex]), sprite, D_800DF4B4);
+                    render_ortho_triangle_image(&sMenuCurrDisplayList, &sMenuCurrHudMat, &sMenuCurrHudVerts, (ObjectSegment *)(&gMenuImageStack[stackIndex]), sprite, gMenuSpriteFlags);
                     gDPSetPrimColor(sMenuCurrDisplayList++, 0, 0, 255, 255, 255, 255);
                 } else {
                     if (sMenuGuiOpacity < 255) {
@@ -11081,8 +11081,8 @@ void func_8009CA60(s32 stackIndex) {
                         gDPSetPrimColor(sMenuCurrDisplayList++, 0, 0, 255, 255, 255, 255);
                     };
                     gDPSetEnvColor(sMenuCurrDisplayList++, 255, 255, 255, 0);
-                    camera_push_model_mtx(&sMenuCurrDisplayList, &sMenuCurrHudMat, (ObjectTransform *) (&gMenuImageStack[stackIndex]), D_800DF454, 0);
-                    temp = ((ObjectModel **) gMenuTextures[gMenuImageStack[stackIndex].unk6]);
+                    camera_push_model_mtx(&sMenuCurrDisplayList, &sMenuCurrHudMat, (ObjectTransform *) (&gMenuImageStack[stackIndex]), gTrackSelectWoodFrameHeightScale, 0);
+                    temp = ((ObjectModel **) gMenuObjects[gMenuImageStack[stackIndex].unk6]);
                     render_track_selection_viewport_border(*temp);
                     apply_matrix_from_stack(&sMenuCurrDisplayList);
                     if (sMenuGuiOpacity < 255) {
@@ -11144,13 +11144,13 @@ void render_track_selection_viewport_border(ObjectModel *objMdl) {
 }
 
 void func_8009CF68(s32 arg0) {
-    if (D_800DF4E4[arg0] == 0) {
+    if (gDoneTalkingToNPC[arg0] == 0) {
         if (arg0 != 3) {
             sCurrentMenuID = 0;
             gDialogueSubmenu = 0;
         }
         gNeedToCloseDialogueBox = TRUE;
-        D_800DF4E4[arg0] = 1;
+        gDoneTalkingToNPC[arg0] = 1;
     }
 }
 
@@ -11173,7 +11173,7 @@ void try_close_dialogue_box(void) {
 s32 npc_dialogue_loop(u32 dialogueOption) {
     s32 result;
 
-    D_800DF4E4[dialogueOption] = 0;
+    gDoneTalkingToNPC[dialogueOption] = 0;
     if ((func_800C3400() != 0) && (dialogueOption != DIALOGUE_CHALLENGE)) {
         return 0;
     }
@@ -11261,7 +11261,7 @@ void handle_menu_joystick_input(void) {
 }
 
 void func_8009D324(void) {
-    D_800DF4D8 = 0;
+    unused_800DF4D8 = 0;
 }
 
 /**
@@ -11341,7 +11341,7 @@ s32 taj_menu_loop(void) {
             // Press A To Continue
             set_current_text(ASSET_GAME_TEXT_7);
             sCurrentMenuID = 1;
-            D_800DF4D8 = 1;
+            unused_800DF4D8 = 1;
             break;
         case 1:
             gNextTajChallengeMenu = 0;

--- a/src/menu.c
+++ b/src/menu.c
@@ -272,23 +272,37 @@ s32 D_80126CC0;
 
 /************ .data ************/
 
+// A boolean, set to TRUE if player has entered trophy race through adventure mode.
 s8 gInAdvModeTrophyRace = 0;
+
+// Height scale of the wooden frames in the track select menu.
 f32 gTrackSelectWoodFrameHeightScale = 1.0f;
+
 s32 gResetTitleScale = 1;
+
 s32 gTitleScreenCurrentOption = 0; // 0 = "Start", 1 = "Options"
-s32 gMenuCurIndex = 0; // Currently selected menu index? Reused in different menus.
-s32 ununsed_800DF464 = 4; // Currently unknown, might be a different type.
+
+// Currently selected index for all menus.
+s32 gMenuCurIndex = 0;
+
+s32 ununsed_800DF464 = 4; 
 s32 ununsed_800DF468 = 0;
+
+// Used as a short delay before printing the missing controller text.
 s32 gMissingControllerDelay = 0;
-s32 gCurrentMenuId = 0; // Currently unknown, might be a different type.
-s32 ununsed_800DF474 = 0;     // Currently unknown, might be a different type.
-s32 unused_800DF478 = 0;     // Currently unknown, might be a different type.
+
+s32 gCurrentMenuId = 0; 
+s32 ununsed_800DF474 = 0;
+
+// A boolean, set to TRUE when a track is loaded using gTrackIdToLoad.
+s32 gTrackSpecifiedWithTrackIdToLoad = 0; 
+
 s32 gMenuDelay = 0;
 s32 gNumberOfReadyPlayers = 0;
-s32 D_800DF484 = 0; // Currently unknown, might be a different type.
+s32 D_800DF484 = 0;
 s32 gTitleScreenLoaded = 0;
-s32 unused_800DF48C = 0; // Currently unknown, might be a different type.
-s32 unused_800DF490 = 0; // Currently unknown, might be a different type.
+s32 unused_800DF48C = 0;
+s32 unused_800DF490 = 0;
 s32 gIsInAdventureTwo = 0;
 s32 gPlayerHasSeenCautionMenu = 0;
 s32 *gMenuTextLangTable = NULL;
@@ -298,34 +312,40 @@ char **gMenuText = NULL;
 u8 sMenuGuiColourR = 0xFF;
 u8 sMenuGuiColourG = 0xFF;
 u8 sMenuGuiColourB = 0xFF;
+u8 sMenuGuiColourA = 0;
 
-u8  sMenuGuiColourA              = 0;
-s32 gMenuSpriteFlags              = 0;
+// Flags for menu/HUD sprites. Used in func_8009CA60()
+// Seems like it doesn't matter what you set it as?
+s32 gMenuSpriteFlags        = 0;
+
 s32 gIsInTracksMode         = 1;
 s32 gNumberOfActivePlayers  = 1;
 s32 gIsInTwoPlayerAdventure = 0;
-s32 gTrackIdForPreview    = ASSET_LEVEL_CENTRALAREAHUB;
+s32 gTrackIdForPreview      = ASSET_LEVEL_CENTRALAREAHUB;
 s32 gTrackSelectRow         = 0; // 1 = Dino Domain, 2 = Sherbet Island, etc.
 s32 gSaveFileIndex          = 0;
-s32 unused_800DF4D0              = 0; // Unused?
+s32 unused_800DF4D0         = 0; // Unused?
 s32 gTrackIdToLoad          = 0;
-s8 unused_800DF4D8               = 1;
+s8 unused_800DF4D8          = 1;
 s8 gNextTajChallengeMenu    = FALSE;
 s8 gNeedToCloseDialogueBox  = FALSE;
 
-s8 gDoneTalkingToNPC[4] = {
-    0, 0, 0, 0
+// Array of booleans, set to TRUE when you are done talking to an NPC.
+// This has (atleast) 5 elements, not 4!
+s8 gDoneTalkingToNPC[5] = {
+    FALSE, // Taj
+    FALSE, // Unused?
+    FALSE, // T.T.
+    FALSE, // Taj Challenge
+    FALSE // Trophy Cabinet
 };
 
-s32 D_800DF4E8 = 0; // Currently unknown, might be a different type.
 s8 gDialogueOptionTangible = FALSE;
 
-// Unused?
 s32 unused_800DF4F0[] = {
     0x4000, 0x8000, 0x1000, 0x2000, 0x8000, 0x10, 0x400, 0x00
 };
 
-//MenuElement?
 unk800DF510 sMenuImageProperties[18] = {
     { 0, 0, 0, 0x00,   1.0f, 0.0f,   0.0f,  -32.0f, 0, 0, 0, 0, 0, { 0 } },
     { 0, 0, 0, 0x01,   1.0f, 0.0f,   0.0f,  -32.0f, 0, 0, 0, 0, 0, { 0 } },
@@ -347,7 +367,7 @@ unk800DF510 sMenuImageProperties[18] = {
     { 0, 0, 0, 0x5D,   1.0f, 0.0f,   0.0f,    0.0f, 0, 0, 0, 0, 0, { 0 } },
 };
 
-s16 *gAssetsMenuElementIds[1] = { NULL }; // This is probably not correct.
+s16 *gAssetsMenuElementIds[1] = { NULL };
 s16 gMenuElementIdCount = 0;
 s16 gMenuObjectsCount = 0;
 unk800DF510 *gMenuImageStack = NULL;
@@ -364,15 +384,15 @@ UNUSED FadeTransition sMenuTransitionFadeOutWhite = FADE_TRANSITION(FADE_FULLSCR
 
 s32 gTrophyRankingsState = 4;
 MenuElement *gTrophyRankingsMenuElements = NULL;
-s32 gDrawMenuElementsYOffset = 0; //PAL Y Offset?
-
+s32 gDrawMenuElementsYOffset = 0;
 s32 gDrawMenuElementsYOffset2 = 0;
+
 char *gTitleMenuStrings[3] = { 0, 0, 0 };
 
 // Version text shown on the title screen? See 1:15 in https://www.youtube.com/watch?v=OHSCLcA74ao.
 char gVersionDisplayText[20] = "VERSION XXXXXXXX";
 
-// "Diddy Kong Racing" logo texture indices?
+// "Diddy Kong Racing" logo texture indices
 s16 sGameTitleTileTextures[12] = {
     TEXTURE_TITLE_SEGMENT_01,
     TEXTURE_TITLE_SEGMENT_02,
@@ -417,13 +437,15 @@ unk800DF83C gTitleCinematicText[10] = {
     { "DIDDY", 63.5f, 64.0f, 66.0f, 66.5f, -80.0f, SCREEN_HEIGHT_FLOAT - 32.0f, SCREEN_WIDTH_FLOAT_HALF, SCREEN_HEIGHT_FLOAT - 32.0f, SCREEN_WIDTH_FLOAT + 80.0f, SCREEN_HEIGHT_FLOAT - 32.0f }
 };
 
+// Number of active colours used in the title screen cinematic.
 s32 gTitleCinematicTextColourCount = 0;
 
+// Colours used for the Character Names during the title screen cinematic
 MenuColour gTitleCinematicTextColours[4] = {
-    { 255, 255, 0, 255, 204 },
-    { 0, 255, 0, 255, 153 },
-    { 0, 255, 255, 255, 102 },
-    { 0, 0, 255, 255, 51 }
+    { 255, 255,   0, 255, 204 }, // Yellow
+    {   0, 255,   0, 255, 153 }, // Green
+    {   0, 255, 255, 255, 102 }, // Cyan
+    {   0,   0, 255, 255,  51 }  // Blue
 };
 
 UNUSED u8 unused_800DFA10[4] = {
@@ -449,12 +471,13 @@ unk800DFA3C gAudioMenuStrings[8] = {
     {   0,   0,    0,    0,    0,    0,    0, 0, 0,  0, NULL },
 };
 
-s32 gMusicTestSongIndex = 0; // Currently unknown, might be a different type.
+// Current song index used in the music test (from JUKEBOX magic code) 
+s32 gMusicTestSongIndex = 0;
 
 s32 gSfxVolumeSliderValue = 256;   // Value from 0 to 256
 s32 gMusicVolumeSliderValue = 256; // Value from 0 to 256
 
-s32 gAudioOutputType = 0;
+StereoPanMode gAudioOutputType = 0;
 
 // This is used for RGBA colors for the save options Controller Pak BG.
 u32 gContPakSaveBgColours[MAXCONTROLLERS] = {
@@ -464,9 +487,10 @@ u32 gContPakSaveBgColours[MAXCONTROLLERS] = {
     COLOUR_RGBA32(64, 255, 64, 255)   // Green for controller 4
 };
 
-s32 D_800DFADC = 0; // Currently unknown, might be a different type.
-s32 D_800DFAE0 = 0; // Currently unknown, might be a different type.
+s32 D_800DFADC = 0;
+s32 D_800DFAE0 = 0;
 
+// Strings related to the controller pak.
 char *gContPakNotPresentStrings[6] = { 0, 0, 0, 0, 0, 0 };
 char *gContPakCorruptDataRepairStrings[6] = { 0, 0, 0, 0, 0, 0 };
 char *gContPakDamagedStrings[6] = { 0, 0, 0, 0, 0, 0 };
@@ -477,25 +501,23 @@ char *gContPakCorruptDataStrings[6] = { 0, 0, 0, 0, 0, 0 };
 char *gContPakRumbleDetectedStrings[6] = { 0, 0, 0, 0, 0, 0 };
 char *gContPakSwitchToRumbleStrings[6] = { 0, 0, 0, 0, 0, 0 };
 char *gContPakNeed2ndAdvStrings[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
-s32 gContPakStrings = 0;
 
-// Unused?
-char **D_800DFBE0[10] = {
-    gContPakNotPresentStrings, gContPakCorruptDataRepairStrings, gContPakDamagedStrings, gContPakFullStrings, gContPakDiffContStrings, gContPakNoRoomForGhostsStrings, gContPakRumbleDetectedStrings, gContPakSwitchToRumbleStrings, gContPakCorruptDataStrings, gContPakNeed2ndAdvStrings
+char **gContPakStrings[11] = {
+    NULL, gContPakNotPresentStrings, gContPakCorruptDataRepairStrings, gContPakDamagedStrings, gContPakFullStrings, gContPakDiffContStrings, gContPakNoRoomForGhostsStrings, gContPakRumbleDetectedStrings, gContPakSwitchToRumbleStrings, gContPakCorruptDataStrings, gContPakNeed2ndAdvStrings
 };
 
-s32 unused_800DFC08 = 0;      // Currently unknown, might be a different type.
-s32 unused_800DFC0C = 0xFFFF; // Currently unknown, might be a different type.
+s32 unused_800DFC08 = 0;     
+s32 unused_800DFC0C = 0xFFFF;
 
-DrawTexture D_800DFC10[2] = { { NULL, 0, 0 }, { NULL, 0, 0 } };
-DrawTexture D_800DFC20[2] = { { NULL, 0, 0 }, { NULL, 0, 0 } };
-DrawTexture D_800DFC30[2] = { { NULL, 0, 0 }, { NULL, 0, 0 } };
-DrawTexture D_800DFC40[2] = { { NULL, 0, 0 }, { NULL, 0, 0 } };
-DrawTexture D_800DFC50[2] = { { NULL, 0, 0 }, { NULL, 0, 0 } };
-DrawTexture D_800DFC60[2] = { { NULL, 0, 0 }, { NULL, 0, 0 } };
+/*** Icons in the save options menu. ***/
+DrawTexture gDrawTexN64Icon[2] = { { NULL, 0, 0 }, { NULL, 0, 0 } };
+DrawTexture gDrawTexTTIcon[2] = { { NULL, 0, 0 }, { NULL, 0, 0 } };
+DrawTexture gDrawTexGhostIcon[2] = { { NULL, 0, 0 }, { NULL, 0, 0 } };
+DrawTexture gDrawTexFileIcon[2] = { { NULL, 0, 0 }, { NULL, 0, 0 } };
+DrawTexture gDrawTexContPakIcon[2] = { { NULL, 0, 0 }, { NULL, 0, 0 } };
+DrawTexture gDrawTexTrashIcon[2] = { { NULL, 0, 0 }, { NULL, 0, 0 } };
 
-// Unused?
-u8 D_800DFC70[8] = { 0x40, 0x40, 0x04, 0x04, 0xFF, 0, 0, 0 };
+u8 unused_800DFC70[8] = { 0x40, 0x40, 0x04, 0x04, 0xFF, 0, 0, 0 };
 
 s16 gSaveMenuObjectIndices[26] = {
     0x0024, 0x0025, 0x0018, 0x0019,
@@ -507,7 +529,6 @@ s16 gSaveMenuObjectIndices[26] = {
     0xFFFF, 0x0000
 };
 
-//Image textures, likely for the below menu
 s16 gSaveMenuImageIndices[4] = {
     0x000B, 0x000C, 0x0002, 0xFFFF
 };
@@ -632,8 +653,18 @@ CharacterSelectData gCharacterSelectBytesComplete[] = {
 //!@bug T.T's down input selects Tiptup. It should be set to NONE.
 };
 
-s32 unused_800DFFCC = 0; // Likely unused.
+s32 unused_800DFFCC = 0;
+
+// Set from func_8008AEB4()
+// Is either 0, 1, or 2. However it is never set to 2?
+// Set to 0 upon entering the Character Select menu normally.
+// Set to 1 upon entering the Char Select from the 
+//   "Select Character" option on the "Pause Options" screen in a race.
 s32 gEnteredCharSelectFrom = 0;
+
+// Set from func_8008AEB4()
+// Set to the value *arg1 when arg0 is 2, but that never happens.
+// Not read from anywhere, so I'd consider this to be unused.
 s32 unused_800DFFD4 = -1;
 
 MenuElement gCautionMenuTextElements[14] = {
@@ -716,8 +747,17 @@ s16 gFileSelectElementPos[10] = {
 // Either 0 (2 racers), 1 (4 racers), or 2 (6 racers)
 s32 gMultiplayerSelectedNumberOfRacers = 0;
 
+// Highlighted option index for time trial in tracks mode.
+//   0 = Time Trial off
+//   1 = Time Trial on
 s32 gTracksMenuTimeTrialHighlightIndex = 0;
+
+// Highlighted option index for adventure 1 or 2 in tracks mode.
+//   0 = Adventure 1 (Normal)
+//   1 = Adventure 2 (Mirrored)
 s32 gTracksMenuAdventureHighlightIndex = 0;
+
+
 DrawTexture gMenuSelectionArrowUp[2] = { { NULL, -12, -8 }, { NULL, 0, 0 }};
 DrawTexture gMenuSelectionArrowLeft[2] = { { NULL, -8, -12 }, { NULL, 0, 0 }};
 DrawTexture gMenuSelectionArrowDown[2] = { { NULL, -12, -8 }, { NULL, 0, 0 }};
@@ -753,11 +793,11 @@ DrawTexture *gRaceSelectionImages[9] = {
 
 };
 
-DrawTexture *D_800E0648[6] = {
+DrawTexture *gTrackSelectTTImage[6] = {
     gRaceSelectionTTOff, gRaceSelectionTTOffOptHighlight, gRaceSelectionTTOffOpt, gRaceSelectionTTOn, gRaceSelectionTTOnOptHighlight, gRaceSelectionTTOnOpt
 };
 
-DrawTexture *D_800E0660[6] = {
+DrawTexture *gTrackSelectPlayerImage[6] = {
     gRaceSelectionPlayer1Texture, gRaceSelectionPlayer2Texture, gRaceSelectionPlayer3Texture, gRaceSelectionPlayer4Texture, gRaceSelectionVehicleTitleTexture, gRaceSelectionTTTitleTexture
 };
 
@@ -765,44 +805,58 @@ DrawTexture *gMenuSelectionArrows[4] = {
     gMenuSelectionArrowUp, gMenuSelectionArrowLeft, gMenuSelectionArrowDown, gMenuSelectionArrowRight
 };
 
+// X/Y offsets for the "Player" icon
 u16 gTracksMenuPlayerNamePositions[20] = {
-    0x44, 0x72, 0x44, 0x72,
-    0xCC, 0x72, 0x21, 0x72,
-    0x88, 0x72, 0xEF, 0x72,
-    0x21, 0x72, 0x66, 0x72,
-    0xAA, 0x72, 0xEF, 0x72,
+    // X, Y
+    0x44, 0x72,                                     // 1 player
+    0x44, 0x72, 0xCC, 0x72,                         // 2 players
+    0x21, 0x72, 0x88, 0x72, 0xEF, 0x72,             // 3 players
+    0x21, 0x72, 0x66, 0x72, 0xAA, 0x72, 0xEF, 0x72, // 4 players
 };
 
+// X offsets for "Car", "Hover", and "Plane" choices in track select.
 u16 gTracksMenuVehicleNamePositions[10] = {
-    0x68, 0x21, 0xFB, 0x27, 0x8E, 0xF5, 0x27, 0x6C, 0xB0, 0xF5
+    0x68,                     // 1 player
+    0x21, 0xFB,               // 2 players
+    0x27, 0x8E, 0xF5,         // 3 players
+    0x27, 0x6C, 0xB0, 0xF5    // 4 players
 };
 
 //Paired X / Y Offsets. X Is First, Y is Second. For NTSC.
 s16 gTracksMenuArrowPositionsNTSC[8] = {
-    0x0000, 0xFFC2, 0x0055, 0x0000,
-    0x0000, 0x003E, 0xFFAB, 0x0000,
+    0x0000, 0xFFC2, 
+    0x0055, 0x0000,
+    0x0000, 0x003E, 
+    0xFFAB, 0x0000,
 };
 
 //Paired X / Y Offsets. X Is First, Y is Second. For PAL.
 s16 gTracksMenuArrowPositionsPAL[8] = {
-    0x0000, 0xFFB6, 0x0055, 0x0000,
-    0x0000, 0x004A, 0xFFAB, 0x0000,
+    0x0000, 0xFFB6, 
+    0x0055, 0x0000,
+    0x0000, 0x004A, 
+    0xFFAB, 0x0000,
 };
 
 ButtonTextElement gTwoPlayerRacerCountMenu = {
     SCREEN_WIDTH_HALF - 80, 140, 160, 64, 4, 4, { 80, 20, 58, 40, 80, 40, 102, 40 }
 };
 
+// Adventure 1/2 button in the track select menu.
+// Note: The first element (.x) is not actually used.
 ButtonElement gTracksMenuAdventureButton = {
     80, 152, 160, 40, 4, 4, 80, 14
 };
 
-// Often access like gTracksMenuBgTextureIndices[i * 3 + 1]. Maybe it's s16[4][3]?
-s16 gTracksMenuBgTextureIndices[16] = {
-    0x0E, 0x0F, 0x00, 0x10,
-    0x11, 0x20, 0x12, 0x13,
-    0x00, 0x14, 0x15, 0x20,
-    0x16, 0x17, 0x20, 0x00
+// Often access like D_800E0710[i * 3 + 1].
+// Texture indices for the backgrounds in the Track Select
+// Seems like the 3rd number of a group of 3 is not used for anything?
+s16 gTracksMenuBgTextureIndices[15] = {
+    0x0E, 0x0F, 0x00, // Dino domain
+    0x10, 0x11, 0x20, // Sherbet Island
+    0x12, 0x13, 0x00, // Snowflake Mountain
+    0x14, 0x15, 0x20, // Dragon Forest
+    0x16, 0x17, 0x20  // Future Fun Land
 };
 
 TextureHeader *gTracksMenuBgTextures[10] = {
@@ -900,6 +954,13 @@ s16 gTrackSelectPreviewImageIndices[8] = {
 };
 
 // Not a struct, since the entries can *technically* be either 4 or 5 bytes. But it is always 5 in the final game.
+/*
+    Offset 0: u8 index;
+    Offset 1: u8 indexInto800E0730;
+    Offset 2: u8 alpha;
+    Offset 3: u8 alpha2;
+    Offset 4: u8 texCoordUFactor;
+*/
 u8 gTrackSelectBgData[295] = {
     0, 0, 255, 255, 0, 
     1, 1, 255, 255, 0, 
@@ -961,29 +1022,35 @@ u8 gTrackSelectBgData[295] = {
     41, 9, 255, 255, 32, 
     255, 0, 0, 0, 0
 };
-Vertex *gTrackSelectBgVertices = NULL;
-s32 D_800E096C = 0;
-Triangle *gTrackSelectBgTriangles = NULL;
-s32 D_800E0974 = 0;
+Vertex *gTrackSelectBgVertices[2] = { NULL, NULL };
+Triangle *gTrackSelectBgTriangles[2] = {NULL, NULL };
 char *gQMarkPtr = "?";
+
+// Boolean. Set to TRUE once in the Track Select menu, then
+//   set to FALSE when leaving the menu.
+// This is effectively unused, since it is only read from the 
+//   unused function func_8008E790()
 s32 gIsInTracksMenu = 0;
+
 s32 gTrackNameVoiceDelay = 0;
 s32 gMenuOptionCap = 0;
 s32 gMenuSubOption = 0;
-s32 gLastPlayerWhoPaused = 0; //Player ID or controllerIndex maybe?
+
+// Index of the last player who paused.
+s32 gLastPlayerWhoPaused = 0;
 
 ColourRGBA gPlayerPauseBgColour[4] = {
-    {{{  64,  64, 255, 160 }}},
-    {{{ 255,  64,  64, 160 }}},
-    {{{ 208, 192,  32, 176 }}},
-    {{{  32, 192,  64, 176 }}},
+    {{{  64,  64, 255, 160 }}}, // Blue for player 1
+    {{{ 255,  64,  64, 160 }}}, // Red for player 2
+    {{{ 208, 192,  32, 176 }}}, // Yellow for player 3
+    {{{  32, 192,  64, 176 }}}, // Green for player 4
 };
 
 ColourRGBA gPlayerPauseOptionsTextColour[4] = {
-    {{{   0, 255,   0, 128 }}},
-    {{{   0, 255,   0,  96 }}},
-    {{{   0,   0, 255,  96 }}},
-    {{{   0,   0, 255, 128 }}},
+    {{{   0, 255,   0, 128 }}}, // Green for Player 1
+    {{{   0, 255,   0,  96 }}}, // Green for Player 2
+    {{{   0,   0, 255,  96 }}}, // Blue for Player 3
+    {{{   0,   0, 255, 128 }}}, // Blue for Player 4
 };
 
 // BAD CONTROLLER PAK / If you wish to change / Controller Pak or Rumble Pak, / please do so now.
@@ -1141,7 +1208,6 @@ s32 gTrophyRaceWorldId = 0;
 s32 gTrophyRaceRound = 0; // Rounds 1 - 4 (as 0 - 3)
 s32 gPrevTrophyRaceRound = 0;
 
-// Unused? Not sure what this is.
 u32 unused_800E0FF4[4] = {
     0x01FFFFFF, 0x0012FFFF, 0x81FFFFFF, 0x00120000
 };
@@ -1151,11 +1217,11 @@ s32 gTrophyRacePointsArray[8] = {
     9, 7, 5, 3, 1, 0, 0, 0
 };
 
-s16 gGhostDataObjectIndices[14] = {
+s16 gTrophyRankingsObjectIndices[14] = {
     0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3A, 0x3B, 0x00, 0x01, -1, 0x00
 };
 
-s16 gGhostDataImageIndices[3] = {
+s16 gTrophyRaceImageIndices[3] = {
     0, 1, -1
 };
 
@@ -1325,7 +1391,7 @@ DrawTexture *gDrawTexWorldBgs[5] = {
     gDrawTexFutureFunLandGhostBg  // Future Fun Land
 };
 
-s16 D_800E1708[34] = {
+s16 gGhostDataObjectIndices[34] = {
     0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
     0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D,
     0x32, 0x33, 0x34, 0x36, 0x35, 0x37, 0x38, 0x39,
@@ -1333,7 +1399,7 @@ s16 D_800E1708[34] = {
     0x3E, -1
 };
 
-s16 D_800E174C[4] = {
+s16 gGhostDataImageIndices[4] = {
     0, 1, 7, -1
 };
 
@@ -1367,38 +1433,111 @@ s16 gCreditsImageIndices[2] = {
     -1, 0
 };
 
-s16 gCreditsControlData[130] = {
-    0x20A5, 0x0000, 0x20A5, 0x0001, 0x0002, 0x20A5, 0x0003, 0x0004,
-    0x0005, 0x0006, 0x4000, 0x20A5, 0x0007, 0x0008, 0x20A5, 0x0009,
-    0x000A, 0x000B, 0x000C, 0x30A5, 0x000D, 0x000E, 0x000F, 0x4000,
-    0x20A5, 0x0010, 0x0011, 0x20A5, 0x0012, 0x0013, 0x20A5, 0x0014,
-    0x4000, 0x20A5, 0x0015, 0x0016, 0x20A5, 0x0017, 0x0018, 0x20A5,
-    0x0019, 0x001A, 0x4000, 0x20A5, 0x001B, 0x001C, 0x001D, 0x001E,
-    0x001F, 0x30A5, 0x0020, 0x0021, 0x0022, 0x0023, 0x30A5, 0x0024,
-    0x0025, 0x0026, 0x4000, 0x20A5, 0x0027, 0x0028, 0x0029, 0x002A,
-    0x002B, 0x30A5, 0x002C, 0x002D, 0x002E, 0x30A5, 0x002F, 0x0030,
-    0x0031, 0x4000, 0x20A5, 0x0032, 0x0033, 0x0034, 0x0035, 0x0036,
-    0x30A5, 0x0037, 0x0038, 0x0039, 0x003A, 0x30A5, 0x003B, 0x003C,
-    0x003D, 0x003E, 0x4000, 0x20A5, 0x003F, 0x0040, 0x0041, 0x20A5,
-    0x0042, 0x0043, 0x0044, 0x0045, 0x0046, 0x20A5, 0x0047, 0x0048,
-    0x0049, 0x4000, 0x20A5, 0x004A, 0x004B, 0x30A5, 0x004C, 0x30A5,
-    0x004D, 0x4000, 0x20A5, 0x004E, 0x004F, 0x20A5, 0x0050, 0x0051,
-    0x20A5, 0x0052, 0x0053, 0x4000, 0x20A5, 0x0054, 0x210E, 0x0055,
-    0x0056, 0x4000
-};
 
-UNUSED u16 D_800E18F8 = 0x1000; // Set but never read.
+#define CREDITS_END (0x1000)
+#define CREDITS_NEW_TITLE(seconds) (0x2000 | ((s16)(seconds * 60.0)))
+#define CREDITS_CONTINUE_TITLE(seconds) (0x3000 | ((s16)(seconds * 60.0)))
+#define CREDITS_NEXT_LEVEL (0x4000)
+#define CREDITS_DEV_TIMES(seconds) (0x6000 | ((s16)(seconds * 60.0)))
 
-// Unused?
-u16 D_800E18FC[30] = {
-    0x0001, 0x0002, 0x0003, 0x4000,
-    0x61F4, 0x0004, 0x0005, 0x0006,
-    0x0007, 0x4000, 0x61F4, 0x0008,
-    0x0009, 0x000A, 0x000B, 0x4000,
-    0x61F4, 0x000C, 0x000D, 0x000E,
-    0x000F, 0x4000, 0x61F4, 0x0010,
-    0x0011, 0x0012, 0x0013, 0x4000,
-    0x1000, 0x0000
+// Number of seconds for each section in the credits.
+#define CREDITS_DEFAULT_TITLE_TIME 2.75
+#define CREDITS_MAGIC_CODE_TIME 4.5 
+#define CREDITS_DEV_TIMES_TIME 8.334
+
+// Data used to control the credits.
+s16 gCreditsControlData[] = {
+    CREDITS_NEW_TITLE(CREDITS_DEFAULT_TITLE_TIME),
+        0, // "CREDITS"
+    CREDITS_NEW_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        1, 2, // "Software Director", "R.Harrison"
+    CREDITS_NEW_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        3, 4, 5, 6, 
+    CREDITS_NEXT_LEVEL,
+    CREDITS_NEW_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        7, 8, 
+    CREDITS_NEW_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        9, 10, 11, 12, 
+    CREDITS_CONTINUE_TITLE(CREDITS_DEFAULT_TITLE_TIME),
+        13, 14, 15, 
+    CREDITS_NEXT_LEVEL,
+    CREDITS_NEW_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        16, 17, 
+    CREDITS_NEW_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        18, 19, 
+    CREDITS_NEW_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        20,
+    CREDITS_NEXT_LEVEL, 
+    CREDITS_NEW_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        21, 22, 
+    CREDITS_NEW_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        23, 24, 
+    CREDITS_NEW_TITLE(CREDITS_DEFAULT_TITLE_TIME),
+        25, 26, 
+    CREDITS_NEXT_LEVEL, 
+    CREDITS_NEW_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        27, 28, 29, 30, 31, 
+    CREDITS_CONTINUE_TITLE(CREDITS_DEFAULT_TITLE_TIME),
+        32, 33, 34, 35, 
+    CREDITS_CONTINUE_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        36, 37, 38, 
+    CREDITS_NEXT_LEVEL, 
+    CREDITS_NEW_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        39, 40, 41, 42, 43, 
+    CREDITS_CONTINUE_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        44, 45, 46, 
+    CREDITS_CONTINUE_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        47, 48, 49, 
+    CREDITS_NEXT_LEVEL, 
+    CREDITS_NEW_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        50, 51, 52, 53, 54,
+    CREDITS_CONTINUE_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        55, 56, 57, 58, 
+    CREDITS_CONTINUE_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        59, 60, 61, 62, 
+    CREDITS_NEXT_LEVEL, 
+    CREDITS_NEW_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        63, 64, 65, 
+    CREDITS_NEW_TITLE(CREDITS_DEFAULT_TITLE_TIME),
+        66, 67, 68, 69, 70, 
+    CREDITS_NEW_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        71, 72, 73, 
+    CREDITS_NEXT_LEVEL, 
+    CREDITS_NEW_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        74, 75, // "Special Thanks To", "J.HOCHBERG"
+    CREDITS_CONTINUE_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        76, // "H.LINCOLN"
+    CREDITS_CONTINUE_TITLE(CREDITS_DEFAULT_TITLE_TIME),
+        77, // "M.ARAKAWA"
+    CREDITS_NEXT_LEVEL, 
+    CREDITS_NEW_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        78, 79, 
+    CREDITS_NEW_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        80, 81,
+    CREDITS_NEW_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        82, 83, 
+    CREDITS_NEXT_LEVEL, 
+    CREDITS_NEW_TITLE(CREDITS_DEFAULT_TITLE_TIME), 
+        84, // "THE END"
+    CREDITS_NEW_TITLE(CREDITS_MAGIC_CODE_TIME),
+        85, 86, // Magic Code Description, Magic Code
+    CREDITS_NEXT_LEVEL,
+    CREDITS_END, // Set to CREDITS_DEV_TIMES(CREDITS_DEV_TIMES_TIME) if you've beaten wizpig 2.
+        0, 1, 2, 3, 
+    CREDITS_NEXT_LEVEL,
+    CREDITS_DEV_TIMES(CREDITS_DEV_TIMES_TIME), 
+        4, 5, 6, 7, 
+    CREDITS_NEXT_LEVEL, 
+    CREDITS_DEV_TIMES(CREDITS_DEV_TIMES_TIME), 
+        8, 9, 10, 11, 
+    CREDITS_NEXT_LEVEL,
+    CREDITS_DEV_TIMES(CREDITS_DEV_TIMES_TIME), 
+        12, 13, 14, 15, 
+    CREDITS_NEXT_LEVEL, 
+    CREDITS_DEV_TIMES(CREDITS_DEV_TIMES_TIME),
+        16, 17, 18, 19, 
+    CREDITS_NEXT_LEVEL,
+    CREDITS_END
 };
 
 // List of amazing people.
@@ -1508,6 +1647,7 @@ UNUSED Gfx dMenuHudDrawModes[][2] = {
     }
 };
 
+// Triangle indices for the wood panels used in multiple menus.
 s8 gWoodPanelsIndices[32] = {
     0, 1, 2, 0, 2, 3, 4, 5,
     6, 4, 6, 7, 8, 9, 10, 8,
@@ -1515,7 +1655,7 @@ s8 gWoodPanelsIndices[32] = {
     16, 17, 18, 16, 18, 19, 0, 0
 };
 
-// UV coordinate indices
+// UV coordinate indices the wood panels.
 u8 gWoodPanelTexCoords[5][12] = {
     { 0, 0, 3, 0, 2, 1, 0, 0, 2, 1, 1, 1 }, 
     { 2, 1, 3, 0, 3, 3, 2, 1, 3, 3, 2, 2 }, 
@@ -1524,7 +1664,7 @@ u8 gWoodPanelTexCoords[5][12] = {
     { 1, 1, 2, 1, 2, 2, 1, 1, 2, 2, 1, 2 }
 };
 
-// Position offsets, why are there 10?
+// Position offsets for the wood panels.
 u16 gWoodPanelVertCoords[10][4] = {
     {   0,    0, 256,    0 },
     { 511,  255,   1,  255 },
@@ -1538,13 +1678,13 @@ u16 gWoodPanelVertCoords[10][4] = {
     { 511, -255,   1, -255 }
 };
 
-// Colours
+// Colour filter, used for the shadows on the side of the panels.
 s16 gWoodPanelVertColours[5][4] = {
-    { 216, 216, 216, 256 },
-    { 176, 176, 176, 256 },
-    {  96,  96,  96, 256 },
-    { 136, 136, 136, 256 },
-    { 256, 256, 256, 256 }
+    { 216, 216, 216, 256 }, // Colour for top part of the panel
+    { 176, 176, 176, 256 }, // Colour for right part of the panel
+    {  96,  96,  96, 256 }, // Colour for bottom part of the panel
+    { 136, 136, 136, 256 }, // Colour for left part of the panel
+    { 256, 256, 256, 256 }  // Colour for the center of the panel
 };
 
 s32 *gWoodPanelVertices[2] = {
@@ -1557,21 +1697,28 @@ s32 *gWoodPanelTriangles[2] = {
 
 s32 D_800E1DB4 = 0;
 s32 gWoodPanelCount = 0;
-s32 D_800E1DBC = 0;
+s32 gWoodPanelAllocCount = 0;
 
+// U tex scale for wood panels (32 is 1.0x)
 s32 gWoodPanelTexScaleU = 32;
+// V tex scale for wood panels (32 is 1.0x)
 s32 gWoodPanelTexScaleV = 32;
 
+// Related to the file select wood panel highlight.
 s16 D_800E1DC8[16] = {
     1, 1, -1, 1, -1, 1, -1, -1, 1, -1, -1, -1, 1, 1, 1, -1
 };
 
+// Fade transition from the logo screen to the title screen.
 FadeTransition gFadeLogoToTitleScreen = FADE_TRANSITION(FADE_FULLSCREEN, FADE_FLAG_NONE, FADE_COLOR_BLACK, 120, -1);
 
 char gRareCopyrightString[24] = "(C) COPYRIGHT RARE 1997";
 
+// Fade transition between levels in the title screen demo.
 FadeTransition gFadeTitleScreenDemo = FADE_TRANSITION(FADE_FULLSCREEN, FADE_FLAG_NONE, FADE_COLOR_BLACK, 52, -1);
 
+// Used in func_800853D0(). Used for controller pak adventure saves.
+// So the first save in the pak would be (ADV.A), second save (ADV.B), etc.
 char *gConPakAdvSavePrefix = " (ADV.";
 
 
@@ -1765,7 +1912,7 @@ void func_8007FF88(void) {
     gWoodPanelVertices[0] = NULL;
     gWoodPanelVertices[1] = NULL;
     gWoodPanelCount = 0;
-    D_800E1DBC = 0;
+    gWoodPanelAllocCount = 0;
 }
 
 GLOBAL_ASM("asm/non_matchings/menu/func_8007FFEC.s")
@@ -3400,12 +3547,12 @@ void menu_save_options_init(void) {
     allocate_menu_images(gSaveMenuImageIndices);
     func_8007FFEC(0xA);
     load_font(ASSET_FONTS_BIGFONT);
-    D_800DFC10[0].texture = gMenuObjects[TEXTURE_ICON_SAVE_N64];
-    D_800DFC20[0].texture = gMenuObjects[TEXTURE_ICON_SAVE_TT];
-    D_800DFC30[0].texture = gMenuObjects[TEXTURE_ICON_SAVE_GHOSTS];
-    D_800DFC40[0].texture = gMenuObjects[TEXTURE_ICON_SAVE_FILECABINET];
-    D_800DFC50[0].texture = gMenuObjects[TEXTURE_ICON_SAVE_CPAK];
-    D_800DFC60[0].texture = gMenuObjects[TEXTURE_ICON_SAVE_BIN];
+    gDrawTexN64Icon[0].texture = gMenuObjects[TEXTURE_ICON_SAVE_N64];
+    gDrawTexTTIcon[0].texture = gMenuObjects[TEXTURE_ICON_SAVE_TT];
+    gDrawTexGhostIcon[0].texture = gMenuObjects[TEXTURE_ICON_SAVE_GHOSTS];
+    gDrawTexFileIcon[0].texture = gMenuObjects[TEXTURE_ICON_SAVE_FILECABINET];
+    gDrawTexContPakIcon[0].texture = gMenuObjects[TEXTURE_ICON_SAVE_CPAK];
+    gDrawTexTrashIcon[0].texture = gMenuObjects[TEXTURE_ICON_SAVE_BIN];
     assign_menu_arrow_textures();
     mark_read_all_save_files();
     transition_begin(&sMenuTransitionFadeOut);
@@ -3427,7 +3574,7 @@ void func_800853D0(unk800861C8 *arg0, s32 x, s32 y) {
     sp70 = 11;
     switch (arg0->saveFileType) {
         case SAVE_FILE_TYPE_UNK1:
-            drawTexture = D_800DFC10;
+            drawTexture = gDrawTexN64Icon;
             texture = gMenuObjects[TEXTURE_SURFACE_BUTTON_WOOD];
             colour = COLOUR_RGBA32(176, 224, 192, 255);
             if (!gSavefileData[arg0->controllerIndex]->newGame) {
@@ -3446,14 +3593,14 @@ void func_800853D0(unk800861C8 *arg0, s32 x, s32 y) {
             text = gMenuText[ASSET_MENU_TEXT_GAMEPAK];
             break;
         case SAVE_FILE_TYPE_UNK2:
-            drawTexture = D_800DFC20;
+            drawTexture = gDrawTexTTIcon;
             texture = gMenuObjects[TEXTURE_SURFACE_BUTTON_WOOD];
             colour = COLOUR_RGBA32(176, 224, 192, 255);
             text2 = gMenuText[ASSET_MENU_TEXT_TIMES];
             text = gMenuText[ASSET_MENU_TEXT_GAMEPAK];
             break;
         case SAVE_FILE_TYPE_GAME_DATA:
-            drawTexture = D_800DFC10;
+            drawTexture = gDrawTexN64Icon;
             texture = gMenuObjects[TEXTURE_UNK_44];
             colour = gContPakSaveBgColours[arg0->controllerIndex];
             text2 = buffer;
@@ -3473,49 +3620,49 @@ void func_800853D0(unk800861C8 *arg0, s32 x, s32 y) {
             }
             break;
         case SAVE_FILE_TYPE_TIME_DATA:
-            drawTexture = D_800DFC20;
+            drawTexture = gDrawTexTTIcon;
             texture = gMenuObjects[TEXTURE_UNK_44];
             colour = gContPakSaveBgColours[arg0->controllerIndex];
             text2 = arg0->unk8;
             text = gMenuText[ASSET_MENU_TEXT_CONTPAK1 + arg0->controllerIndex];
             break;
         case SAVE_FILE_TYPE_GHOST_DATA:
-            drawTexture = D_800DFC30;
+            drawTexture = gDrawTexGhostIcon;
             texture = gMenuObjects[TEXTURE_UNK_44];
             colour = gContPakSaveBgColours[arg0->controllerIndex];
             text2 = gMenuText[ASSET_MENU_TEXT_GHOSTS];
             text = gMenuText[ASSET_MENU_TEXT_CONTPAK1 + arg0->controllerIndex];
             break;
         case SAVE_FILE_TYPE_UNKNOWN:
-            drawTexture = D_800DFC40;
+            drawTexture = gDrawTexFileIcon;
             texture = gMenuObjects[TEXTURE_UNK_44];
             colour = gContPakSaveBgColours[arg0->controllerIndex];
             text2 = arg0->unk8;
             text = gMenuText[ASSET_MENU_TEXT_CONTPAK1 + arg0->controllerIndex];
             break;
         case SAVE_FILE_TYPE_UNK8:
-            drawTexture = D_800DFC50;
+            drawTexture = gDrawTexContPakIcon;
             texture = gMenuObjects[TEXTURE_UNK_44];
             colour = gContPakSaveBgColours[arg0->controllerIndex];
             text2 = gMenuText[ASSET_MENU_TEXT_EMPTYSLOT];
             text = gMenuText[ASSET_MENU_TEXT_CONTPAK1 + arg0->controllerIndex];
             break;
         case SAVE_FILE_TYPE_UNK9:
-            drawTexture = D_800DFC30;
+            drawTexture = gDrawTexGhostIcon;
             texture = gMenuObjects[TEXTURE_UNK_45];
             colour = -1;
             text2 = gMenuText[ASSET_MENU_TEXT_VIEWGHOSTS];
             text = NULL;
             break;
         case SAVE_FILE_TYPE_UNKA:
-            drawTexture = D_800DFC10;
+            drawTexture = gDrawTexN64Icon;
             text2 = gMenuText[ASSET_MENU_TEXT_GAMEPAKBONUSES];
             texture = gMenuObjects[TEXTURE_SURFACE_BUTTON_WOOD];
             colour = COLOUR_RGBA32(176, 224, 192, 255);
             text = gMenuText[ASSET_MENU_TEXT_GAMEPAK];
             break;
         default:
-            drawTexture = D_800DFC60;
+            drawTexture = gDrawTexTrashIcon;
             texture = gMenuObjects[TEXTURE_UNK_45];
             colour = COLOUR_RGBA32(128, 128, 128, 255);
             text2 = gMenuText[ASSET_MENU_TEXT_ERASE];
@@ -6866,10 +7013,10 @@ void menu_track_select_init(void) {
             var_s0[1] = NULL;
         }
     }
-    gTrackSelectBgTriangles = (Triangle *) allocate_from_main_pool_safe(2880, COLOUR_TAG_YELLOW);
-    D_800E0974 = (s32) (&gTrackSelectBgTriangles[40]); //640 bytes forward
-    D_800E096C = (s32) (&gTrackSelectBgTriangles[80]); //1280 bytes forward
-    //D_800E096C = (s32) (&gTrackSelectBgVertices[80]); //800 bytes past gTrackSelectBgVertices
+    gTrackSelectBgTriangles[0] = (Triangle *) allocate_from_main_pool_safe(2880, COLOUR_TAG_YELLOW);
+    gTrackSelectBgTriangles[1] = (s32) (&gTrackSelectBgTriangles[0][40]); //640 bytes forward
+    gTrackSelectBgVertices[0] = (s32) (&gTrackSelectBgTriangles[1][80]); //1280 bytes forward
+    //gTrackSelectBgVertices[1] = (s32) (&gTrackSelectBgVertices[0][80]); //800 bytes past gTrackSelectBgVertices
     var_a0 = -160;
     var_v0 = 0;
     for (var_v0 = 0; var_v0 < 80; var_v0++) {
@@ -7065,7 +7212,7 @@ s32 menu_track_select_loop(s32 updateRate) {
     }
     if (D_801267D0 < 0) {
         func_8008F534();
-        unused_800DF478 = 0;
+        gTrackSpecifiedWithTrackIdToLoad = 0;
         if (gNumberOfActivePlayers >= 3 || (gNumberOfActivePlayers == 2 && (gActiveMagicCodes << 7) >= 0)) {
             cutsceneId = 0;
             if (is_drumstick_unlocked()) {
@@ -7091,7 +7238,7 @@ s32 menu_track_select_loop(s32 updateRate) {
             }
         }
         if (D_801269C8 != 4) {
-            unused_800DF478 = 1;
+            gTrackSpecifiedWithTrackIdToLoad = 1;
             return gNumberOfActivePlayers;
         }
         gTrophyRaceWorldId = D_801269CC + 1;
@@ -7110,7 +7257,7 @@ void func_8008F534(void) {
     camDisableUserView(0, FALSE);
     func_8009C4A8(gTrackSelectObjectIndices);
     set_free_queue_state(0);
-    free_from_memory_pool(gTrackSelectBgTriangles);
+    free_from_memory_pool(gTrackSelectBgTriangles[0]);
     set_free_queue_state(2);
     for (i = 0; i < 15; i += 3) {
         if (gTracksMenuBgTextureIndices[i] != -1) {
@@ -7696,9 +7843,9 @@ void render_track_select_setup_ui(s32 updateRate) {
                         for (i = 0; i < 2; i++) {
                             s32 yTemp = 0x97 + sp80 + (i * 0x18);
                             if (i == gTracksMenuTimeTrialHighlightIndex) {
-                                render_textured_rectangle(&sMenuCurrDisplayList, D_800E0648[(i * 3) + 1], 0x68, yTemp, 0xFF, 0xFF, 0xFF, sMenuGuiOpacity);
+                                render_textured_rectangle(&sMenuCurrDisplayList, gTrackSelectTTImage[(i * 3) + 1], 0x68, yTemp, 0xFF, 0xFF, 0xFF, sMenuGuiOpacity);
                             } else {
-                                render_textured_rectangle(&sMenuCurrDisplayList, D_800E0648[(i * 3) + 2], 0x68, yTemp, 0xFF, 0xFF, 0xFF, sMenuGuiOpacity);
+                                render_textured_rectangle(&sMenuCurrDisplayList, gTrackSelectTTImage[(i * 3) + 2], 0x68, yTemp, 0xFF, 0xFF, 0xFF, sMenuGuiOpacity);
                             }
                         }
                     }
@@ -7716,7 +7863,7 @@ void render_track_select_setup_ui(s32 updateRate) {
                             }
 
                             // "Player" text image
-                            render_textured_rectangle(&sMenuCurrDisplayList, D_800E0660[i], gTracksMenuPlayerNamePositions[s3 + (i * 2)], gTracksMenuPlayerNamePositions[s3 + (i * 2) + 1] + sp80, 0xFF, 0xFF, 0xFF, sMenuGuiOpacity);
+                            render_textured_rectangle(&sMenuCurrDisplayList, gTrackSelectPlayerImage[i], gTracksMenuPlayerNamePositions[s3 + (i * 2)], gTracksMenuPlayerNamePositions[s3 + (i * 2) + 1] + sp80, 0xFF, 0xFF, 0xFF, sMenuGuiOpacity);
                         }
                     }
                 }
@@ -7758,7 +7905,7 @@ void render_track_select_setup_ui(s32 updateRate) {
                         render_textured_rectangle(&sMenuCurrDisplayList, gRaceSelectionImages[gPlayerSelectVehicle[PLAYER_ONE] * 3], 0x95, s7, 0xFF, 0xFF, 0xFF, sMenuGuiOpacity);
                     } else {
                         // Draw T.T. image for one player
-                        render_textured_rectangle(&sMenuCurrDisplayList, D_800E0648[gTracksMenuTimeTrialHighlightIndex * 3], 0x95, sp80, 0xFF, 0xFF, 0xFF, sMenuGuiOpacity);
+                        render_textured_rectangle(&sMenuCurrDisplayList, gTrackSelectTTImage[gTracksMenuTimeTrialHighlightIndex * 3], 0x95, sp80, 0xFF, 0xFF, 0xFF, sMenuGuiOpacity);
                     }
                 }
                 if ((gNumberOfActivePlayers == 2) && (!sp74)) {
@@ -9789,7 +9936,7 @@ s32 menu_trophy_race_round_loop(s32 updateRate) {
     if (gMenuDelay >= 31) {
         unload_big_font_5();
         gTrackIdToLoad = trackMenuIds[(((gTrophyRaceWorldId - 1) * 6) + gTrophyRaceRound)];
-        unused_800DF478 = 1;
+        gTrackSpecifiedWithTrackIdToLoad = 1;
         return gNumberOfActivePlayers;
     }
     gIgnorePlayerInputTime = 0;
@@ -9828,8 +9975,8 @@ void menu_trophy_race_rankings_init(void) {
     gOptionBlinkTimer = 0;
     gOpacityDecayTimer = 0;
     reset_controller_sticks();
-    func_8009C674(gGhostDataObjectIndices);
-    allocate_menu_images(gGhostDataImageIndices);
+    func_8009C674(gTrophyRankingsObjectIndices);
+    allocate_menu_images(gTrophyRaceImageIndices);
     gPrevTrophyRaceRound = gTrophyRaceRound;
     do {
         if(++gTrophyRaceRound >= 4) break;
@@ -10080,7 +10227,7 @@ s32 menu_trophy_race_rankings_loop(s32 updateRate) {
 }
 
 void func_80099600(void) {
-    func_8009C4A8(gGhostDataObjectIndices);
+    func_8009C4A8(gTrophyRankingsObjectIndices);
     unload_font(ASSET_FONTS_BIGFONT);
 }
 
@@ -10145,8 +10292,8 @@ void menu_ghost_data_init(void) {
     if (pakStatus == CONTROLLER_PAK_GOOD) {
         func_8009963C();
     }
-    func_8009C674(&D_800E1708);
-    allocate_menu_images(&D_800E174C);
+    func_8009C674(&gGhostDataObjectIndices);
+    allocate_menu_images(&gGhostDataImageIndices);
     load_font(ASSET_FONTS_BIGFONT);
     gDrawTexDinoDomainGhostBg[0].texture = gMenuObjects[TEXTURE_BACKGROUND_DINO_DOMAIN_TOP];
     gDrawTexDinoDomainGhostBg[5].texture = gMenuObjects[TEXTURE_BACKGROUND_DINO_DOMAIN_BOTTOM];
@@ -10436,7 +10583,7 @@ s32 menu_ghost_data_loop(s32 updateRate) {
 }
 
 void func_8009ABAC(void) {
-    func_8009C4A8(D_800E1708);
+    func_8009C4A8(gGhostDataObjectIndices);
     unload_font(ASSET_FONTS_BIGFONT);
 }
 
@@ -10557,7 +10704,7 @@ void menu_credits_init(void) {
     assign_racer_portrait_textures();
     load_font(ASSET_FONTS_BIGFONT);
     set_music_player_voice_limit(24);
-    D_800E18F8 = 0x1000;
+    gCreditsControlData[130] = CREDITS_END; // DONT show developer times
     if (gViewingCreditsFromCheat) {
         play_music(SEQUENCE_DARKMOON_CAVERNS);
         gCreditsArray[84] = gCreditsLastMessageArray[2]; // "THE END"
@@ -10568,7 +10715,7 @@ void menu_credits_init(void) {
         if (settings->bosses & 0x20) {
             play_music(SEQUENCE_CRESCENT_ISLAND);
             gCreditsArray[84] = gCreditsLastMessageArray[1]; // "TO BE CONTINUED ..."
-            D_800E18F8 = 0x61F4;
+            gCreditsControlData[130] = CREDITS_DEV_TIMES(CREDITS_DEV_TIMES_TIME); // Show developer times.
             D_80126BCC = 9;
         } else {
             play_music(SEQUENCE_DARKMOON_CAVERNS);
@@ -10769,14 +10916,14 @@ s32 get_save_file_index(void) {
  */
 s32 get_track_id_to_load(void) {
     Settings *settings = get_settings();
-    if (!gIsInTracksMode && unused_800DF478 == 0) {
+    if (!gIsInTracksMode && gTrackSpecifiedWithTrackIdToLoad == 0) {
         if (settings->newGame) {
             return 0;
         } else {
             return settings->courseId;
         }
     }
-    unused_800DF478 = 0;
+    gTrackSpecifiedWithTrackIdToLoad = 0;
     return gTrackIdToLoad;
 }
 

--- a/src/menu.c
+++ b/src/menu.c
@@ -273,7 +273,7 @@ s32 D_80126CC0;
 /************ .data ************/
 
 // A boolean, set to TRUE if player has entered trophy race through adventure mode.
-s8 gInAdvModeTrophyRace = 0;
+s8 gInAdvModeTrophyRace = FALSE;
 
 // Height scale of the wooden frames in the track select menu.
 f32 gTrackSelectWoodFrameHeightScale = 1.0f;
@@ -324,7 +324,7 @@ s32 gIsInTwoPlayerAdventure = 0;
 s32 gTrackIdForPreview      = ASSET_LEVEL_CENTRALAREAHUB;
 s32 gTrackSelectRow         = 0; // 1 = Dino Domain, 2 = Sherbet Island, etc.
 s32 gSaveFileIndex          = 0;
-s32 unused_800DF4D0         = 0; // Unused?
+s32 unused_800DF4D0         = 0;
 s32 gTrackIdToLoad          = 0;
 s8 unused_800DF4D8          = 1;
 s8 gNextTajChallengeMenu    = FALSE;
@@ -384,8 +384,8 @@ UNUSED FadeTransition sMenuTransitionFadeOutWhite = FADE_TRANSITION(FADE_FULLSCR
 
 s32 gTrophyRankingsState = 4;
 MenuElement *gTrophyRankingsMenuElements = NULL;
-s32 gDrawMenuElementsYOffset = 0;
-s32 gDrawMenuElementsYOffset2 = 0;
+s32 gDrawElementsRegionYOffset = 0;
+s32 gDrawElementsYOffset = 0;
 
 char *gTitleMenuStrings[3] = { 0, 0, 0 };
 
@@ -477,7 +477,7 @@ s32 gMusicTestSongIndex = 0;
 s32 gSfxVolumeSliderValue = 256;   // Value from 0 to 256
 s32 gMusicVolumeSliderValue = 256; // Value from 0 to 256
 
-StereoPanMode gAudioOutputType = 0;
+StereoPanMode gAudioOutputType = STEREO;
 
 // This is used for RGBA colors for the save options Controller Pak BG.
 u32 gContPakSaveBgColours[MAXCONTROLLERS] = {
@@ -718,7 +718,6 @@ char *gFilenames[3] = {
     NULL, NULL, NULL
 };
 
-// Unused?
 u16 unused_800E03BC[8] = {
     0x004C,
     0x0070,
@@ -2421,8 +2420,8 @@ void func_80081E54(MenuElement *arg0, f32 arg1, f32 arg2, f32 arg3, s32 arg4, s3
     D_8012685C = arg2 * 60.0f;
     D_80126860 = arg3 * 60.0f;
     D_80126854 = 0;
-    gDrawMenuElementsYOffset = arg4;
-    gDrawMenuElementsYOffset2 = arg5;
+    gDrawElementsRegionYOffset = arg4;
+    gDrawElementsYOffset = arg5;
     if (D_80126858 > 0) {
         play_sound_global(SOUND_WHOOSH1, NULL);
     }
@@ -2540,7 +2539,7 @@ void draw_menu_elements(s32 arg0, MenuElement *elem, f32 arg2) {
                             elem->details.background.backgroundAlpha);
                         set_text_colour(elem->filterRed, elem->filterGreen, elem->filterBlue, elem->filterAlpha, elem->opacity);
                         set_text_font(elem->textFont);
-                        draw_text(&sMenuCurrDisplayList, xPos, yPos + gDrawMenuElementsYOffset, elem->unk14_a.asciiText, elem->textAlignFlags);
+                        draw_text(&sMenuCurrDisplayList, xPos, yPos + gDrawElementsRegionYOffset, elem->unk14_a.asciiText, elem->textAlignFlags);
                         break;
                     case 1:
                         if (s5) {
@@ -2551,7 +2550,7 @@ void draw_menu_elements(s32 arg0, MenuElement *elem, f32 arg2) {
                         show_timestamp(
                             *elem->unk14_a.numberU16,
                             xPos - 160,
-                            (-yPos - gDrawMenuElementsYOffset2) + 120,
+                            (-yPos - gDrawElementsYOffset) + 120,
                             elem->filterRed,
                             elem->filterGreen,
                             elem->filterBlue,
@@ -2565,7 +2564,7 @@ void draw_menu_elements(s32 arg0, MenuElement *elem, f32 arg2) {
                         func_80081C04(
                             *elem->unk14_a.number,
                             xPos - 160,
-                            (-yPos - gDrawMenuElementsYOffset2) + 120,
+                            (-yPos - gDrawElementsYOffset) + 120,
                             elem->filterRed,
                             elem->filterGreen,
                             elem->filterBlue,
@@ -2578,7 +2577,7 @@ void draw_menu_elements(s32 arg0, MenuElement *elem, f32 arg2) {
                             &sMenuCurrDisplayList,
                             elem->unk14_a.texture,
                             xPos,
-                            yPos + gDrawMenuElementsYOffset,
+                            yPos + gDrawElementsRegionYOffset,
                             elem->filterRed,
                             elem->filterGreen,
                             elem->filterBlue,
@@ -2590,7 +2589,7 @@ void draw_menu_elements(s32 arg0, MenuElement *elem, f32 arg2) {
                             &sMenuCurrDisplayList,
                             elem->unk14_a.element,
                             xPos,
-                            yPos + gDrawMenuElementsYOffset,
+                            yPos + gDrawElementsRegionYOffset,
                             elem->details.texture.width / 256.0f,
                             elem->details.texture.height / 256.0f,
                             (elem->filterRed << 24) | (elem->filterGreen << 16) | (elem->filterBlue << 8) | elem->opacity,
@@ -2605,7 +2604,7 @@ void draw_menu_elements(s32 arg0, MenuElement *elem, f32 arg2) {
                         func_80068508(1);
                         sprite_opaque(FALSE);
                         gMenuImageStack[elem->unk14_a.value].unkC = xPos - 160;
-                        gMenuImageStack[elem->unk14_a.value].unk10 = (-yPos - gDrawMenuElementsYOffset2) + 120;
+                        gMenuImageStack[elem->unk14_a.value].unk10 = (-yPos - gDrawElementsYOffset) + 120;
                         gMenuImageStack[elem->unk14_a.value].unk18 = elem->textFont;
                         gMenuImageStack[elem->unk14_a.value].unk4 = elem->details.background.backgroundRed;
                         gMenuImageStack[elem->unk14_a.value].unk2 = elem->details.background.backgroundGreen;
@@ -2624,7 +2623,7 @@ void draw_menu_elements(s32 arg0, MenuElement *elem, f32 arg2) {
                         func_80080E90(
                             &sMenuCurrDisplayList,
                             xPos,
-                            yPos + gDrawMenuElementsYOffset2,
+                            yPos + gDrawElementsYOffset,
                             elem->details.texture.width,
                             elem->details.texture.height,
                             elem->details.texture.borderWidth,
@@ -2638,7 +2637,7 @@ void draw_menu_elements(s32 arg0, MenuElement *elem, f32 arg2) {
                         func_80080580(
                             &sMenuCurrDisplayList,
                             xPos,
-                            yPos + gDrawMenuElementsYOffset2,
+                            yPos + gDrawElementsYOffset,
                             elem->details.texture.width,
                             elem->details.texture.height,
                             elem->details.texture.borderWidth,
@@ -3432,10 +3431,10 @@ s32 menu_audio_options_loop(s32 updateRate) {
                     gAudioOutputType++;
                 }
                 if (gAudioOutputType < 0) {
-                    gAudioOutputType = 2;
+                    gAudioOutputType = HEADPHONES;
                 }
                 if (gAudioOutputType >= 3) {
-                    gAudioOutputType = 0;
+                    gAudioOutputType = STEREO;
                 }
                 set_stereo_pan_mode(gAudioOutputType);
                 sp30 = 1;
@@ -6177,11 +6176,11 @@ void func_8008C698(UNUSED s32 updateRate) {
         }
 
         if (osTvType == TV_TYPE_PAL) {
-            gDrawMenuElementsYOffset = 12;
-            gDrawMenuElementsYOffset2 = 0;
+            gDrawElementsRegionYOffset = 12;
+            gDrawElementsYOffset = 0;
         } else {
-            gDrawMenuElementsYOffset = 0;
-            gDrawMenuElementsYOffset2 = 0;
+            gDrawElementsRegionYOffset = 0;
+            gDrawElementsYOffset = 0;
         }
 
         draw_menu_elements(1, gGameSelectElements, 1.0f);

--- a/src/menu.c
+++ b/src/menu.c
@@ -285,14 +285,14 @@ s32 gTitleScreenCurrentOption = 0; // 0 = "Start", 1 = "Options"
 // Currently selected index for all menus.
 s32 gMenuCurIndex = 0;
 
-s32 ununsed_800DF464 = 4; 
-s32 ununsed_800DF468 = 0;
+s32 unused_800DF464 = 4; 
+s32 unused_800DF468 = 0;
 
 // Used as a short delay before printing the missing controller text.
 s32 gMissingControllerDelay = 0;
 
 s32 gCurrentMenuId = 0; 
-s32 ununsed_800DF474 = 0;
+s32 unused_800DF474 = 0;
 
 // A boolean, set to TRUE when a track is loaded using gTrackIdToLoad.
 s32 gTrackSpecifiedWithTrackIdToLoad = 0; 
@@ -11208,7 +11208,7 @@ void func_8009CA60(s32 stackIndex) {
                 new_var->segment.trans.y_position = new_var2->trans.y_position;
                 new_var->segment.trans.z_position = new_var2->trans.z_position;
                 new_var->segment.trans.scale = new_var2->trans.scale;
-                if (ununsed_800DF468 == 0) {
+                if (unused_800DF468 == 0) {
                     new_var->segment.animFrame = new_var2->unk1D;
                     new_var->segment.object.modelIndex = new_var2->unk18;
                 }


### PR DESCRIPTION
Taking on the big scary file.

There are still several unlabeled symbols in the `.data` section of menu.c, but this PR gets most of those labeled. Still need to do the .bss section though.

Also added an optional third argument to `rename.sh` which can be used to check to see if the new symbol already exists in the repo.