### PR TITLE
Fix the last two unmatched JPN functions that were matched in other versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -334,9 +334,9 @@ no_verify: $(TARGET).z64
 extract:
 	$(SPLAT) ver/splat/$(BASENAME).$(REGION).$(VERSION).yaml
 	$(TOOLS_DIR)/dkr_assets_tool extract -dkrv $(REGION).$(VERSION) >&2 || echo FAIL
-#These are the only 2 jpn region functions that match elsewhere, but not for this region. As a temp hack for progress script reasons, just delete these for other regions.
+#This is only jpn region function that matches in other version, but not for this region. As a temp hack for progress script reasons, just delete this for other regions.
 ifneq ($(REGION),jpn)
-	@$(RM) asm/nonmatchings/menu/pakmenu_render.s asm/nonmatchings/menu/menu_credits_loop.s
+	@$(RM) asm/nonmatchings/menu/menu_credits_loop.s
 endif
 
 extractall:

--- a/Makefile
+++ b/Makefile
@@ -334,10 +334,6 @@ no_verify: $(TARGET).z64
 extract:
 	$(SPLAT) ver/splat/$(BASENAME).$(REGION).$(VERSION).yaml
 	$(TOOLS_DIR)/dkr_assets_tool extract -dkrv $(REGION).$(VERSION) >&2 || echo FAIL
-#This is only jpn region function that matches in other version, but not for this region. As a temp hack for progress script reasons, just delete this for other regions.
-ifneq ($(REGION),jpn)
-	@$(RM) asm/nonmatchings/menu/menu_credits_loop.s
-endif
 
 extractall:
 	$(SPLAT) ver/splat/$(BASENAME).us.v77.yaml

--- a/Makefile
+++ b/Makefile
@@ -334,9 +334,9 @@ no_verify: $(TARGET).z64
 extract:
 	$(SPLAT) ver/splat/$(BASENAME).$(REGION).$(VERSION).yaml
 	$(TOOLS_DIR)/dkr_assets_tool extract -dkrv $(REGION).$(VERSION) >&2 || echo FAIL
-#These are the only 4 jpn region functions that match elsewhere, but not for this region. As a temp hack for progress script reasons, just delete these for other regions.
+#These are the only 2 jpn region functions that match elsewhere, but not for this region. As a temp hack for progress script reasons, just delete these for other regions.
 ifneq ($(REGION),jpn)
