### PR TITLE
Fix opt flags for GCC builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,7 @@ ASM_PROCESSOR      = $(PYTHON) $(ASM_PROCESSOR_DIR)/build.py
 ### Optimisation Overrides
 ####################### LIBULTRA #########################
 
+ifeq ($(COMPILER),ido)
 $(BUILD_DIR)/$(LIBULTRA_DIR)/%.c.o: OPT_FLAGS := -O2
 $(BUILD_DIR)/$(LIBULTRA_DIR)/src/audio/%.c.o: OPT_FLAGS := -O3
 $(BUILD_DIR)/$(LIBULTRA_DIR)/src/audio/mips1/%.c.o: OPT_FLAGS := -O2
@@ -267,7 +268,6 @@ $(BUILD_DIR)/$(LIBULTRA_DIR)/src/audio/env.c.o: MIPSISET := -mips1
 $(BUILD_DIR)/$(LIBULTRA_DIR)/%.c.o: CC_WARNINGS := -w
 $(BUILD_DIR)/$(LIBULTRA_DIR)/%.c.o: CC_CHECK := :
 
-ifeq ($(COMPILER),ido)
 # Allow dollar sign to be used in var names for this file alone
 # It allows us to return the current stack pointer
 $(BUILD_DIR)/$(SRC_DIR)/get_stack_pointer.c.o: OPT_FLAGS += -dollar
@@ -283,10 +283,13 @@ endif
 $(GCC_SAFE_FILES): CC := $(CROSS)gcc
 $(GCC_SAFE_FILES): CC_WARNINGS := 
 $(GCC_SAFE_FILES): MIPSISET := -mips3
-$(GCC_SAFE_FILES): CFLAGS := -DNDEBUG -DAVOID_UB -DNON_MATCHING -O2 $(INCLUDE_CFLAGS) $(C_DEFINES) \
+$(GCC_SAFE_FILES): OPT_FLAGS := -Os
+$(GCC_SAFE_FILES): CFLAGS := -DNDEBUG -DAVOID_UB -DNON_MATCHING $(INCLUDE_CFLAGS) $(C_DEFINES) \
 	-EB \
 	-march=vr4300 \
 	-mabi=32 \
+	-Wno-int-conversion \
+	-Wno-incompatible-pointer-types \
 	-mno-check-zero-division \
 	-mno-abicalls \
 	-mgp32 \

--- a/libultra/src/libc/ldiv.c
+++ b/libultra/src/libc/ldiv.c
@@ -1,5 +1,6 @@
 #include "os_version.h"
 #include "stdlib.h"
+#include "ultra64.h"
 
 // TODO: these come from headers
 #ident "$Revision: 1.34 $"
@@ -32,3 +33,18 @@ lldiv_t lldiv(long long num, long long denom) {
 
     return ret;
 }
+
+
+#ifdef __GNUC__
+u64 __lshrdi3(u64 u, unsigned int b) {
+    return u >> b;
+}
+
+u64 __ashldi3(u64 u, unsigned int b) {
+    return u << b;
+}
+
+s64 __ashrdi3(s64 u, unsigned int b) {
+    return u >> b;
+}
+#endif

--- a/src/objects.c
+++ b/src/objects.c
@@ -6447,9 +6447,7 @@ void func_80019808(s32 updateRate) {
     s32 newStartingPosition;
     s8 sp5C[4];
     s8 someBool2; // sp5B
-#ifdef ANTI_TAMPER
     s8 flags[3];
-#endif
     s32 camera;
 
     currentLevelHeader = get_current_level_header();


### PR DESCRIPTION
GCC currently builds incorrectly, using the optimisation flags from IDO, rather than the override, leading to files not compiling as well as they could. This PR fixes that.