### PR TITLE
Fixed m2ctx.py issues

### DIFF
--- a/src/memory.h
+++ b/src/memory.h
@@ -16,10 +16,10 @@ typedef enum MemoryPools {
 } MemoryPools;
 
 typedef enum MempoolFlags {
-    SLOT_FREE = 0,              // The slot is free.
-    SLOT_USED = (1 << 0),       // The slot is used.
-    SLOT_LOCKED = (1 << 1),     // The slot is used, and cannot be freed by normal means.
-    SLOT_SAFEGUARD = (1 << 2),  // The slot is used, and marks the stopping point of a global pool clear.
+    SLOT_FREE = 0,             // The slot is free.
+    SLOT_USED = (1 << 0),      // The slot is used.
+    SLOT_LOCKED = (1 << 1),    // The slot is used, and cannot be freed by normal means.
+    SLOT_SAFEGUARD = (1 << 2)  // The slot is used, and marks the stopping point of a global pool clear.
 } MempoolFlags;
 
 #define RAM_END 0x80400000

--- a/tools/python/m2ctx.py
+++ b/tools/python/m2ctx.py
@@ -16,7 +16,7 @@ ignoreFiles = ["include/sys/regdef.h"]
 search_folders = ["include/", "src/"]
 
 # Needed for StereoPanMode
-includeFiles = ['include/PR/libaudio.h']
+includeFiles = ['lib/src/audio/synstartvoiceparam.h']
 
 hack_directives_into_singleline = ['DRAW_TABLE_ENTRY', 'DRAW_TABLE_GROUP']
 
@@ -66,7 +66,13 @@ def fix_enums(text):
 
 # Fixes up a string to make it look nice. Also removes some unnecessary stuff.
 def cleanup_string(text):
-    return ' '.join(text.strip().replace('UNUSED', '').replace('extern', '').replace('\t', '    ').replace('\n', ' ').split())
+    return ' '.join(text.strip()
+        .replace('UNUSED', '')
+        .replace('extern', '')
+        .replace('__stdcall', '')
+        .replace('\t', '    ')
+        .replace('\n', ' ')
+        .split())
 
 # Returns the arguments for a function in a nice clean way.
 def get_cleaned_args(argsString):


### PR DESCRIPTION
StereoPanMode now gets included again, removed instances of __stdcall, and removed a trailing comma from MempoolFlags.

The tool will still generate a bunch of warnings of other little things we need to fix, but this PR fixes the immediate issues.