### PR TITLE
Convert Asset20 to Object_Boost and convert unk80068514_arg4 to Sprite

### DIFF
--- a/include/structs.h
+++ b/include/structs.h
@@ -1020,8 +1020,8 @@ typedef struct Object_Weapon {
   /* 0x14 */ s16 unk16;
   /* 0x18 */ u8 weaponID;
   /* 0x19 */ s8 checkpoint;
-  /* 0x19 */ s16 unk1A;
-  /* 0x19 */ SoundHandle soundMask;
+  /* 0x1A */ s16 unk1A;
+  /* 0x1C */ struct AudioPoint *soundMask;
 } Object_Weapon;
 
 typedef struct Object_Butterfly {

--- a/include/structs.h
+++ b/include/structs.h
@@ -156,7 +156,10 @@ typedef struct Sprite {
   /* 0x02 */ s16 numberOfFrames; // 1 means static texture
   /* 0x04 */ s16 numberOfInstances;
   /* 0x06 */ s16 drawFlags;
-  /* 0x08 */ TextureHeader **frames;
+  union {
+    /* 0x08 */ TextureHeader **frames;
+    /* 0x08 */ Gfx *gfx[1];
+  };
   union {
     /* 0x0C */ u8 val[1]; // Actual size varies.
     /* 0x0C */ u8 *ptr[1]; // Display list?
@@ -1059,19 +1062,25 @@ typedef struct Object_Boost_Inner {
   Vec3f position;
   f32 unkC;
   f32 unk10;
-  u8 pad[0x24 - 0x14];
+  f32 unk14;
+  f32 unk18;
+  f32 unk1C;
+  f32 unk20;
 } Object_Boost_Inner;
 
 typedef struct Object_Boost {
   Object_Boost_Inner unk0;
   Object_Boost_Inner unk24;
   Object_Boost_Inner unk48;
-  u8 pad6C[4];
+  s16 unk6C;
+  s16 unk6E;
   u8 unk70;
   u8 unk71;
   u8 unk72;
-  u8 unk73;
+  s8 unk73;
   f32 unk74;
+  Sprite *unk78;
+  TextureHeader *unk7C;
 } Object_Boost;
 
 typedef struct Object_EffectBox {

--- a/include/structs.h
+++ b/include/structs.h
@@ -1651,6 +1651,7 @@ typedef struct Object_CharacterSelect {
     s8 pad42;
     s8 unk43;
 } Object_CharacterSelect;
+
 typedef struct Object_64 {
     union {
         Object_Laser laser;

--- a/src/audio_vehicle.c
+++ b/src/audio_vehicle.c
@@ -27,8 +27,7 @@ Object_Racer *gSoundRacerObj;
 
 /******************************/
 
-// racer_sound_init
-VehicleSoundData *func_80004B40(s32 characterId, s32 vehicleId) {
+VehicleSoundData *racer_sound_init(s32 characterId, s32 vehicleId) {
     s32 unused[2];
     s32 i;
     u8 *ptr;

--- a/src/audio_vehicle.c
+++ b/src/audio_vehicle.c
@@ -502,10 +502,10 @@ void func_800063EC(Object *obj, UNUSED u32 buttonsPressed, u32 buttonsHeld, s32 
     }
     gRacerSound->unk5C[1] = 1.0f;
     gRacerSound->unk54[1] = 0;
-    if ((gSoundRacerObj->playerIndex != PLAYER_COMPUTER) && (gSoundRacerObj->spinout_timer != 0) &&
+    if (gSoundRacerObj->playerIndex != PLAYER_COMPUTER && gSoundRacerObj->spinout_timer != 0 &&
         !gRacerSound->brakeSound) {
         gRacerSound->brakeSound = TRUE;
-        sound_play(SOUND_UNK_13D, (s32 *) &gRacerSound->brakeSoundMask);
+        sound_play(SOUND_UNK_13D, &gRacerSound->brakeSoundMask);
     } else if (gSoundRacerObj->spinout_timer == 0) {
         gRacerSound->brakeSound = FALSE;
         if (gRacerSound->brakeSoundMask != NULL) {

--- a/src/audio_vehicle.h
+++ b/src/audio_vehicle.h
@@ -82,7 +82,7 @@ void racer_sound_update(Object *obj, u32 buttonsPressed, u32 buttonsHeld, s32 up
 void racer_sound_free(Object *);
 
 f32 func_80007FA4(f32 arg0);
-VehicleSoundData *func_80004B40(s32 characterId, s32 vehicleId);
+VehicleSoundData *racer_sound_init(s32 characterId, s32 vehicleId);
 void func_80005254(Object *obj, u32 buttonsPressed, u32 buttonsHeld, s32 updateRate);
 void racer_sound_hovercraft(Object *, u32 buttonsPressed, u32 buttonsHeld, s32 updateRate);
 void func_800063EC(Object *, u32 buttonsPressed, u32 buttonsHeld, s32 updateRate);

--- a/src/audiosfx.c
+++ b/src/audiosfx.c
@@ -92,7 +92,7 @@ void sndp_init_player(audioMgrConfig *c) {
     gSoundStateLists.freeHead = (ALSoundState *) gSoundPlayerPtr->soundStatesArray;
     for (i = 1; i < c->maxSounds; i++) {
         sounds = gSoundPlayerPtr->soundStatesArray;
-        alLink(&(sounds + i)->next, &(sounds + i - 1)->next);
+        alLink((ALLink *) &sounds[i].next, (ALLink *) &(&sounds[i] - 1)->next);
     }
 
     /*
@@ -777,7 +777,7 @@ void sndp_stop(ALSoundState *state) {
     alEvent.common.state = state;
     if (state != NULL) {
         state->flags &= ~SOUND_FLAG_RETRIGGER;
-        alEvtqPostEvent(&gSoundPlayerPtr->evtq, &alEvent, 0);
+        alEvtqPostEvent(&gSoundPlayerPtr->evtq, (ALEvent *) &alEvent, 0);
     } else {
         // From JFG
         // osSyncPrintf("WARNING: Attempt to stop NULL sound aborted\n");
@@ -799,7 +799,7 @@ void sndp_stop_with_flags(u8 flags) {
         evt.common.state = soundState;
         if ((soundState->flags & flags) == flags) {
             evt.common.state->flags &= ~SOUND_FLAG_RETRIGGER;
-            alEvtqPostEvent(&gSoundPlayerPtr->evtq, &evt, 0);
+            alEvtqPostEvent(&gSoundPlayerPtr->evtq, (ALEvent *) &evt, 0);
         }
         soundState = soundState->next;
     }

--- a/src/camera.c
+++ b/src/camera.c
@@ -1031,8 +1031,7 @@ void sprite_anim_off(s32 setting) {
 /**
  * Calculates angle from object to camera, then renders the sprite as a billboard, facing the camera.
  */
-s32 render_sprite_billboard(Gfx **dList, MatrixS **mtx, Vertex **vertexList, Object *obj, unk80068514_arg4 *arg4,
-                            s32 flags) {
+s32 render_sprite_billboard(Gfx **dList, MatrixS **mtx, Vertex **vertexList, Object *obj, Sprite *arg4, s32 flags) {
     f32 diffX;
     f32 diffY;
     Vertex *v;
@@ -1128,7 +1127,7 @@ s32 render_sprite_billboard(Gfx **dList, MatrixS **mtx, Vertex **vertexList, Obj
         gDkrEnableBillboard((*dList)++);
     }
     if (gSpriteAnimOff == FALSE) {
-        textureFrame = ((textureFrame & 0xFF) * arg4->textureCount) >> 8;
+        textureFrame = ((textureFrame & 0xFF) * arg4->baseTextureId) >> 8;
     }
     flags &= ~RENDER_VEHICLE_PART;
     if (flags & RENDER_SEMI_TRANSPARENT) {
@@ -1139,7 +1138,7 @@ s32 render_sprite_billboard(Gfx **dList, MatrixS **mtx, Vertex **vertexList, Obj
     if (!(flags & RENDER_Z_UPDATE)) {
         gDPSetPrimColor((*dList)++, 0, 0, 255, 255, 255, 255);
     }
-    gSPDisplayList((*dList)++, arg4->unk8[textureFrame + 1]);
+    gSPDisplayList((*dList)++, arg4->gfx[textureFrame + 1]);
     gModelMatrixStackPos--;
     if (gModelMatrixStackPos == 0) {
         textureFrame = 0;

--- a/src/camera.h
+++ b/src/camera.h
@@ -71,14 +71,6 @@ typedef struct ScreenViewport {
     /* 0x30 */ s32 flags;
 } ScreenViewport;
 
-typedef struct unk80068514_arg4 {
-    s16 textureCount;
-    s16 unk2;
-    s16 unk4;
-    s16 drawFlags;
-    Gfx *unk8[1];
-} unk80068514_arg4;
-
 void func_80066060(s32 cameraID, s32 zoomLevel);
 void set_viewport_tv_type(s8 setting);
 void func_800660C0(void);
@@ -122,7 +114,7 @@ void set_camera_shake_by_distance(f32 x, f32 y, f32 z, f32 dist, f32 magnitude);
 void set_camera_shake(f32 magnitude);
 void func_80067D3C(Gfx **dList, MatrixS **mats);
 void render_ortho_triangle_image(Gfx **dList, MatrixS **mtx, Vertex **vtx, ObjectSegment *segment, Sprite *sprite, s32 flags);
-s32 render_sprite_billboard(Gfx **dList, MatrixS **mtx, Vertex **vertexList, Object *obj, unk80068514_arg4 *arg4, s32 flags);
+s32 render_sprite_billboard(Gfx **dList, MatrixS **mtx, Vertex **vertexList, Object *obj, Sprite *arg4, s32 flags);
 s32 camera_push_model_mtx(Gfx **dList, MatrixS **mtx, ObjectTransform *trans, f32 scale, f32 scaleY);
 void viewport_scissor(Gfx **dList);
 void apply_matrix_from_stack(Gfx **dList);

--- a/src/game_ui.c
+++ b/src/game_ui.c
@@ -273,7 +273,7 @@ u8 gHudSlide;
 u8 gHideRaceTimer;
 u8 gNumActivePlayers;
 u8 gWrongWayNagPrefix;
-SoundHandle gRaceStartSoundMask;
+AudioPoint *gRaceStartSoundMask;
 SoundHandle gHUDVoiceSoundMask;
 SoundHandle gHudBalloonSoundMask;
 u16 gHudTTSoundID;
@@ -1916,7 +1916,7 @@ void hud_race_start(s32 countdown, s32 updateRate) {
                 s32 numRacerObjects;
                 racerGroup = get_racer_objects(&numRacerObjects);
                 randomRacer = racerGroup[get_random_number_from_range(1, numRacerObjects) - 1];
-                racer = (Object_Racer *) randomRacer->unk64;
+                racer = &randomRacer->unk64->racer;
                 if (racer->vehicleID == VEHICLE_CAR) {
                     if (get_random_number_from_range(0, 100) >= 96) {
                         frequency = 1.25 - ((get_random_number_from_range(0, 7) * 0.5) / 7.0);

--- a/src/game_ui.c
+++ b/src/game_ui.c
@@ -3117,7 +3117,7 @@ void hud_weapon(Object *obj, s32 updateRate) {
  * If currently using a magnet, render a reticle over the racer that's being targeted.
  */
 void hud_magnet_reticle(Object *racerObj) {
-    unk80068514_arg4 *entry;
+    Sprite *entry;
     HudElement *hud;
     Object_Racer *racer;
 

--- a/src/menu.c
+++ b/src/menu.c
@@ -3512,14 +3512,14 @@ s32 menu_title_screen_loop(s32 updateRate) {
     } else if ((gMenuDelay == 0) && !is_controller_missing()) {
         s32 temp0 = gTitleScreenCurrentOption;
         // gMenuStickY[PLAYER_MENU] = +1 when going up, and -1 when going down.
-        if ((gMenuStickY[PLAYER_MENU] < 0) && (gTitleScreenCurrentOption < 1)) {
+        if (gMenuStickY[PLAYER_MENU] < 0 && gTitleScreenCurrentOption < 1) {
             gTitleScreenCurrentOption++;
         }
-        if ((gMenuStickY[PLAYER_MENU] > 0) && (gTitleScreenCurrentOption > 0)) {
+        if (gMenuStickY[PLAYER_MENU] > 0 && gTitleScreenCurrentOption > 0) {
             gTitleScreenCurrentOption--;
         }
         if (temp0 != gTitleScreenCurrentOption) {
-            sound_play(SOUND_MENU_PICK2, (s32 *) (0 * contrIndex)); // TODO: The `* contrIndex` here is a fake match.
+            sound_play(SOUND_MENU_PICK2, (SoundHandle *) (s32 *) (0 * contrIndex)); // TODO: The `* contrIndex` here is a fake match.
         }
         if (gMenuButtons[PLAYER_MENU] & (A_BUTTON | START_BUTTON)) {
             for (contrIndex = 3; contrIndex > 0 && !(gMenuButtons[contrIndex] & (A_BUTTON | START_BUTTON));

--- a/src/menu.c
+++ b/src/menu.c
@@ -3519,7 +3519,8 @@ s32 menu_title_screen_loop(s32 updateRate) {
             gTitleScreenCurrentOption--;
         }
         if (temp0 != gTitleScreenCurrentOption) {
-            sound_play(SOUND_MENU_PICK2, (SoundHandle *) (s32 *) (0 * contrIndex)); // TODO: The `* contrIndex` here is a fake match.
+            sound_play(SOUND_MENU_PICK2,
+                       (SoundHandle *) (s32 *) (0 * contrIndex)); // TODO: The `* contrIndex` here is a fake match.
         }
         if (gMenuButtons[PLAYER_MENU] & (A_BUTTON | START_BUTTON)) {
             for (contrIndex = 3; contrIndex > 0 && !(gMenuButtons[contrIndex] & (A_BUTTON | START_BUTTON));

--- a/src/object_functions.c
+++ b/src/object_functions.c
@@ -1352,7 +1352,7 @@ void obj_loop_stopwatchman(Object *obj, s32 updateRate) {
                 slowly_change_fog(PLAYER_ONE, tt->fogR, tt->fogG, tt->fogB, tt->fogNear, tt->fogFar, 180);
                 music_play(header->music);
                 music_dynamic_set(header->instruments);
-                racer->vehicleSound = func_80004B40(racer->characterId, racer->vehicleID);
+                racer->vehicleSound = racer_sound_init(racer->characterId, racer->vehicleID);
             }
             obj->properties.npc.timer = 180;
             move_object(obj, obj->segment.x_velocity * updateRateF, obj->segment.y_velocity * updateRateF,
@@ -2876,7 +2876,7 @@ void obj_loop_parkwarden(Object *obj, s32 updateRate) {
                 }
                 obj->properties.npc.action = TAJ_MODE_TELEPORT_AWAY_BEGIN;
                 sound_play(SOUND_WHOOSH4, NULL);
-                racer->vehicleSound = func_80004B40(racer->characterId, racer->vehicleID);
+                racer->vehicleSound = racer_sound_init(racer->characterId, racer->vehicleID);
             }
             break;
         case TAJ_MODE_TELEPORT_TO_PLAYER_BEGIN:
@@ -2935,7 +2935,7 @@ void obj_loop_parkwarden(Object *obj, s32 updateRate) {
             if (obj->segment.object.opacity > var_a2) {
                 obj->segment.object.opacity -= var_a2;
             } else {
-                racer->vehicleSound = func_80004B40(racer->characterId, racer->vehicleID);
+                racer->vehicleSound = racer_sound_init(racer->characterId, racer->vehicleID);
                 slowly_change_fog(PLAYER_ONE, taj->fogR, taj->fogG, taj->fogB, taj->fogNear, taj->fogFar, 180);
                 music_voicelimit_set(levelHeader->voiceLimit);
                 music_play(levelHeader->music);

--- a/src/object_functions.c
+++ b/src/object_functions.c
@@ -6304,7 +6304,7 @@ void obj_loop_bubbler(Object *obj, s32 updateRate) {
 
 void obj_init_boost(Object *obj, LevelObjectEntry_Boost2 *entry) {
     Object_Boost *asset20 = (Object_Boost *) get_misc_asset(ASSET_MISC_20);
-    obj->unk64 = (Object_64 *) &asset20[entry->unk8[0]].unk0;
+    obj->unk64 = (Object_64 *) &asset20[entry->unk8[0]];
     obj->segment.level_entry = NULL;
 }
 

--- a/src/object_functions.c
+++ b/src/object_functions.c
@@ -6303,7 +6303,8 @@ void obj_loop_bubbler(Object *obj, s32 updateRate) {
 }
 
 void obj_init_boost(Object *obj, LevelObjectEntry_Boost2 *entry) {
-    obj->unk64 = (Object_64 *) ((s32) get_misc_asset(ASSET_MISC_20) + (entry->unk8[0] << 7));
+    Object_Boost *asset20 = (Object_Boost *) get_misc_asset(ASSET_MISC_20);
+    obj->unk64 = (Object_64 *) &asset20[entry->unk8[0]].unk0;
     obj->segment.level_entry = NULL;
 }
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -343,7 +343,7 @@ typedef struct LevelObjectEntry_unk8000B020 {
  * This function is called on every level load, but only racers use the stuff here.
  */
 void racerfx_alloc(s32 numberOfVertices, s32 numberOfTriangles) {
-    Asset20 *miscAsset20;
+    Object_Boost *miscAsset20;
     LevelObjectEntry_unk8000B020 objEntry;
     s32 i;
 
@@ -357,7 +357,7 @@ void racerfx_alloc(s32 numberOfVertices, s32 numberOfTriangles) {
     gBoostTriCount = numberOfTriangles;
     D_8011B004 = 0;
     gBoostVertFlip = 0;
-    miscAsset20 = (Asset20 *) get_misc_asset(ASSET_MISC_20);
+    miscAsset20 = (Object_Boost *) get_misc_asset(ASSET_MISC_20);
     // Makes 10 boost objects, but only 8 racers can actually exist at once.
     for (i = 0; i < NUMBER_OF_CHARACTERS; i++) {
         objEntry.common.objectID = ASSET_OBJECT_ID_BOOST;
@@ -408,7 +408,7 @@ void racerfx_alloc(s32 numberOfVertices, s32 numberOfTriangles) {
 void racerfx_free(void) {
     Sprite *sprite;
     TextureHeader *texture;
-    Asset20 *asset20;
+    Object_Boost *asset20;
     u32 i;
 
     if (gBoostTris[0]) {
@@ -418,7 +418,7 @@ void racerfx_free(void) {
         gBoostVerts[0] = NULL;
         gBoostVerts[1] = NULL;
     }
-    asset20 = (Asset20 *) get_misc_asset(ASSET_MISC_20);
+    asset20 = (Object_Boost *) get_misc_asset(ASSET_MISC_20);
     for (i = 0; i < NUMBER_OF_CHARACTERS; i++) {
         sprite = asset20[i].unk78;
         if (sprite != NULL) {
@@ -444,7 +444,100 @@ void racerfx_free(void) {
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/objects/func_8000B38C.s")
+
+#ifdef NON_EQUIVALENT
+void func_8000B38C(Vertex *, Triangle *, ObjectTransform *, f32, f32, s16, TextureHeader *arg6);
+void func_8000B750(Object *obj, s32 objId, s32 arg2, s32 arg3, s32 arg4) {
+    Vec3f sp74;
+    ObjectTransform sp50;
+    Object_Boost **temp_v0;
+    Object **var_t2;
+    f32 temp_f0;
+    f32 var_f14;
+    f32 var_f2;
+    Object_Boost *temp_t4;
+    Object_Boost *temp_v1;
+    Object_Boost_Inner *var_v0;
+
+    if (objId == -1) {
+        objId = gBoostObjOverrideID;
+        gBoostObjOverrideID--;
+    }
+    if (gBoostObjOverrideID < 0) {
+        gBoostObjOverrideID = 0;
+    }
+    if (objId >= 0 && objId < 10) {
+        temp_v0 = get_misc_asset(ASSET_MISC_20);
+        var_t2 = &gBoostEffectObjects[objId];
+        temp_t4 = &temp_v0[(arg3 << 5)];
+        temp_v1 = &temp_v0[(objId << 5)];
+        if (*var_t2 != NULL) {
+            switch (arg2) {
+                default:
+                    var_v0 = &temp_v1->unk48;
+                    if (arg2 != 0xD) {
+                        var_v0 = NULL;
+                    }
+                    break;
+                case 0:
+                    var_v0 = &temp_v1->unk0;
+                    break;
+                case 1:
+                    var_v0 = &temp_v1->unk24;
+                    break;
+                case 2:
+                    var_v0 = &temp_v1->unk48;
+                    break;
+            }
+            if (var_v0 != NULL) {
+                D_8011B048[objId] = arg2;
+                D_8011B058[objId] = arg3;
+                if (temp_v1->unk70 == 2) {
+                    temp_f0 = coss_f(temp_v1->unk72 << 12);
+                    var_f2 = (var_v0->unk14 + (temp_f0 * var_v0->unk18)) * temp_v1->unk74;
+                    var_f14 = (var_v0->unk1C + (temp_f0 * var_v0->unk20)) * temp_v1->unk74;
+                    if ((arg3 & 3) == 1) {
+                        var_f2 *= 1.09f;
+                        var_f14 *= 1.09f;
+                    }
+                    if ((arg3 & 3) >= 2) {
+                        var_f2 *= 1.18f;
+                        var_f14 *= 1.18f;
+                    }
+                    sp50.x_position = var_v0->position.x;
+                    sp50.y_position = var_v0->position.y;
+                    sp50.z_position = var_v0->position.z;
+                    sp50.scale = 1.0f;
+                    sp50.rotation.x_rotation = -0x8000;
+                    sp50.rotation.y_rotation = 0;
+                    sp50.rotation.z_rotation = 0;
+                    func_8000B38C(&gBoostVerts[gBoostVertFlip][D_8011AFFC], &gBoostTris[gBoostVertFlip][D_8011B004],
+                                  &sp50, var_f2, var_f14, (temp_v1->unk72), &temp_t4->unk7C);
+                    (*var_t2)->properties.common.unk4 = (objId << 28) | (D_8011AFFC << 14) | D_8011B004;
+                    D_8011AFFC += 9;
+                    D_8011B004 += 8;
+                }
+                (*var_t2)->properties.common.unk0 = (s32) obj;
+                (*var_t2)->segment.trans.x_position = 0.0f;
+                (*var_t2)->segment.trans.y_position = 0.0f;
+                (*var_t2)->segment.trans.z_position = 0.0f;
+                sp74.x = var_v0->position.x;
+                sp74.y = var_v0->position.y;
+                sp74.z = var_v0->position.z;
+                f32_vec3_apply_object_rotation(&obj->segment.trans, &sp74);
+                ignore_bounds_check();
+                move_object(var_t2, sp74.x + obj->segment.trans.x_position, sp74.y + obj->segment.trans.y_position,
+                            sp74.z + obj->segment.trans.z_position);
+            }
+            if (arg4 != 0) {
+                D_8011B068[objId] = 0;
+            }
+        }
+    }
+}
+#else
 #pragma GLOBAL_ASM("asm/nonmatchings/objects/func_8000B750.s")
+#endif
 
 /**
  * Updates the racer FX object states.
@@ -452,16 +545,16 @@ void racerfx_free(void) {
  */
 void racerfx_update(s32 updateRate) {
     s32 i;
-    Asset20 *asset20Part;
+    Object_Boost *asset20Part;
     s32 temp;
-    Asset20 *asset20;
+    Object_Boost *asset20;
     f32 updateRateF;
     Object_Racer *racer;
 
     gBoostVertFlip = 1 - gBoostVertFlip;
     D_8011AFFC = 0;
     D_8011B004 = 0;
-    asset20 = (Asset20 *) get_misc_asset(ASSET_MISC_20);
+    asset20 = (Object_Boost *) get_misc_asset(ASSET_MISC_20);
     gBoostObjOverrideID = 9;
     for (i = 0; i < NUMBER_OF_CHARACTERS; i++) {
         if (D_8011B068[i] && gBoostEffectObjects[i] != NULL) {
@@ -2846,7 +2939,7 @@ void render_3d_billboard(Object *obj) {
                            RENDER_Z_COMPARE | RENDER_SEMI_TRANSPARENT | RENDER_Z_UPDATE);
     } else {
         render_sprite_billboard(&gObjectCurrDisplayList, &gObjectCurrMatrix, &gObjectCurrVertexList, obj,
-                                (unk80068514_arg4 *) gfxData, flags);
+                                (Sprite *) gfxData, flags);
     }
     if (hasPrimCol) {
         gDPSetPrimColor(gObjectCurrDisplayList++, 0, 0, 255, 255, 255, 255);
@@ -3034,9 +3127,9 @@ void render_3d_model(Object *obj) {
                                 gDPSetEnvColor(gObjectCurrDisplayList++, 255, 255, 255, 0);
                                 gDPSetPrimColor(gObjectCurrDisplayList++, 0, 0, intensity, intensity, intensity, alpha);
                             }
-                            loopObj->properties.common.unk0 = render_sprite_billboard(
-                                &gObjectCurrDisplayList, &gObjectCurrMatrix, &gObjectCurrVertexList, loopObj,
-                                (unk80068514_arg4 *) something, flags);
+                            loopObj->properties.common.unk0 =
+                                render_sprite_billboard(&gObjectCurrDisplayList, &gObjectCurrMatrix,
+                                                        &gObjectCurrVertexList, loopObj, (Sprite *) something, flags);
                             if (var_v0_2) {
                                 gDkrInsertMatrix(gObjectCurrDisplayList++, 0, 0);
                                 func_80012CE8(&gObjectCurrDisplayList);
@@ -3065,7 +3158,7 @@ void render_3d_model(Object *obj) {
                     loopObj->segment.trans.z_position += (vtxZ - loopObj->segment.trans.z_position) * 0.25;
                     if (loopObj->segment.header->modelType == OBJECT_MODEL_TYPE_SPRITE_BILLBOARD) {
                         render_sprite_billboard(&gObjectCurrDisplayList, &gObjectCurrMatrix, &gObjectCurrVertexList,
-                                                loopObj, (unk80068514_arg4 *) something, flags);
+                                                loopObj, (Sprite *) something, flags);
                     }
                 }
             }
@@ -3379,7 +3472,7 @@ void func_800135B8(Object *boostObj) {
     ObjectTransform_800135B8 objTransform;
     Object_Boost_Inner *boostData;
     Object_Boost *boost;
-    Asset20 *asset;
+    Object_Boost *asset;
     s32 hasTexture;
     s32 idx;
 
@@ -3396,7 +3489,7 @@ void func_800135B8(Object *boostObj) {
             boostData = &boost->unk48;
             break;
     }
-    asset = (Asset20 *) get_misc_asset(ASSET_MISC_20);
+    asset = (Object_Boost *) get_misc_asset(ASSET_MISC_20);
     asset = &asset[D_8011B058[idx]];
     object_do_player_tumble((Object *) boostObj->properties.common.unk0);
     camera_push_model_mtx(&gObjectCurrDisplayList, &gObjectCurrMatrix,
@@ -3467,7 +3560,7 @@ void render_bubble_trap(ObjectTransform *trans, Object_68 *gfxData, Object *obj,
     obj->segment.trans.y_position += y;
     obj->segment.trans.z_position += z;
     render_sprite_billboard(&gObjectCurrDisplayList, &gObjectCurrMatrix, &gObjectCurrVertexList, obj,
-                            (unk80068514_arg4 *) gfxData, flags);
+                            (Sprite *) gfxData, flags);
 }
 
 /**

--- a/src/objects.c
+++ b/src/objects.c
@@ -1292,7 +1292,7 @@ void func_8000CC7C(Vehicle vehicle, u32 arg1, s32 arg2) {
                 }
             }
             if ((gameMode != GAMEMODE_MENU || D_8011AD3C == 2) && vehicle < VEHICLE_BOSSES) {
-                curRacer->vehicleSound = func_80004B40(curRacer->characterId, curRacer->vehicleID);
+                curRacer->vehicleSound = racer_sound_init(curRacer->characterId, curRacer->vehicleID);
             } else {
                 curRacer->vehicleSound = NULL;
             }

--- a/src/objects.h
+++ b/src/objects.h
@@ -326,21 +326,6 @@ typedef struct unk800149C0 {
     s16 unk6;
 } unk800149C0;
 
-// Size: 0x80 bytes.
-typedef struct Asset20 {
-    f32 unk0;
-    u8 pad4[0x68];
-    s16 unk6C;
-    s16 unk6E;
-    u8 unk70;
-    u8 unk71;
-    u8 unk72;
-    s8 unk73;
-    f32 unk74;
-    Sprite *unk78;
-    TextureHeader *unk7C;
-} Asset20;
-
 typedef struct RacerFXData {
     u8 unk0;
     u8 unk1;
@@ -535,7 +520,7 @@ void decrypt_magic_codes(s32 *data, s32 length);
 s32 get_first_active_object(s32 *);
 Object *spawn_object(LevelObjectEntryCommon *entry, s32);
 s32 func_8001F460(Object*, s32, Object*);
-void func_8000B750(Object *arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4);
+void func_8000B750(Object *obj, s32 objId, s32 arg2, s32 arg3, s32 arg4);
 void func_80018CE0(Object* obj, f32 xPos, f32 yPos, f32 zPos, s32 updateRate);
 s32 func_800185E4(s8, Object* obj, f32 xPos, f32 yPos, f32 zPos, f32* checkpointDistance, u8*); 
 void func_80011134(Object *, s32);

--- a/src/particles.c
+++ b/src/particles.c
@@ -2411,8 +2411,7 @@ void render_particle(Particle *particle, Gfx **dList, MatrixS **mtx, Vertex **vt
             temp = particle->textureFrame;
             particle->textureFrame >>= 8;
             particle->textureFrame = (particle->textureFrame * 255) / (particle->sprite->baseTextureId);
-            render_sprite_billboard(dList, mtx, vtx, (Object *) particle, (unk80068514_arg4 *) particle->sprite,
-                                    renderFlags);
+            render_sprite_billboard(dList, mtx, vtx, (Object *) particle, particle->sprite, renderFlags);
             particle->textureFrame = temp;
         } else {
             model = particle->model;

--- a/src/particles.h
+++ b/src/particles.h
@@ -242,7 +242,7 @@ typedef struct Particle {
     /* 0x40 */ s32 descFlags;
     union {
     /* 0x44 */ ParticleModel *model;
-    /* 0x44 */ Sprite *sprite; // Unclear whether this is the same as unk80068514_arg4
+    /* 0x44 */ Sprite *sprite;
     };
     /* 0x48 */ s16 unk_48;
     /* 0x4A */ s16 brightness;

--- a/src/racer.c
+++ b/src/racer.c
@@ -923,7 +923,7 @@ void func_80046524(s32 updateRate, f32 updateRateF, Object *obj, Object_Racer *r
     s32 var_v1;
     Unknown80046524 *temp_v0_16;
     s32 var_t0;
-    Asset20 *asset20;
+    Object_Boost *asset20;
     s8 lastWheelSurface;
     s8 wave_properties;
     s8 wheelsOnStone;
@@ -1520,7 +1520,7 @@ void func_80046524(s32 updateRate, f32 updateRateF, Object *obj, Object_Racer *r
         }
     }
     if (gCurrentPlayerIndex != PLAYER_COMPUTER && racer->boostTimer == 0 && gNumViewports < 2) {
-        asset20 = (Asset20 *) get_misc_asset(ASSET_MISC_20);
+        asset20 = (Object_Boost *) get_misc_asset(ASSET_MISC_20);
         asset20 = &asset20[racer->racerIndex];
         iTemp = ((racer->boostType & EMPOWER_BOOST) >> 2) + 10;
         if (iTemp > 10) {
@@ -2969,7 +2969,7 @@ void func_8004F7F4(s32 updateRate, f32 updateRateF, Object *racerObj, Object_Rac
     f32 spA0;
     Matrix sp60;
     LevelHeader *currentLevelHeader;
-    Asset20 *asset20;
+    Object_Boost *asset20;
     s32 var_v1;
     s8 playerObjectHasMoved;
     s32 objectMoved;
@@ -3208,7 +3208,7 @@ void func_8004F7F4(s32 updateRate, f32 updateRateF, Object *racerObj, Object_Rac
             }
         }
         if (racer->boostTimer == 0 && gNumViewports < 2) {
-            asset20 = (Asset20 *) get_misc_asset(ASSET_MISC_20);
+            asset20 = (Object_Boost *) get_misc_asset(ASSET_MISC_20);
             asset20 = &asset20[racer->racerIndex];
             var_v1 = ((racer->boostType & EMPOWER_BOOST) >> 2) + 0x10;
             if (var_v1 > 0x10) {

--- a/src/racer.c
+++ b/src/racer.c
@@ -3520,7 +3520,8 @@ void func_80050A28(Object *obj, Object_Racer *racer, s32 updateRate, f32 updateR
                 sound_play_spatial(SOUND_CAR_SLIDE, obj->segment.trans.x_position, obj->segment.trans.y_position,
                                    obj->segment.trans.z_position, &racer->unk10);
             } else {
-                audspat_calculate_echo((SoundHandle) (s32) racer->unk10, obj->segment.trans.x_position, obj->segment.trans.y_position,
+                audspat_calculate_echo((SoundHandle) (s32) racer->unk10, obj->segment.trans.x_position,
+                                       obj->segment.trans.y_position,
                                        obj->segment.trans.z_position); // type cast required to match
             }
             if (racer->unk14) {

--- a/src/racer.c
+++ b/src/racer.c
@@ -3057,7 +3057,7 @@ void func_8004F7F4(s32 updateRate, f32 updateRateF, Object *racerObj, Object_Rac
             update_car_velocity_offground(racerObj, racer, updateRate, updateRateF);
         }
         if (racer->unk1C != 0) {
-            sndp_stop((s32) racer->unk1C); // type cast required to match
+            sndp_stop((SoundHandle) (s32) racer->unk1C); // type cast required to match
             racer->unk1C = 0;
         }
         if (racer->buoyancy != 0.0f && racer->vehicleIDPrev != VEHICLE_BUBBLER) {
@@ -3520,23 +3520,23 @@ void func_80050A28(Object *obj, Object_Racer *racer, s32 updateRate, f32 updateR
                 sound_play_spatial(SOUND_CAR_SLIDE, obj->segment.trans.x_position, obj->segment.trans.y_position,
                                    obj->segment.trans.z_position, &racer->unk10);
             } else {
-                audspat_calculate_echo((s32) racer->unk10, obj->segment.trans.x_position, obj->segment.trans.y_position,
-                                       obj->segment.trans.z_position);
+                audspat_calculate_echo((SoundHandle) (s32) racer->unk10, obj->segment.trans.x_position, obj->segment.trans.y_position,
+                                       obj->segment.trans.z_position); // type cast required to match
             }
             if (racer->unk14) {
-                sndp_stop((s32) racer->unk14); // type cast required to match
+                sndp_stop((SoundHandle) (s32) racer->unk14); // type cast required to match
             }
         } else {
             if (racer->unk10) {
-                sndp_stop((s32) racer->unk10); // type cast required to match
+                sndp_stop((SoundHandle) (s32) racer->unk10); // type cast required to match
             }
         }
     } else {
         if (racer->unk10) {
-            sndp_stop((s32) racer->unk10); // type cast required to match
+            sndp_stop((SoundHandle) (s32) racer->unk10); // type cast required to match
         }
         if (racer->unk14) {
-            sndp_stop((s32) racer->unk14); // type cast required to match
+            sndp_stop((SoundHandle) (s32) racer->unk14); // type cast required to match
         }
     }
     // Velocity of steering input
@@ -3715,7 +3715,7 @@ void func_80050A28(Object *obj, Object_Racer *racer, s32 updateRate, f32 updateR
         sound_play(surfaceType, &racer->unk18);
     }
     if (racer->unk18 != 0 && (surfaceType == SOUND_NONE || racer->velocity > -2.0)) {
-        sndp_stop((s32) racer->unk18); // type cast required to match
+        sndp_stop((SoundHandle) (s32) racer->unk18); // type cast required to match
     }
     // Apply a bobbing effect when on grass and sand.
     if (racer->velocity < -2.0 && sp68 >= 4) {
@@ -4171,13 +4171,13 @@ void update_car_velocity_offground(Object *obj, Object_Racer *racer, s32 updateR
         racer->x_rotation_vel += (angle >> 3); //!@Delta
     }
     if (racer->unk18) {
-        sndp_stop((s32) racer->unk18); // type cast required to match
+        sndp_stop((SoundHandle) (s32) racer->unk18); // type cast required to match
     }
     if (racer->unk10) {
-        sndp_stop((s32) racer->unk10); // type cast required to match
+        sndp_stop((SoundHandle) (s32) racer->unk10); // type cast required to match
     }
     if (racer->unk14) {
-        sndp_stop((s32) racer->unk14); // type cast required to match
+        sndp_stop((SoundHandle) (s32) racer->unk14); // type cast required to match
     }
     if (racer->unk1FE == 1 || racer->unk1FE == 3) {
         racer->unk1E8 = racer->steerAngle;

--- a/src/textures_sprites.c
+++ b/src/textures_sprites.c
@@ -505,7 +505,7 @@ TextureHeader *load_texture(s32 arg0) {
     }
     D_80126344 = 0;
 
-    assetOffset = (s32)align16((u8 *) ((s32) tex + assetSize));
+    assetOffset = (s32) align16((u8 *) ((s32) tex + assetSize));
     texTemp = tex;
     for (i = 0; i < numberOfTextures; i++) {
         material_init(texTemp, (Gfx *) assetOffset);

--- a/src/weather.c
+++ b/src/weather.c
@@ -694,7 +694,7 @@ void lensflare_render(Gfx **dList, MatrixS **mats, Vertex **verts, ObjectSegment
                                             lensFlareData->colour.b,
                                             (s32) (lensFlareData->colour.a * magSquareSquared));
                             render_sprite_billboard(dList, mats, verts, (Object *) &trans,
-                                                    (unk80068514_arg4 *) gLensFlare->unk68[lensFlareData->count],
+                                                    (Sprite *) gLensFlare->unk68[lensFlareData->count],
                                                     (RENDER_SEMI_TRANSPARENT | RENDER_Z_UPDATE));
                             lensFlareData++;
                         }
@@ -1011,7 +1011,7 @@ void rain_render_splashes(s32 updateRate) {
 
                     gDPSetPrimColor(gCurrWeatherDisplayList++, 0, 0, 192, 192, 255, gRainSplashSegments[i].opacity);
                     render_sprite_billboard(&gCurrWeatherDisplayList, &gCurrWeatherMatrix, &gCurrWeatherVertexList,
-                                            (Object *) &gRainSplashSegments[i], (unk80068514_arg4 *) gRainSplashGfx,
+                                            (Object *) &gRainSplashSegments[i], gRainSplashGfx,
                                             RENDER_Z_COMPARE | RENDER_SEMI_TRANSPARENT | RENDER_FOG_ACTIVE |
                                                 RENDER_Z_UPDATE);
                 }

--- a/ver/symbols/symbol_addrs.jpn.v79.txt
+++ b/ver/symbols/symbol_addrs.jpn.v79.txt
@@ -119,7 +119,7 @@ sndp_get_group_volume = 0x80004A3C;
 sndp_set_group_volume = 0x80004A60;
 
 // audio_vehicle.c .text
-func_80004B40 = 0x80004B40;
+racer_sound_init = 0x80004B40;
 racer_sound_update = 0x800050D0;
 func_80005254 = 0x80005254;
 racer_sound_hovercraft = 0x80005D08;

--- a/ver/symbols/symbol_addrs.pal.v77.txt
+++ b/ver/symbols/symbol_addrs.pal.v77.txt
@@ -119,7 +119,7 @@ sndp_get_group_volume = 0x80004A3C;
 sndp_set_group_volume = 0x80004A60;
 
 // audio_vehicle.c .text
-func_80004B40 = 0x80004B40;
+racer_sound_init = 0x80004B40;
 racer_sound_update = 0x800050D0;
 func_80005254 = 0x80005254;
 racer_sound_hovercraft = 0x80005D08;

--- a/ver/symbols/symbol_addrs.pal.v80.txt
+++ b/ver/symbols/symbol_addrs.pal.v80.txt
@@ -119,7 +119,7 @@ sndp_get_group_volume = 0x80004A3C;
 sndp_set_group_volume = 0x80004A60;
 
 // audio_vehicle.c .text
-func_80004B40 = 0x80004B40;
+racer_sound_init = 0x80004B40;
 racer_sound_update = 0x800050D0;
 func_80005254 = 0x80005254;
 racer_sound_hovercraft = 0x80005D08;

--- a/ver/symbols/symbol_addrs.us.v77.txt
+++ b/ver/symbols/symbol_addrs.us.v77.txt
@@ -119,7 +119,7 @@ sndp_get_group_volume = 0x80004A3C;
 sndp_set_group_volume = 0x80004A60;
 
 // audio_vehicle.c .text
-func_80004B40 = 0x80004B40;
+racer_sound_init = 0x80004B40;
 racer_sound_update = 0x800050D0;
 func_80005254 = 0x80005254;
 racer_sound_hovercraft = 0x80005D08;

--- a/ver/symbols/symbol_addrs.us.v80.txt
+++ b/ver/symbols/symbol_addrs.us.v80.txt
@@ -119,7 +119,7 @@ sndp_get_group_volume = 0x80004A3C;
 sndp_set_group_volume = 0x80004A60;
 
 // audio_vehicle.c .text
-func_80004B40 = 0x80004B40;
+racer_sound_init = 0x80004B40;
 racer_sound_update = 0x800050D0;
 func_80005254 = 0x80005254;
 racer_sound_hovercraft = 0x80005D08;


### PR DESCRIPTION
Fixes a lot of warnings, as well.

I was working on `func_8000B750` when I noticed that Asset20 is Object_Boost, so I decided to clean that up, and somehow that lead me to convert unk80068514_arg4 to Sprite as well.

Then I fell into the trap of trying to fix all of our warnings. So I figured rather than let this get out of hand, I should submit it now.