### PR TITLE
Update makefile and README for macOS and depdencies

### DIFF
--- a/.github/workflows/VerifyBuild.yml
+++ b/.github/workflows/VerifyBuild.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install packages
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential pkg-config git python3 libssl-dev wget libcapstone-dev binutils-mips-linux-gnu
+        sudo apt-get install -y build-essential pkg-config git python3 libssl-dev wget binutils-mips-linux-gnu
 
     - name: Get ROM
       run: wget -q -O baseroms/dkr.z64 ${{secrets.ROMURL}}

--- a/.github/workflows/VerifyPR.yml
+++ b/.github/workflows/VerifyPR.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install packages
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential pkg-config git python3 libssl-dev wget libcapstone-dev binutils-mips-linux-gnu
+        sudo apt-get install -y build-essential pkg-config git python3 libssl-dev wget binutils-mips-linux-gnu
 
     - name: Get ROM
       run: wget -q -O baseroms/dkr.z64 ${{secrets.ROMURL}}
@@ -30,7 +30,7 @@ jobs:
 
     - name: Download Recomp
       run: |
-        wget -q -O ido-static-recomp.tar.gz https://github.com/decompals/ido-static-recomp/releases/download/v0.1/ido-5.3-recomp-ubuntu-latest.tar.gz
+        wget -q -O ido-static-recomp.tar.gz https://github.com/decompals/ido-static-recomp/releases/download/v1.0/ido-5.3-recomp-linux.tar.gz
         mkdir -p tools/ido-static-recomp/build5.3/out
         tar -xvzf ido-static-recomp.tar.gz -C tools/ido-static-recomp/build5.3/out
 

--- a/README.md
+++ b/README.md
@@ -37,12 +37,10 @@ You are not required to install a binutils package, but it does speed up the ini
 3. Run `make` in the main directory.  
     **a.** Use the `-jN` argument to use `N` number of threads to speed up building. For example, if you have a system with 4 cores / 4 threads, you should do `make -j4`.
 
-### Building on MacOS
-1. `brew install gcc coreutils`
-2. Put GNU-coreutils `bin` on path using by adding `PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"` to your shell rcfile (or update any GNU-util usage in `Makefile` and `tools/Makefile` to use the `g`-prefixed versions).
-3. Download latest `macos` build of `ido-static-recomp` from [here](https://github.com/decompals/ido-static-recomp/releases/), and add `cp` the binaries to `tools/ido-static-recomp/build5.3/out`.
-4. Take a look at [this gist](https://gist.github.com/tonyspumoni/fc1b4c9217c5f2821a9fc4cbf69b51ef) to see what other updates are needed to get the build to pass, and apply them if they are relevant to your environment. You may need to add specific `-I` and `-L` flags to get things like `openssl` and `gcc-12` includes/libs included.
-5. `make` from repository root should work now.
+### Building on macOS
+1. Use homebrew to install dependencies: `brew install make`
+2. Place the ROM file within the `baseroms` directory. See [Setup](#setup--building) above for more info.
+3. Run `gmake` from the main directory. Note that macOS built-in `make` will not work since it does not meet the version requirements.
 
 ## Modding
 If you are modifying the code in the repo, then you should add `NON_MATCHING=1` to the make command.  

--- a/README.md
+++ b/README.md
@@ -16,13 +16,12 @@ As of November 18, 2023, this is our current score:
 
 ## Dependencies
 
-* `libcapstone-dev`
 * `gcc`, Version 8.0 or higher
 * `make`, Version 4.2 or higher
 * `python3`
 * `wget`
 
-`sudo apt install build-essential pkg-config git python3 wget libcapstone-dev`
+`sudo apt install build-essential pkg-config git python3 wget`
 
 ### binutils
 
@@ -39,7 +38,7 @@ You are not required to install a binutils package, but it does speed up the ini
     **a.** Use the `-jN` argument to use `N` number of threads to speed up building. For example, if you have a system with 4 cores / 4 threads, you should do `make -j4`.
 
 ### Building on MacOS
-1. `brew install gcc capstone coreutils`
+1. `brew install gcc coreutils`
 2. Put GNU-coreutils `bin` on path using by adding `PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"` to your shell rcfile (or update any GNU-util usage in `Makefile` and `tools/Makefile` to use the `g`-prefixed versions).
 3. Download latest `macos` build of `ido-static-recomp` from [here](https://github.com/decompals/ido-static-recomp/releases/), and add `cp` the binaries to `tools/ido-static-recomp/build5.3/out`.
 4. Take a look at [this gist](https://gist.github.com/tonyspumoni/fc1b4c9217c5f2821a9fc4cbf69b51ef) to see what other updates are needed to get the build to pass, and apply them if they are relevant to your environment. You may need to add specific `-I` and `-L` flags to get things like `openssl` and `gcc-12` includes/libs included.


### PR DESCRIPTION
- support make 4.4 syntax for C and asm file lists
- prefer clang for C preprocessing since gcc on macOS is a clang alias
- update macOS setup and build instructions