### PR TITLE
Extend score.py script to generate treemap file for decomp progress

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ cxxfilt>=0.3.0
 mapfile-parser>=2.7.5
 PyYAML>=6.0.2
 colour>=0.1.5
+plotly>=6.1.0


### PR DESCRIPTION
This PR introduces the ability to pass a `--treemap` parameter to the score.py script.

It will generating a treemap .html file to show decomp progress.
It ain't pretty, but it gives us a vague picture which files have the most unmatched functions in a visual way.