-	@$(RM) asm/nonmatchings/menu/savemenu_render_element.s asm/nonmatchings/menu/pakmenu_render.s asm/nonmatchings/menu/results_render.s asm/nonmatchings/menu/menu_credits_loop.s
+	@$(RM) asm/nonmatchings/menu/pakmenu_render.s asm/nonmatchings/menu/menu_credits_loop.s
 endif
 
 extractall:

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ All versions are supported, and the US 1.0 version (SHA1 = 0cb115d8716dbbc2922fd
 <!-- README_SCORE_SUMMARY_BEGIN -->
 As of June 17, 2025, this is our current score:
 
-&emsp;&emsp;&emsp;&emsp;Decomp progress: 92.22%
+&emsp;&emsp;&emsp;&emsp;Decomp progress: 92.49%
 
-&emsp;&emsp;&emsp;&emsp;Documentation progress: 59.33%
+&emsp;&emsp;&emsp;&emsp;Documentation progress: 59.63%
 <!-- README_SCORE_SUMMARY_END -->
 
 ---
@@ -119,28 +119,28 @@ s32 is_drumstick_unlocked(void) {
 <!-- README_SCORE_BEGIN -->
 As of June 17, 2025, this is our current score:
 ```
- =====================================================================
-                ADVENTURE ONE (ASM -> C Decompilation)
- --------------- 92.22% Complete (93.00% NON_MATCHING) ---------------
-                     # Decompiled functions: 1923
-                      # GLOBAL_ASM remaining: 25
+ ======================================================================
+                 ADVENTURE ONE (ASM -> C Decompilation)
+ --------------- 92.49% Complete (93.27% NON_MATCHING) ----------------
+                      # Decompiled functions: 1924
+                       # GLOBAL_ASM remaining: 25
                       # NON_MATCHING functions: 4
-                  # NON_EQUIVALENT WIP functions: 21
- ---------------------------- Game Status ----------------------------
-               Balloons: 43/47, Keys: 4/4, Trophies: 4/5
-                T.T. Amulets: 4/4, Wizpig Amulets: 4/4
- ---------------------------------------------------------------------
- We are collecting silver coins in Spacedust Alley. (7/8 silver coins)
- =====================================================================
+                   # NON_EQUIVALENT WIP functions: 21
+ ---------------------------- Game Status -----------------------------
+               Balloons: 44/47, Keys: 4/4, Trophies: 4/5
+                 T.T. Amulets: 4/4, Wizpig Amulets: 4/4
+ ----------------------------------------------------------------------
+ We are collecting silver coins in Darkmoon Caverns. (0/8 silver coins)
+ ======================================================================
                  ADVENTURE TWO (Cleanup & Documentation)
- -------------------------- 59.33% Complete --------------------------
-                     # Documented functions: 1208
+ -------------------------- 59.63% Complete ---------------------------
+                      # Documented functions: 1209
                      # Undocumented remaining: 440
- ---------------------------- Game Status ----------------------------
+ ---------------------------- Game Status -----------------------------
                Balloons: 29/47, Keys: 3/4, Trophies: 2/5
-                T.T. Amulets: 3/4, Wizpig Amulets: 2/4
- ---------------------------------------------------------------------
- We are collecting silver coins in Treasure Caves. (1/8 silver coins)
- =====================================================================
+                 T.T. Amulets: 3/4, Wizpig Amulets: 2/4
+ ----------------------------------------------------------------------
+  We are collecting silver coins in Treasure Caves. (3/8 silver coins)
+ ======================================================================
 ```
 <!-- README_SCORE_END -->

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ All versions are supported, and the US 1.0 version (SHA1 = 0cb115d8716dbbc2922fd
 <!-- README_SCORE_SUMMARY_BEGIN -->
 As of June 17, 2025, this is our current score:
 
-&emsp;&emsp;&emsp;&emsp;Decomp progress: 92.49%
+&emsp;&emsp;&emsp;&emsp;Decomp progress: 92.78%
 
-&emsp;&emsp;&emsp;&emsp;Documentation progress: 59.63%
+&emsp;&emsp;&emsp;&emsp;Documentation progress: 59.95%
 <!-- README_SCORE_SUMMARY_END -->
 
 ---
@@ -121,8 +121,8 @@ As of June 17, 2025, this is our current score:
 ```
  ======================================================================
                  ADVENTURE ONE (ASM -> C Decompilation)
- --------------- 92.49% Complete (93.27% NON_MATCHING) ----------------
-                      # Decompiled functions: 1924
+ --------------- 92.78% Complete (93.55% NON_MATCHING) ----------------
+                      # Decompiled functions: 1925
                        # GLOBAL_ASM remaining: 25
                       # NON_MATCHING functions: 4
                    # NON_EQUIVALENT WIP functions: 21
@@ -130,17 +130,17 @@ As of June 17, 2025, this is our current score:
                Balloons: 44/47, Keys: 4/4, Trophies: 4/5
                  T.T. Amulets: 4/4, Wizpig Amulets: 4/4
  ----------------------------------------------------------------------
- We are collecting silver coins in Darkmoon Caverns. (0/8 silver coins)
+ We are collecting silver coins in Darkmoon Caverns. (2/8 silver coins)
  ======================================================================
                  ADVENTURE TWO (Cleanup & Documentation)
- -------------------------- 59.63% Complete ---------------------------
-                      # Documented functions: 1209
+ -------------------------- 59.95% Complete ---------------------------
+                      # Documented functions: 1210
                      # Undocumented remaining: 440
  ---------------------------- Game Status -----------------------------
                Balloons: 29/47, Keys: 3/4, Trophies: 2/5
                  T.T. Amulets: 3/4, Wizpig Amulets: 2/4
  ----------------------------------------------------------------------
-  We are collecting silver coins in Treasure Caves. (3/8 silver coins)
+  We are collecting silver coins in Treasure Caves. (5/8 silver coins)
  ======================================================================
 ```
 <!-- README_SCORE_END -->

--- a/src/menu.c
+++ b/src/menu.c
@@ -11202,8 +11202,6 @@ void menu_results_init(void) {
  * Draw the portraits of the four player onscreen, then draw the scoreboard below.
  * After, draw the text options at the bottom.
  */
-#if REGION != REGION_JP
-// NON_EQUIVALENT IN JP - Too lazy to fix it right now, there's so many others to worry about.
 void results_render(UNUSED s32 updateRate, f32 opacity) {
     s32 x2;
     s32 y2;
@@ -11283,6 +11281,7 @@ void results_render(UNUSED s32 updateRate, f32 opacity) {
     for (spA0 = 0; spA0 < 4; spA0++) {
 #endif
         time = offsetX;
+        x2 = offsetX;
 #if REGION == REGION_JP
         func_80082BC8_837C8(-1, time - 40, y2 + offsetY + 2, 2, 2, gRacePlacementsArray[spA0], ALIGN_MIDDLE_CENTER,
                             COLOUR_RGBA32(255, 255, 255, 255), 0);
@@ -11299,7 +11298,6 @@ void results_render(UNUSED s32 updateRate, f32 opacity) {
         sMenuGuiColourG = 255 - 64 * spA0;
         sMenuGuiColourB = 255;
         sMenuGuiColourBlendFactor = 255;
-        x2 = offsetX;
 #if VERSION >= VERSION_79
         for (i = 0; i < gNumberOfActivePlayers; i++, x2 += offsetX2) {
 #else
@@ -11387,10 +11385,6 @@ void results_render(UNUSED s32 updateRate, f32 opacity) {
         open_dialogue_box(7);
     }
 }
-// No match JPN results_render
-#else
-#pragma GLOBAL_ASM("asm/nonmatchings/menu/results_render.s")
-#endif
 
 /**
  * When someone presses A, decide whether to play the stage again,

--- a/src/menu.c
+++ b/src/menu.c
@@ -13028,7 +13028,7 @@ void credits_fade(s32 x1, s32 y1, s32 x2, s32 y2, s32 a) {
     rendermode_reset(&sMenuCurrDisplayList);
 }
 
-#if REGION != REGION_JP
+#if 1
 /**
  * Handles the credits for the game
  */
@@ -13047,7 +13047,7 @@ s32 menu_credits_loop(s32 updateRate) {
     s32 textPos;
     s32 buttonsPressedAllPlayers;
     s32 controlDataLength;
-    s32 creditsMenuElementInex;
+    s32 creditsMenuElementIndex;
     s32 var_s5;
     s32 var_s4;
     s32 textLineHeight;
@@ -13083,8 +13083,8 @@ s32 menu_credits_loop(s32 updateRate) {
         halvedFbSize >>= 17;
         halvedFbSize &= 0x7FFF;
         textPos = halvedFbSize;
-        for (i = 0; i < ARRAY_COUNT(gRacerPortraits); i++) {
-            texrect_draw(&sMenuCurrDisplayList, gRacerPortraits[i], ((sins_s16(var_s5) * var_s4) >> 16) + 140,
+        for (nextIndex = 0; nextIndex < ARRAY_COUNT(gRacerPortraits); nextIndex++) {
+            texrect_draw(&sMenuCurrDisplayList, gRacerPortraits[nextIndex], ((sins_s16(var_s5) * var_s4) >> 16) + 140,
                          (((coss_s16(var_s5) * var_s4) >> 16) + textPos) - 20, 255, 255, 255, 255);
             var_s5 += 0x1999;
         }
@@ -13134,6 +13134,7 @@ s32 menu_credits_loop(s32 updateRate) {
                         var_s5 = FONT_LARGE;
                     } else if (isShowingBestRaceTimes) {
                         textPos -= (controlDataLength * 16) - 3;
+                        if (1){}
                         textLineHeight = 32;
                     } else {
                         // we're showing multiple things
@@ -13148,36 +13149,46 @@ s32 menu_credits_loop(s32 updateRate) {
                         gCreditsMenuElements[0].right = -SCREEN_WIDTH_HALF;
                     }
 
-                    for (creditsMenuElementInex = 0, var_s4 = nextIndex; var_s4 < gCreditsControlDataIndex; var_s4++) {
-                        gCreditsMenuElements[creditsMenuElementInex].top = textPos;
-                        gCreditsMenuElements[creditsMenuElementInex].middle = textPos;
-                        gCreditsMenuElements[creditsMenuElementInex].bottom = textPos;
+                    for (creditsMenuElementIndex = 0, var_s4 = nextIndex; var_s4 < gCreditsControlDataIndex; var_s4++) {
+                        gCreditsMenuElements[creditsMenuElementIndex].top = textPos;
+                        gCreditsMenuElements[creditsMenuElementIndex].middle = textPos;
+                        gCreditsMenuElements[creditsMenuElementIndex].bottom = textPos;
                         if (isShowingBestRaceTimes) {
                             // Best time for a level. Lists level in the first row and then the time in the next row
-                            gCreditsMenuElements[creditsMenuElementInex].textFont = FONT_COLOURFUL;
-                            gCreditsMenuElements[creditsMenuElementInex].filterGreen = 0;
-                            gCreditsMenuElements[creditsMenuElementInex].filterBlendFactor = 48;
-                            gCreditsMenuElements[creditsMenuElementInex].t.asciiText =
+                            gCreditsMenuElements[creditsMenuElementIndex].textFont = FONT_COLOURFUL;
+                            gCreditsMenuElements[creditsMenuElementIndex].filterGreen = 0;
+                            gCreditsMenuElements[creditsMenuElementIndex].filterBlendFactor = 48;
+                            gCreditsMenuElements[creditsMenuElementIndex].t.asciiText =
                                 get_level_name(mainTrackIds[gCreditsControlData[var_s4]]);
 
-                            creditsMenuElementInex++;
-                            gCreditsMenuElements[creditsMenuElementInex].top = textPos + 14;
-                            gCreditsMenuElements[creditsMenuElementInex].middle = textPos + 14;
-                            gCreditsMenuElements[creditsMenuElementInex].bottom = textPos + 14;
-                            gCreditsMenuElements[creditsMenuElementInex].textFont = FONT_COLOURFUL;
-                            gCreditsMenuElements[creditsMenuElementInex].t.asciiText =
+                            creditsMenuElementIndex++;
+                            gCreditsMenuElements[creditsMenuElementIndex].top = textPos + 14;
+                            gCreditsMenuElements[creditsMenuElementIndex].middle = textPos + 14;
+                            gCreditsMenuElements[creditsMenuElementIndex].bottom = textPos + 14;
+                            gCreditsMenuElements[creditsMenuElementIndex].textFont = FONT_COLOURFUL;
+                            gCreditsMenuElements[creditsMenuElementIndex].t.asciiText =
                                 gCreditsBestTimesArray[gCreditsControlData[var_s4]];
-                            creditsMenuElementInex++;
+                            creditsMenuElementIndex++;
                         } else {
                             // every other element should have a little more green and a little less red/orange
-                            if (creditsMenuElementInex & 1) {
-                                gCreditsMenuElements[creditsMenuElementInex].filterGreen = 255;
-                                gCreditsMenuElements[creditsMenuElementInex].filterBlendFactor = 0;
+                            if (creditsMenuElementIndex & 1) {
+                                gCreditsMenuElements[creditsMenuElementIndex].filterGreen = 255;
+                                gCreditsMenuElements[creditsMenuElementIndex].filterBlendFactor = 0;
                             }
-                            gCreditsMenuElements[creditsMenuElementInex].textFont = var_s5;
-                            gCreditsMenuElements[creditsMenuElementInex].t.asciiText =
+                            if (creditsMenuElementIndex == 0) {
+                                if (gCreditsControlData[var_s4] == 0x55) {
+                                    gCreditsMenuElements[creditsMenuElementIndex].filterBlendFactor = 144;
+                                } else {                                    
+                                    gCreditsMenuElements[creditsMenuElementIndex].filterBlendFactor = 48;
+                                }
+                            }
+                            if (gCreditsControlData[var_s4] == 0x56) {
+                                var_s5 = FONT_COLOURFUL;
+                            }
+                            gCreditsMenuElements[creditsMenuElementIndex].textFont = var_s5;
+                            gCreditsMenuElements[creditsMenuElementIndex].t.asciiText =
                                 gCreditsArray[gCreditsControlData[var_s4]];
-                            creditsMenuElementInex++;
+                            creditsMenuElementIndex++;
                         }
                         // after the first iteration, whatever was the font previously, set it to large now
                         // this way to title like "Software Director" is colourful while the parts after it are "just"
@@ -13187,9 +13198,10 @@ s32 menu_credits_loop(s32 updateRate) {
                         textPos += textLineHeight;
                         // Since every element now uses large font increase the text line height
                         textLineHeight = 32;
+                        if (nextIndex){}
                     }
 
-                    gCreditsMenuElements[creditsMenuElementInex].t.element = NULL;
+                    gCreditsMenuElements[creditsMenuElementIndex].t.element = NULL;
                     postrace_offsets(gCreditsMenuElements, 0.5f, (f32) D_80126BE8 / 60.0f, 0.5f, 0, 0);
                     D_80126BE0 = postrace_render(0) == MENU_RESULT_CONTINUE;
                     breakLoop = TRUE;

--- a/src/menu.c
+++ b/src/menu.c
@@ -5571,6 +5571,7 @@ void bootscreen_init_cpak(void) {
 #else
 #define PAKMENU_JP_OFFSET 0
 #endif
+
 /**
  * Render the controller pak menu.
  * Lists the pak index, as well as remaining pages, then displays all known files.

--- a/src/menu.c
+++ b/src/menu.c
@@ -13028,7 +13028,6 @@ void credits_fade(s32 x1, s32 y1, s32 x2, s32 y2, s32 a) {
     rendermode_reset(&sMenuCurrDisplayList);
 }
 
-#if 1
 /**
  * Handles the credits for the game
  */
@@ -13128,13 +13127,15 @@ s32 menu_credits_loop(s32 updateRate) {
                     var_s5 = FONT_COLOURFUL;
                     textLineHeight = 20;
                     controlDataLength = gCreditsControlDataIndex - nextIndex;
+#if REGION == REGION_JP
+                    if (1) {}
+#endif
                     // only one thing to show for example "CREDITS"
                     if (controlDataLength == 1) {
                         textPos -= 14;
                         var_s5 = FONT_LARGE;
                     } else if (isShowingBestRaceTimes) {
                         textPos -= (controlDataLength * 16) - 3;
-                        if (1){}
                         textLineHeight = 32;
                     } else {
                         // we're showing multiple things
@@ -13175,16 +13176,18 @@ s32 menu_credits_loop(s32 updateRate) {
                                 gCreditsMenuElements[creditsMenuElementIndex].filterGreen = 255;
                                 gCreditsMenuElements[creditsMenuElementIndex].filterBlendFactor = 0;
                             }
+#if REGION == REGION_JP
                             if (creditsMenuElementIndex == 0) {
                                 if (gCreditsControlData[var_s4] == 0x55) {
                                     gCreditsMenuElements[creditsMenuElementIndex].filterBlendFactor = 144;
-                                } else {                                    
+                                } else {
                                     gCreditsMenuElements[creditsMenuElementIndex].filterBlendFactor = 48;
                                 }
                             }
                             if (gCreditsControlData[var_s4] == 0x56) {
                                 var_s5 = FONT_COLOURFUL;
                             }
+#endif
                             gCreditsMenuElements[creditsMenuElementIndex].textFont = var_s5;
                             gCreditsMenuElements[creditsMenuElementIndex].t.asciiText =
                                 gCreditsArray[gCreditsControlData[var_s4]];
@@ -13198,7 +13201,9 @@ s32 menu_credits_loop(s32 updateRate) {
                         textPos += textLineHeight;
                         // Since every element now uses large font increase the text line height
                         textLineHeight = 32;
-                        if (nextIndex){}
+#if REGION == REGION_JP
+                        if (nextIndex) {}
+#endif
                     }
 
                     gCreditsMenuElements[creditsMenuElementIndex].t.element = NULL;
@@ -13337,9 +13342,6 @@ s32 menu_credits_loop(s32 updateRate) {
     }
     return 0;
 }
-#else
-#pragma GLOBAL_ASM("asm/nonmatchings/menu/menu_credits_loop.s")
-#endif
 
 /**
  * Unload associated assets with the credits scene.

--- a/tools/python/score.py
+++ b/tools/python/score.py
@@ -117,7 +117,7 @@ MAP_FILE = DkrMapFile()
 NOT_FUNCTION_NAMES = ['if', 'else', 'switch', 'while', 'for', 'dmacopy_internal', 'func_80082BC8_837C8', 'rumble_enable',
     'func_800C6464_C7064', 'func_800C663C_C723C', 'func_800C67F4_C73F4', 'func_800C6870_C7470',
     'func_800C68CC_C74CC', 'fontCreateDisplayList', 'func_800C7744_C8344', 'func_800C7804_C8404',
-    'fontConvertString', 'func_800C78E0_C84E0', 'menu_credits_loop', 'results_render']
+    'fontConvertString', 'func_800C78E0_C84E0', 'menu_credits_loop']
 
 class ScoreFileMatch:
     def __init__(self, comment, functionName):

--- a/tools/python/score.py
+++ b/tools/python/score.py
@@ -117,7 +117,7 @@ MAP_FILE = DkrMapFile()
 NOT_FUNCTION_NAMES = ['if', 'else', 'switch', 'while', 'for', 'dmacopy_internal', 'func_80082BC8_837C8', 'rumble_enable',
     'func_800C6464_C7064', 'func_800C663C_C723C', 'func_800C67F4_C73F4', 'func_800C6870_C7470',
     'func_800C68CC_C74CC', 'fontCreateDisplayList', 'func_800C7744_C8344', 'func_800C7804_C8404',
-    'fontConvertString', 'func_800C78E0_C84E0', 'menu_credits_loop']
+    'fontConvertString', 'func_800C78E0_C84E0']
 
 class ScoreFileMatch:
     def __init__(self, comment, functionName):


### PR DESCRIPTION
I can now remove some of the ugly stuff that was there to workaround the fact that some versions matched, and others didn't.