### PR TITLE
Update gbi.h to use one found in libultra E version

### DIFF
--- a/include/PR/gbi.h
+++ b/include/PR/gbi.h
@@ -9,32 +9,9 @@
  *  in part, without the prior written consent of Silicon Graphics, Inc.  *
  *									  *
  **************************************************************************/
-/**************************************************************************
- *
- *  $Revision: 1.141 $
- *  $Date: 1999/09/03 03:43:08 $
- *  $Source: /exdisk2/cvs/N64OS/Master/cvsmdev2/PR/include/gbi.h,v $
- *
- **************************************************************************/
 
 #ifndef _GBI_H_
 #define	_GBI_H_
-
-#define F3D_OLD
-
-#include <PR/ultratypes.h>
-
-/*
- * To use the F3DEX ucodes, define F3DEX_GBI before include this file.
- *
- *     #define  F3DEX_GBI
- *     #include <ultra64.h>
- *
- *     or
- *
- *     cc -c -DF3DEX_GBI -I.... foo.c
- *
- */
 
 /**************************************************************************
  *
@@ -89,40 +66,6 @@
  *
  */
 
-#ifdef    F3DEX_GBI_2
-# ifndef  F3DEX_GBI
-#  define F3DEX_GBI
-# endif
-#define	G_NOOP			0x00
-#define	G_RDPHALF_2		0xf1
-#define	G_SETOTHERMODE_H	0xe3
-#define	G_SETOTHERMODE_L	0xe2
-#define	G_RDPHALF_1		0xe1
-#define	G_SPNOOP		0xe0
-#define	G_ENDDL			0xdf
-#define	G_DL			0xde
-#define	G_LOAD_UCODE		0xdd
-#define	G_MOVEMEM		0xdc
-#define	G_MOVEWORD		0xdb
-#define	G_MTX			0xda
-#define G_GEOMETRYMODE		0xd9
-#define	G_POPMTX		0xd8
-#define	G_TEXTURE		0xd7
-#define	G_DMA_IO		0xd6
-#define	G_SPECIAL_1		0xd5
-#define	G_SPECIAL_2		0xd4
-#define	G_SPECIAL_3		0xd3
-
-#define	G_VTX			0x01
-#define	G_MODIFYVTX		0x02
-#define	G_CULLDL		0x03
-#define	G_BRANCH_Z		0x04
-#define	G_TRI1			0x05
-#define G_TRI2			0x06
-#define G_QUAD			0x07
-#define G_LINE3D		0x08
-#else	/* F3DEX_GBI_2 */
-
 /* DMA commands: */
 #define	G_SPNOOP		0	/* handle 0 gracefully */
 #define	G_MTX			1
@@ -133,7 +76,7 @@
 #define	G_DL			6
 #define G_RESERVED2		7	/* not implemeted */
 #define G_RESERVED3		8	/* not implemeted */
-#define G_SPRITE2D_BASE		9	/* sprite command */
+#define G_RESERVED4		9	/* not implemeted */
 
 /* IMMEDIATE commands: */
 #define	G_IMMFIRST		-65
@@ -148,36 +91,13 @@
 #define G_SETGEOMETRYMODE	(G_IMMFIRST-8)
 #define G_CLEARGEOMETRYMODE	(G_IMMFIRST-9)
 #define G_LINE3D		(G_IMMFIRST-10)
-#ifdef F3D_OLD
-#define G_PERSPNORM		(G_IMMFIRST-11)
+#define G_PERSPNORMALIZE	(G_IMMFIRST-11)
 #define G_RDPHALF_1		(G_IMMFIRST-12)
 #define G_RDPHALF_2		(G_IMMFIRST-13)
-#define G_RDPHALF_CONT	(G_IMMFIRST-14)
-#else
-#define G_RDPHALF_1		(G_IMMFIRST-11)
-#define G_RDPHALF_2		(G_IMMFIRST-12)
-#if (defined(F3DEX_GBI)||defined(F3DLP_GBI))
-#  define G_MODIFYVTX		(G_IMMFIRST-13)
-#  define G_TRI2		(G_IMMFIRST-14)
-#  define G_BRANCH_Z		(G_IMMFIRST-15)
-#  define G_LOAD_UCODE		(G_IMMFIRST-16)
-#else
-#  define G_RDPHALF_CONT	(G_IMMFIRST-13)
-#endif
-#endif
-
-/* We are overloading 2 of the immediate commands
-   to keep the byte alignment of dmem the same */
-
-#define G_SPRITE2D_SCALEFLIP    (G_IMMFIRST-1)
-#define G_SPRITE2D_DRAW         (G_IMMFIRST-2)
+#define G_RDPHALF_CONT		(G_IMMFIRST-14)
 
 /* RDP commands: */
 #define	G_NOOP			0xc0	/*   0 */
-
-#endif	/* F3DEX_GBI_2 */
-
-/* RDP commands: */
 #define	G_SETCIMG		0xff	/*  -1 */
 #define	G_SETZIMG		0xfe	/*  -2 */
 #define	G_SETTIMG		0xfd	/*  -3 */
@@ -205,7 +125,6 @@
 #define	G_RDPLOADSYNC		0xe6	/* -26 */
 #define G_TEXRECTFLIP		0xe5	/* -27 */
 #define G_TEXRECT		0xe4	/* -28 */
-
 
 /* 
  * The following commands are the "generated" RDP commands; the user
@@ -305,21 +224,12 @@
 /*
  * G_MTX: parameter flags
  */
-#ifdef	F3DEX_GBI_2
-# define G_MTX_MODELVIEW	0x00	/* matrix types */
-# define G_MTX_PROJECTION	0x04
-# define G_MTX_MUL		0x00	/* concat or load */
-# define G_MTX_LOAD		0x02
-# define G_MTX_NOPUSH		0x00	/* push or not */
-# define G_MTX_PUSH		0x01
-#else	/* F3DEX_GBI_2 */
-# define G_MTX_MODELVIEW	0x00	/* matrix types */
-# define G_MTX_PROJECTION	0x01
-# define G_MTX_MUL		0x00	/* concat or load */
-# define G_MTX_LOAD		0x02
-# define G_MTX_NOPUSH		0x00	/* push or not */
-# define G_MTX_PUSH		0x04
-#endif	/* F3DEX_GBI_2 */
+#define	G_MTX_MODELVIEW		0x00	/* matrix types */
+#define	G_MTX_PROJECTION	0x01
+#define	G_MTX_MUL		0x00	/* concat or load */
+#define	G_MTX_LOAD		0x02
+#define G_MTX_NOPUSH		0x00	/* push or not */
+#define G_MTX_PUSH		0x04
 
 /*
  * flags for G_SETGEOMETRYMODE
@@ -347,31 +257,20 @@
  *
  */
 #define G_ZBUFFER		0x00000001
+#define G_TEXTURE_ENABLE	0x00000002	/* Microcode use only */
 #define G_SHADE			0x00000004	/* enable Gouraud interp */
 /* rest of low byte reserved for setup ucode */
-#ifdef	F3DEX_GBI_2
-# define G_TEXTURE_ENABLE	0x00000000	/* Ignored               */
-# define G_SHADING_SMOOTH	0x00200000	/* flat or smooth shaded */
-# define G_CULL_FRONT		0x00000200
-# define G_CULL_BACK		0x00000400
-# define G_CULL_BOTH		0x00000600	/* To make code cleaner */
-#else
-# define G_TEXTURE_ENABLE	0x00000002	/* Microcode use only */
-# define G_SHADING_SMOOTH	0x00000200	/* flat or smooth shaded */
-# define G_CULL_FRONT		0x00001000
-# define G_CULL_BACK		0x00002000
-# define G_CULL_BOTH		0x00003000	/* To make code cleaner */
-#endif
+#define G_SHADING_SMOOTH	0x00000200	/* flat or smooth shaded */
+#define G_CULL_FRONT		0x00001000
+#define G_CULL_BACK		0x00002000
+#define G_CULL_BOTH		0x00003000	/* To make code cleaner */
 #define G_FOG			0x00010000
 #define G_LIGHTING		0x00020000
 #define G_TEXTURE_GEN		0x00040000
 #define G_TEXTURE_GEN_LINEAR	0x00080000
 #define G_LOD			0x00100000	/* NOT IMPLEMENTED */
-#if	(defined(F3DEX_GBI)||defined(F3DLP_GBI))
-# define G_CLIPPING		0x00800000
-#else
-# define G_CLIPPING		0x00000000
-#endif
+
+
 
 #ifdef _LANGUAGE_ASSEMBLY
 #define G_FOG_H			(G_FOG/0x10000)
@@ -379,22 +278,6 @@
 #define G_TEXTURE_GEN_H		(G_TEXTURE_GEN/0x10000)
 #define G_TEXTURE_GEN_LINEAR_H	(G_TEXTURE_GEN_LINEAR/0x10000)
 #define G_LOD_H			(G_LOD/0x10000)	/* NOT IMPLEMENTED */
-#if	(defined(F3DEX_GBI)||defined(F3DLP_GBI))
-#  define G_CLIPPING_H		(G_CLIPPING/0x10000)
-#endif
-#endif
-
-/* Need these defined for Sprite Microcode */
-#ifdef _LANGUAGE_ASSEMBLY
-#define	G_TX_LOADTILE	7
-#define	G_TX_RENDERTILE	0
-
-#define	G_TX_NOMIRROR	0
-#define	G_TX_WRAP	0
-#define	G_TX_MIRROR	0x1
-#define	G_TX_CLAMP	0x2
-#define	G_TX_NOMASK	0
-#define	G_TX_NOLOD	0
 #endif
 
 /*
@@ -413,7 +296,6 @@
 #define G_IM_SIZ_8b	1
 #define G_IM_SIZ_16b	2
 #define G_IM_SIZ_32b	3
-#define G_IM_SIZ_DD	5
 
 #define G_IM_SIZ_4b_BYTES		0
 #define G_IM_SIZ_4b_TILE_BYTES	G_IM_SIZ_4b_BYTES
@@ -498,7 +380,7 @@
 #define	G_CC_MODULATEIDECALA_PRIM	TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, TEXEL0
 #define	G_CC_MODULATERGB_PRIM	G_CC_MODULATEI_PRIM
 #define	G_CC_MODULATERGBA_PRIM	G_CC_MODULATEIA_PRIM
-#define	G_CC_MODULATERGBDECALA_PRIM	G_CC_MODULATEIDECALA_PRIM
+#define	G_CC_MODULATERGBDECALA_PRIM	G_CC_MODULATEIA_PRIM
 #define	G_CC_DECALRGB		0, 0, 0, TEXEL0, 0, 0, 0, SHADE
 #define	G_CC_DECALRGBA		0, 0, 0, TEXEL0, 0, 0, 0, TEXEL0
 #define	G_CC_BLENDI		ENVIRONMENT, SHADE, TEXEL0, SHADE, 0, 0, 0, SHADE
@@ -1101,34 +983,6 @@ typedef union {
 } Vtx;
 
 /*
- * Sprite structure
- */
-
-typedef struct {
-  void *SourceImagePointer;
-  void *TlutPointer;
-  short Stride;
-  short SubImageWidth;
-  short SubImageHeight;
-  char  SourceImageType;
-  char  SourceImageBitSize;
-  short SourceImageOffsetS;
-  short SourceImageOffsetT;
-  /* 20 bytes for above */
-
-  /* padding to bring structure size to 64 bit allignment */
-  char dummy[4]; 
-
-} uSprite_t;
-
-typedef union {	
-  uSprite_t  s;
-
-  /* Need to make sure this is 64 bit aligned */   
-  long long int         force_structure_allignment[3];
-} uSprite;
-
-/*
  * Triangle face
  */
 typedef struct {
@@ -1201,42 +1055,22 @@ typedef union {
  * which to store a 1-4 word DMA.
  *
  */
-#ifdef	F3DEX_GBI_2
-/* 0,4 are reserved by G_MTX */
-# define G_MV_MMTX	2	
-# define G_MV_PMTX	6
-# define G_MV_VIEWPORT	8
-# define G_MV_LIGHT	10
-# define G_MV_POINT	12
-# define G_MV_MATRIX	14		/* NOTE: this is in moveword table */
-# define G_MVO_LOOKATX	(0*24)
-# define G_MVO_LOOKATY	(1*24)
-# define G_MVO_L0	(2*24)
-# define G_MVO_L1	(3*24)
-# define G_MVO_L2	(4*24)
-# define G_MVO_L3	(5*24)
-# define G_MVO_L4	(6*24)
-# define G_MVO_L5	(7*24)
-# define G_MVO_L6	(8*24)
-# define G_MVO_L7	(9*24)
-#else	/* F3DEX_GBI_2 */
-# define G_MV_VIEWPORT	0x80
-# define G_MV_LOOKATY	0x82
-# define G_MV_LOOKATX	0x84
-# define G_MV_L0	0x86
-# define G_MV_L1	0x88
-# define G_MV_L2	0x8a
-# define G_MV_L3	0x8c
-# define G_MV_L4	0x8e
-# define G_MV_L5	0x90
-# define G_MV_L6	0x92
-# define G_MV_L7	0x94
-# define G_MV_TXTATT	0x96
-# define G_MV_MATRIX_1	0x9e	/* NOTE: this is in moveword table */
-# define G_MV_MATRIX_2	0x98
-# define G_MV_MATRIX_3	0x9a
-# define G_MV_MATRIX_4	0x9c
-#endif	/* F3DEX_GBI_2 */
+#define G_MV_VIEWPORT	0x80
+#define G_MV_LOOKATY	0x82
+#define G_MV_LOOKATX	0x84
+#define G_MV_L0		0x86
+#define G_MV_L1		0x88
+#define G_MV_L2		0x8a
+#define G_MV_L3		0x8c
+#define G_MV_L4		0x8e
+#define G_MV_L5		0x90
+#define G_MV_L6		0x92
+#define G_MV_L7		0x94
+#define G_MV_TXTATT	0x96
+#define G_MV_MATRIX_1	0x9e	/* NOTE: this is in moveword table */
+#define G_MV_MATRIX_2	0x98
+#define G_MV_MATRIX_3	0x9a
+#define G_MV_MATRIX_4	0x9c
 
 /*
  * MOVEWORD indices
@@ -1252,12 +1086,7 @@ typedef union {
 #define G_MW_SEGMENT		0x06
 #define G_MW_FOG		0x08
 #define G_MW_LIGHTCOL		0x0a
-#ifdef	F3DEX_GBI_2
-# define G_MW_FORCEMTX		0x0c
-#else	/* F3DEX_GBI_2 */
-# define G_MW_POINTS		0x0c
-#endif	/* F3DEX_GBI_2 */
-#define	G_MW_PERSPNORM		0x0e
+#define	G_MW_POINTS		0x0c
 
 /*
  * These are offsets from the address in the dmem table
@@ -1286,22 +1115,6 @@ typedef union {
 #define G_MWO_FOG		0x00
 #define G_MWO_aLIGHT_1		0x00
 #define G_MWO_bLIGHT_1		0x04
-#ifdef	F3DEX_GBI_2
-#define G_MWO_aLIGHT_2		0x18
-#define G_MWO_bLIGHT_2		0x1c
-#define G_MWO_aLIGHT_3		0x30
-#define G_MWO_bLIGHT_3		0x34
-#define G_MWO_aLIGHT_4		0x48
-#define G_MWO_bLIGHT_4		0x4c
-#define G_MWO_aLIGHT_5		0x60
-#define G_MWO_bLIGHT_5		0x64
-#define G_MWO_aLIGHT_6		0x78
-#define G_MWO_bLIGHT_6		0x7c
-#define G_MWO_aLIGHT_7		0x90
-#define G_MWO_bLIGHT_7		0x94
-#define G_MWO_aLIGHT_8		0xa8
-#define G_MWO_bLIGHT_8		0xac
-#else
 #define G_MWO_aLIGHT_2		0x20
 #define G_MWO_bLIGHT_2		0x24
 #define G_MWO_aLIGHT_3		0x40
@@ -1316,7 +1129,6 @@ typedef union {
 #define G_MWO_bLIGHT_7		0xc4
 #define G_MWO_aLIGHT_8		0xe0
 #define G_MWO_bLIGHT_8		0xe4
-#endif
 #define G_MWO_MATRIX_XX_XY_I	0x00
 #define G_MWO_MATRIX_XZ_XW_I	0x04
 #define G_MWO_MATRIX_YX_YY_I	0x08
@@ -1336,7 +1148,7 @@ typedef union {
 #define G_MWO_POINT_RGBA	0x10
 #define G_MWO_POINT_ST		0x14
 #define G_MWO_POINT_XYSCREEN	0x18
-#define G_MWO_POINT_ZSCREEN	0x1c
+#define	G_MWO_POINT_ZSCREEN	0x1c
 
 /*
  * Light structure.
@@ -1742,97 +1554,23 @@ typedef union {
         (unsigned int)(s)						\
 }}
 
-#define	gDma2p(pkt, c, adrs, len, idx, ofs)				\
-{									\
-	Gfx *_g = (Gfx *)(pkt);						\
-	_g->words.w0 = (_SHIFTL((c),24,8)|_SHIFTL(((len)-1)/8,19,5)|	\
-			_SHIFTL((ofs)/8,8,8)|_SHIFTL((idx),0,8));	\
-	_g->words.w1 = (unsigned int)(adrs);				\
-}
-#define	gsDma2p(c, adrs, len, idx, ofs)					\
-{{									\
-	(_SHIFTL((c),24,8)|_SHIFTL(((len)-1)/8,19,5)|			\
-	 _SHIFTL((ofs)/8,8,8)|_SHIFTL((idx),0,8)),			\
-        (unsigned int)(adrs)						\
-}}
-
 #define	gSPNoOp(pkt)		gDma0p(pkt, G_SPNOOP, 0, 0)
 #define	gsSPNoOp()		gsDma0p(G_SPNOOP, 0, 0)
 
-#ifdef	F3DEX_GBI_2
-# define	gSPMatrix(pkt, m, p)	\
-		gDma2p((pkt),G_MTX,(m),sizeof(Mtx),(p)^G_MTX_PUSH,0)
-# define	gsSPMatrix(m, p)	\
-		gsDma2p(     G_MTX,(m),sizeof(Mtx),(p)^G_MTX_PUSH,0)
-#else	/* F3DEX_GBI_2 */
-# define	gSPMatrix(pkt, m, p)	gDma1p(pkt, G_MTX, m, sizeof(Mtx), p)
-# define	gsSPMatrix(m, p)	gsDma1p(G_MTX, m, sizeof(Mtx), p)
-#endif	/* F3DEX_GBI_2 */
+#define	gSPMatrix(pkt, m, p)	gDma1p(pkt, G_MTX, m, sizeof(Mtx), p)
+#define	gsSPMatrix(m, p)	gsDma1p(G_MTX, m, sizeof(Mtx), p)
 
-#if	defined(F3DEX_GBI_2)
-/*
- * F3DEX_GBI_2: G_VTX GBI format was changed.
- *
- *        +--------+----+---+---+----+------+-+
- *  G_VTX |  cmd:8 |0000|  n:8  |0000|v0+n:7|0|
- *        +-+---+--+----+---+---+----+------+-+
- *        | |seg|         address             |
- *        +-+---+-----------------------------+
- */
-# define	gSPVertex(pkt, v, n, v0)				\
-{									\
-	Gfx *_g = (Gfx *)(pkt);						\
-	_g->words.w0 =							\
-	  _SHIFTL(G_VTX,24,8)|_SHIFTL((n),12,8)|_SHIFTL((v0)+(n),1,7);	\
-	_g->words.w1 = (unsigned int)(v);				\
-}
-# define	gsSPVertex(v, n, v0)					\
-{{									\
-	(_SHIFTL(G_VTX,24,8)|_SHIFTL((n),12,8)|_SHIFTL((v0)+(n),1,7)),	\
-        (unsigned int)(v)						\
-}}
-#elif	(defined(F3DEX_GBI)||defined(F3DLP_GBI))
-/*
- * F3DEX_GBI: G_VTX GBI format was changed to support 64 vertice.
- *
- *        +--------+--------+------+----------+
- *  G_VTX |  cmd:8 |  v0:8  |  n:6 |length:10 |
- *        +-+---+--+--------+------+----------+
- *        | |seg|          address            |
- *        +-+---+-----------------------------+
- */
-# define	gSPVertex(pkt, v, n, v0) \
-                gDma1p((pkt),G_VTX,(v),((n)<<10)|(sizeof(Vtx)*(n)-1),(v0)*2)
-# define	gsSPVertex(v, n, v0) \
-                gsDma1p(G_VTX,(v),((n)<<10)|(sizeof(Vtx)*(n)-1),(v0)*2)
-#else
-# define	gSPVertex(pkt, v, n, v0) \
-                gDma1p(pkt, G_VTX, v, sizeof(Vtx)*(n),((n)-1)<<4|(v0))
-# define	gsSPVertex(v, n, v0) \
-                gsDma1p(G_VTX, v, sizeof(Vtx)*(n), ((n)-1)<<4|(v0))
-#endif
+#define	gSPVertex(pkt, v, n, v0)	gDma1p(pkt, G_VTX, v, sizeof(Vtx)*(n),((n)-1)<<4|(v0))
+#define	gsSPVertex(v, n, v0)	gsDma1p(G_VTX, v, sizeof(Vtx)*(n), ((n)-1)<<4|(v0))
 
-	
-#ifdef	F3DEX_GBI_2
-# define gSPViewport(pkt, v)	\
-		gDma2p((pkt), G_MOVEMEM, (v), sizeof(Vp), G_MV_VIEWPORT, 0)
-# define gsSPViewport(v)	\
-		gsDma2p(      G_MOVEMEM, (v), sizeof(Vp), G_MV_VIEWPORT, 0)
-#else	/* F3DEX_GBI_2 */
-# define gSPViewport(pkt,v)	\
-		gDma1p((pkt), G_MOVEMEM, (v), sizeof(Vp), G_MV_VIEWPORT)
-# define gsSPViewport(v)	\
-		gsDma1p(      G_MOVEMEM, (v), sizeof(Vp), G_MV_VIEWPORT)
-#endif	/* F3DEX_GBI_2 */
+#define	gSPViewport(pkt, v)	gDma1p(pkt, G_MOVEMEM, v, sizeof(Vp), G_MV_VIEWPORT)
+#define	gsSPViewport(v)		gsDma1p(G_MOVEMEM,     v, sizeof(Vp), G_MV_VIEWPORT)
 
 #define	gSPDisplayList(pkt,dl)	gDma1p(pkt,G_DL,dl,0,G_DL_PUSH)
 #define	gsSPDisplayList(   dl)	gsDma1p(   G_DL,dl,0,G_DL_PUSH)
 
 #define	gSPBranchList(pkt,dl)	gDma1p(pkt,G_DL,dl,0,G_DL_NOPUSH)
 #define	gsSPBranchList(   dl)	gsDma1p(   G_DL,dl,0,G_DL_NOPUSH)
-
-#define	gSPSprite2DBase(pkt, s)	gDma1p(pkt, G_SPRITE2D_BASE, s, sizeof(uSprite), 0)
-#define	gsSPSprite2DBase(s)	gsDma1p(G_SPRITE2D_BASE, s, sizeof(uSprite), 0)
 
 /*
  * RSP short command (no DMA required) macros
@@ -1905,205 +1643,50 @@ typedef union {
         (unsigned int) (dat)						\
 }}
 
-#ifdef	F3DEX_GBI_2
 #define gMoveWd(pkt, index, offset, data)				\
-	gDma1p((pkt), G_MOVEWORD, data, offset, index)
+	gImmp21(pkt, G_MOVEWORD, offset, index, data)
+
 #define gsMoveWd(    index, offset, data)				\
-	gsDma1p(      G_MOVEWORD, data, offset, index)
-#else	/* F3DEX_GBI_2 */
-#define gMoveWd(pkt, index, offset, data)				\
-	gImmp21((pkt), G_MOVEWORD, offset, index, data)
-#define gsMoveWd(    index, offset, data)				\
-	gsImmp21(      G_MOVEWORD, offset, index, data)
-#endif	/* F3DEX_GBI_2 */
+	gsImmp21(    G_MOVEWORD, offset, index, data)
 
-/* Sprite immediate macros, there is also a sprite dma macro above */
-
-#define gSPSprite2DScaleFlip(pkt, sx, sy, fx, fy)                       \
-{                                                                       \
-	Gfx *_g = (Gfx *)(pkt);						\
-									\
-	_g->words.w0 = (_SHIFTL(G_SPRITE2D_SCALEFLIP, 24, 8) |          \
-			_SHIFTL((fx), 8, 8) |                           \
-			_SHIFTL((fy), 0, 8));	                        \
-	_g->words.w1 = (_SHIFTL((sx), 16, 16) |                         \
-			_SHIFTL((sy),  0, 16));                         \
-}
-
-#define gsSPSprite2DScaleFlip(sx, sy, fx, fy)                           \
-{{                                                                       \
-          (_SHIFTL(G_SPRITE2D_SCALEFLIP, 24, 8) |                       \
-	   _SHIFTL((fx), 8, 8) |                                        \
-	   _SHIFTL((fy), 0, 8)),	                                \
-	  (_SHIFTL((sx), 16, 16) |                                      \
-	   _SHIFTL((sy),  0, 16))                                       \
-}}
-
-#define gSPSprite2DDraw(pkt, px, py)                                    \
-{                                                                       \
-	Gfx *_g = (Gfx *)(pkt);						\
-									\
-	_g->words.w0 = (_SHIFTL(G_SPRITE2D_DRAW, 24, 8));               \
-	_g->words.w1 = (_SHIFTL((px), 16, 16) |                         \
-			_SHIFTL((py),  0, 16));                         \
-}
-
-#define gsSPSprite2DDraw(px, py)                                        \
-{{                                                                       \
-          (_SHIFTL(G_SPRITE2D_DRAW, 24, 8)),                            \
-	  (_SHIFTL((px), 16, 16) |                                      \
-	   _SHIFTL((py),  0, 16))                                       \
-}}
 
 
 /*
  * Note: the SP1Triangle() and line macros multiply the vertex indices
  * by 10, this is an optimization for the microcode.
  */
-#if	(defined(F3DLP_GBI)||defined(F3DEX_GBI))
-#  define __gsSP1Triangle_w1(v0, v1, v2)			\
-     (_SHIFTL((v0)*2,16,8)|_SHIFTL((v1)*2,8,8)|_SHIFTL((v2)*2,0,8))
-#  define __gsSP1Triangle_w1f(v0, v1, v2, flag)			\
-     (((flag) == 0) ? __gsSP1Triangle_w1(v0, v1, v2):		\
-      ((flag) == 1) ? __gsSP1Triangle_w1(v1, v2, v0):		\
-	              __gsSP1Triangle_w1(v2, v0, v1))
-#  define __gsSPLine3D_w1(v0, v1, wd)				\
-     (_SHIFTL((v0)*2,16,8)|_SHIFT((v1)*2,8,8)|_SHIFT((wd),0,8))
-#  define __gsSPLine3D_w1f(v0, v1, wd, flag)			\
-     (((flag) == 0) ? __gsSPLine3D_w1(v0, v1, wd):		\
-	              __gsSPLine3D_w1(v1, v0, wd))
-#  define __gsSP1Quadrangle_w1f(v0, v1, v2, v3, flag)	\
-  (((flag) == 0) ? __gsSP1Triangle_w1(v0, v1, v2):      \
-   ((flag) == 1) ? __gsSP1Triangle_w1(v1, v2, v3):      \
-   ((flag) == 2) ? __gsSP1Triangle_w1(v2, v3, v0):      \
-                   __gsSP1Triangle_w1(v3, v0, v1))
-#  define __gsSP1Quadrangle_w2f(v0, v1, v2, v3, flag)	\
-  (((flag) == 0) ? __gsSP1Triangle_w1(v0, v2, v3):      \
-   ((flag) == 1) ? __gsSP1Triangle_w1(v1, v3, v0):      \
-   ((flag) == 2) ? __gsSP1Triangle_w1(v2, v0, v1):      \
-                   __gsSP1Triangle_w1(v3, v1, v2))
-#else
-#  define __gsSP1Triangle_w1f(v0, v1, v2, flag)			\
-     (_SHIFTL((flag), 24,8)|_SHIFTL((v0)*10,16,8)|		\
-      _SHIFTL((v1)*10, 8,8)|_SHIFTL((v2)*10, 0,8))
-#  define __gsSPLine3D_w1f(v0, v1, wd, flag)			\
-     (_SHIFTL((flag), 24,8)|_SHIFTL((v0)*10,16,8)| 		\
-      _SHIFTL((v1)*10, 8,8)|_SHIFTL((wd),    0,8))
-#endif
-
-#ifdef	F3DEX_GBI_2
-/***
- ***  1 Triangle
- ***/
-#define gSP1Triangle(pkt, v0, v1, v2, flag)				\
-{									\
-	Gfx *_g = (Gfx *)(pkt);						\
-									\
-	_g->words.w0 = _SHIFTL(G_TRI1, 24, 8)|				\
-			__gsSP1Triangle_w1f(v0, v1, v2, flag);		\
-	_g->words.w1 = 0;						\
-}
-#define gsSP1Triangle(v0, v1, v2, flag)					\
-{{									\
-	_SHIFTL(G_TRI1, 24, 8)|__gsSP1Triangle_w1f(v0, v1, v2, flag),	\
-	0								\
-}}
-
-/***
- ***  Line
- ***/
-#define gSPLine3D(pkt, v0, v1, flag)					\
-{									\
-	Gfx *_g = (Gfx *)(pkt);						\
-									\
-	_g->words.w0 = _SHIFTL(G_LINE3D, 24, 8)|			\
-			__gsSPLine3D_w1f(v0, v1, 0, flag);		\
-	_g->words.w1 = 0;						\
-}
-#define gsSPLine3D(v0, v1, flag)					\
-{{									\
-	_SHIFTL(G_LINE3D, 24, 8)|__gsSPLine3D_w1f(v0, v1, 0, flag),	\
-	0								\
-}}
-
-/***
- ***  LineW
- ***/
-/* these macros are the same as SPLine3D, except they have an
- * additional parameter for width. The width is added to the "minimum"
- * thickness, which is 1.5 pixels. The units for width are in
- * half-pixel units, so a width of 1 translates to (.5 + 1.5) or
- * a 2.0 pixels wide line.
- */
-#define gSPLineW3D(pkt, v0, v1, wd, flag)				\
-{									\
-	Gfx *_g = (Gfx *)(pkt);						\
-									\
-	_g->words.w0 = _SHIFTL(G_LINE3D, 24, 8)|			\
-			__gsSPLine3D_w1f(v0, v1, wd, flag);		\
-	_g->words.w1 = 0;						\
-}
-#define gsSPLineW3D(v0, v1, wd, flag)					\
-{{									\
-	_SHIFTL(G_LINE3D, 24, 8)|__gsSPLine3D_w1f(v0, v1, wd, flag),	\
-	0								\
-}}
-
-/***
- ***  1 Quadrangle
- ***/
-#define gSP1Quadrangle(pkt, v0, v1, v2, v3, flag)                       \
-{                                                                       \
-        Gfx *_g = (Gfx *)(pkt);                                         \
-                                                                        \
-        _g->words.w0 = (_SHIFTL(G_QUAD, 24, 8)|	                        \
-                        __gsSP1Quadrangle_w1f(v0, v1, v2, v3, flag));   \
-        _g->words.w1 =  __gsSP1Quadrangle_w2f(v0, v1, v2, v3, flag);    \
-}
-
-#define gsSP1Quadrangle(v0, v1, v2, v3, flag)                           \
-{{                                                                       \
-        (_SHIFTL(G_QUAD, 24, 8)|                                        \
-         __gsSP1Quadrangle_w1f(v0, v1, v2, v3, flag)),                  \
-         __gsSP1Quadrangle_w2f(v0, v1, v2, v3, flag)                    \
-}}
-#else	/* F3DEX_GBI_2 */
-
-/***
- ***  1 Triangle
- ***/	
 #define gSP1Triangle(pkt, v0, v1, v2, flag)				\
 {									\
 	Gfx *_g = (Gfx *)(pkt);						\
 									\
 	_g->words.w0 = _SHIFTL(G_TRI1, 24, 8);				\
-	_g->words.w1 = __gsSP1Triangle_w1f(v0, v1, v2, flag);		\
+	_g->words.w1 = (_SHIFTL((flag), 24, 8) | _SHIFTL(((v0)*10), 16, 8) |\
+			_SHIFTL(((v1)*10), 8, 8) | _SHIFTL(((v2)*10), 0, 8));\
 }
+
 #define gsSP1Triangle(v0, v1, v2, flag)					\
 {{									\
 	_SHIFTL(G_TRI1, 24, 8),						\
-	__gsSP1Triangle_w1f(v0, v1, v2, flag)				\
+	(_SHIFTL((flag), 24, 8) | _SHIFTL(((v0)*10), 16, 8) |		\
+	 _SHIFTL(((v1)*10), 8, 8) | _SHIFTL(((v2)*10), 0, 8))		\
 }}
 
-/***
- ***  Line
- ***/
 #define gSPLine3D(pkt, v0, v1, flag)					\
 {									\
 	Gfx *_g = (Gfx *)(pkt);						\
 									\
 	_g->words.w0 = _SHIFTL(G_LINE3D, 24, 8);			\
-	_g->words.w1 = __gsSPLine3D_w1f(v0, v1, 0, flag);		\
+	_g->words.w1 = (_SHIFTL((flag), 24, 8) | _SHIFTL(((v0)*10), 16, 8) |\
+			_SHIFTL(((v1)*10), 8, 8) | _SHIFTL(0, 0, 8));	\
 }
+
 #define gsSPLine3D(v0, v1, flag)					\
 {{									\
 	_SHIFTL(G_LINE3D, 24, 8),					\
-	__gsSPLine3D_w1f(v0, v1, 0, flag)				\
+	(_SHIFTL((flag), 24, 8) | _SHIFTL(((v0)*10), 16, 8) |		\
+	 _SHIFTL(((v1)*10), 8, 8) | _SHIFTL(0, 0, 8))			\
 }}
 
-/***
- ***  LineW
- ***/
 /* these macros are the same as SPLine3D, except they have an
  * additional parameter for width. The width is added to the "minimum"
  * thickness, which is 1.5 pixels. The units for width are in
@@ -2115,73 +1698,17 @@ typedef union {
 	Gfx *_g = (Gfx *)(pkt);						\
 									\
 	_g->words.w0 = _SHIFTL(G_LINE3D, 24, 8);			\
-	_g->words.w1 = __gsSPLine3D_w1f(v0, v1, wd, flag);		\
+	_g->words.w1 = (_SHIFTL((flag), 24, 8) | _SHIFTL(((v0)*10), 16, 8) |\
+			_SHIFTL(((v1)*10), 8, 8) | _SHIFTL((wd), 0, 8));\
 }
+
 #define gsSPLineW3D(v0, v1, wd, flag)					\
 {{									\
 	_SHIFTL(G_LINE3D, 24, 8),					\
-	__gsSPLine3D_w1f(v0, v1, wd, flag)				\
+	(_SHIFTL((flag), 24, 8) | _SHIFTL(((v0)*10), 16, 8) |		\
+	 _SHIFTL(((v1)*10), 8, 8) | _SHIFTL((wd), 0, 8))		\
 }}
 
-/***
- ***  1 Quadrangle
- ***/
-#define gSP1Quadrangle(pkt, v0, v1, v2, v3, flag)                       \
-{                                                                       \
-        Gfx *_g = (Gfx *)(pkt);                                         \
-                                                                        \
-        _g->words.w0 = (_SHIFTL(G_TRI2, 24, 8)|	                        \
-                        __gsSP1Quadrangle_w1f(v0, v1, v2, v3, flag));   \
-        _g->words.w1 =  __gsSP1Quadrangle_w2f(v0, v1, v2, v3, flag);    \
-}
-
-#define gsSP1Quadrangle(v0, v1, v2, v3, flag)                           \
-{{                                                                       \
-        (_SHIFTL(G_TRI2, 24, 8)|                                        \
-         __gsSP1Quadrangle_w1f(v0, v1, v2, v3, flag)),                  \
-         __gsSP1Quadrangle_w2f(v0, v1, v2, v3, flag)                    \
-}}
-#endif	/* F3DEX_GBI_2 */
-
-#if	(defined(F3DLP_GBI)||defined(F3DEX_GBI))
-/***
- ***  2 Triangles
- ***/
-#define gSP2Triangles(pkt, v00, v01, v02, flag0, v10, v11, v12, flag1)	\
-{									\
-	Gfx *_g = (Gfx *)(pkt);						\
-									\
-	_g->words.w0 = (_SHIFTL(G_TRI2, 24, 8)|				\
-			__gsSP1Triangle_w1f(v00, v01, v02, flag0));	\
-        _g->words.w1 =  __gsSP1Triangle_w1f(v10, v11, v12, flag1); 	\
-}
-
-#define gsSP2Triangles(v00, v01, v02, flag0, v10, v11, v12, flag1)	\
-{{									\
-	(_SHIFTL(G_TRI2, 24, 8)|					\
-	 __gsSP1Triangle_w1f(v00, v01, v02, flag0)),			\
-	 __gsSP1Triangle_w1f(v10, v11, v12, flag1)			\
-}}
-
-#endif	/* F3DEX_GBI/F3DLP_GBI */
-
-#if	(defined(F3DEX_GBI)||defined(F3DLP_GBI))
-#define gSPCullDisplayList(pkt,vstart,vend)				\
-{									\
-	Gfx *_g = (Gfx *)(pkt);						\
-									\
-	_g->words.w0 = _SHIFTL(G_CULLDL, 24, 8) | 			\
-			_SHIFTL((vstart)*2, 0, 16);			\
-	_g->words.w1 = _SHIFTL((vend)*2, 0, 16);			\
-}
-
-#define gsSPCullDisplayList(vstart,vend)				\
-{{									\
-	_SHIFTL(G_CULLDL, 24, 8) | _SHIFTL((vstart)*2, 0, 16),		\
-	_SHIFTL((vend)*2, 0, 16)					\
-}}
-
-#else
 #define gSPCullDisplayList(pkt,vstart,vend)				\
 {									\
 	Gfx *_g = (Gfx *)(pkt);						\
@@ -2196,7 +1723,6 @@ typedef union {
 	_SHIFTL(G_CULLDL, 24, 8) | ((0x0f & (vstart))*40), 		\
 	((0x0f & ((vend)+1))*40)					\
 }}
-#endif
 
 #define gSPSegment(pkt, segment, base)					\
 	gMoveWd(pkt, G_MW_SEGMENT, (segment)*4, base)
@@ -2242,33 +1768,17 @@ typedef union {
  * num   = new element (32 bit value replacing 2 int or 2 frac matrix 
  *                                 componants
  */
-#ifdef	F3DEX_GBI_2
-#define gSPInsertMatrix(pkt, where, num)				\
-	ERROR!! gSPInsertMatrix is no longer supported.
-#define gsSPInsertMatrix(where, num)					\
-	ERROR!! gsSPInsertMatrix is no longer supported.
-#else
 #define gSPInsertMatrix(pkt, where, num)				\
 	gMoveWd(pkt, G_MW_MATRIX, where, num)
+
 #define gsSPInsertMatrix(where, num)					\
 	gsMoveWd(G_MW_MATRIX, where, num)
-#endif
 
 /*
  * Load new matrix directly
  *
  * mptr = pointer to matrix
  */
-#ifdef	F3DEX_GBI_2
-#define	gSPForceMatrix(pkt, mptr)					\
-{	gDma2p((pkt),G_MOVEMEM,(mptr),sizeof(Mtx),G_MV_MATRIX,0);	\
-	gMoveWd((pkt), G_MW_FORCEMTX,0,0x00010000);			\
-}
-#define	gsSPForceMatrix(mptr)						\
-	gsDma2p(G_MOVEMEM,(mptr),sizeof(Mtx),G_MV_MATRIX,0),		\
-	gsMoveWd(G_MW_FORCEMTX,0,0x00010000)
-	
-#else	/* F3DEX_GBI_2 */
 #define	gSPForceMatrix(pkt, mptr)					\
 {									\
 	gDma1p(pkt, G_MOVEMEM, mptr,              16, G_MV_MATRIX_1);	\
@@ -2281,7 +1791,6 @@ typedef union {
 	gsDma1p(    G_MOVEMEM, (char *)(mptr)+16, 16, G_MV_MATRIX_2),	\
 	gsDma1p(    G_MOVEMEM, (char *)(mptr)+32, 16, G_MV_MATRIX_3),	\
 	gsDma1p(    G_MOVEMEM, (char *)(mptr)+48, 16, G_MV_MATRIX_4)
-#endif	/* F3DEX_GBI_2 */
 
 /*
  * Insert values into Points
@@ -2290,169 +1799,18 @@ typedef union {
  * where = which element of point to modify (byte offset into point)
  * num   = new value (32 bit)
  */
-#if	(defined(F3DEX_GBI)||defined(F3DLP_GBI))
-# define gSPModifyVertex(pkt, vtx, where, val)				\
-{									\
-	Gfx *_g = (Gfx *)(pkt);						\
-	_g->words.w0 = (_SHIFTL(G_MODIFYVTX,24,8)|			\
-		        _SHIFTL((where),16,8)|_SHIFTL((vtx)*2,0,16));	\
-	_g->words.w1 = (unsigned int)(val);				\
-}
-# define gsSPModifyVertex(vtx, where, val)				\
-{{									\
-	_SHIFTL(G_MODIFYVTX,24,8)|					\
-	_SHIFTL((where),16,8)|_SHIFTL((vtx)*2,0,16),			\
-	(unsigned int)(val)						\
-}}
-#else
-# define gSPModifyVertex(pkt, vtx, where, val)				\
-	 gMoveWd(pkt, G_MW_POINTS, (vtx)*40+(where), val)
-# define gsSPModifyVertex(vtx, where, val)				\
-	 gsMoveWd(G_MW_POINTS, (vtx)*40+(where), val)
-#endif
+#define	gSPModifyVertex(pkt, vtx, where, val)				\
+	gMoveWd(pkt, G_MW_POINTS, (vtx)*40+(where), val)
 
-#if	(defined(F3DEX_GBI)||defined(F3DLP_GBI))
-/*
- *  gSPBranchLessZ   Branch DL if (vtx.z) less than or equal (zval).
- *
- *  dl	 = DL branch to 
- *  vtx  = Vertex
- *  zval = Screen depth
- *  near = Near plane
- *  far  = Far  plane
- *  flag = G_BZ_PERSP or G_BZ_ORTHO
- */
+#define	gsSPModifyVertex(vtx, where, val)				\
+	gsMoveWd(G_MW_POINTS, (vtx)*40+(where), val)
 
-#define	G_BZ_PERSP	0
-#define	G_BZ_ORTHO	1
-
-#define	G_DEPTOZSrg(zval, near, far, flag, zmin, zmax)			\
-(((unsigned int)FTOFIX32(((flag) == G_BZ_PERSP ? 			\
-			  (1.0f-(float)(near)/(float)(zval)) / 		\
-			  (1.0f-(float)(near)/(float)(far )) :		\
-			  ((float)(zval) - (float)(near)) /		\
-			  ((float)(far ) - (float)(near))))) *		\
- (((int)((zmax) - (zmin)))&~1) + (int)FTOFIX32(zmin))
-
-#define	G_DEPTOZS(zval, near, far, flag) \
-	G_DEPTOZSrg(zval, near, far, flag, 0, G_MAXZ)
-
-#define	gSPBranchLessZrg(pkt, dl, vtx, zval, near, far, flag, zmin, zmax) \
-{									\
-	Gfx *_g = (Gfx *)(pkt);						\
-	_g->words.w0 = _SHIFTL(G_RDPHALF_1,24,8);			\
-	_g->words.w1 = (unsigned int)(dl);				\
-	_g = (Gfx *)(pkt);						\
-	_g->words.w0 = (_SHIFTL(G_BRANCH_Z,24,8)|			\
-		        _SHIFTL((vtx)*5,12,12)|_SHIFTL((vtx)*2,0,12));	\
-	_g->words.w1 = G_DEPTOZSrg(zval, near, far, flag, zmin, zmax);	\
-}
-
-#define	gsSPBranchLessZrg(dl, vtx, zval, near, far, flag, zmin, zmax)	      \
-{{	_SHIFTL(G_RDPHALF_1,24,8),					      \
-	(unsigned int)(dl),						}},    \
-{{	_SHIFTL(G_BRANCH_Z,24,8)|_SHIFTL((vtx)*5,12,12)|_SHIFTL((vtx)*2,0,12),\
-	G_DEPTOZSrg(zval, near, far, flag, zmin, zmax),			}}
-
-#define	gSPBranchLessZ(pkt, dl, vtx, zval, near, far, flag)		\
-	gSPBranchLessZrg(pkt, dl, vtx, zval, near, far, flag, 0, G_MAXZ)
-#define	gsSPBranchLessZ(dl, vtx, zval, near, far, flag)			\
-	gsSPBranchLessZrg(dl, vtx, zval, near, far, flag, 0, G_MAXZ)
-
-/*
- *  gSPBranchLessZraw   Branch DL if (vtx.z) less than or equal (raw zval).
- *
- *  dl	 = DL branch to 
- *  vtx  = Vertex
- *  zval = Raw value of screen depth
- */
-#define	gSPBranchLessZraw(pkt, dl, vtx, zval)				\
-{									\
-	Gfx *_g = (Gfx *)(pkt);						\
-	_g->words.w0 = _SHIFTL(G_RDPHALF_1,24,8);			\
-	_g->words.w1 = (unsigned int)(dl);				\
-	_g = (Gfx *)(pkt);						\
-	_g->words.w0 = (_SHIFTL(G_BRANCH_Z,24,8)|			\
-		        _SHIFTL((vtx)*5,12,12)|_SHIFTL((vtx)*2,0,12));	\
-	_g->words.w1 = (unsigned int)(zval);				\
-}
-
-#define	gsSPBranchLessZraw(dl, vtx, zval)				\
-{{	_SHIFTL(G_RDPHALF_1,24,8),					      \
-	(unsigned int)(dl),						}},    \
-{{	_SHIFTL(G_BRANCH_Z,24,8)|_SHIFTL((vtx)*5,12,12)|_SHIFTL((vtx)*2,0,12),\
-	(unsigned int)(zval),						}}
-
-/*
- * gSPLoadUcode   RSP loads specified ucode.
- *
- * uc_start  = ucode text section start
- * uc_dstart = ucode data section start
- */
-#define	gSPLoadUcodeEx(pkt, uc_start, uc_dstart, uc_dsize)		\
-{									\
-	Gfx *_g = (Gfx *)(pkt);						\
-	_g->words.w0 = _SHIFTL(G_RDPHALF_1,24,8);			\
-	_g->words.w1 = (unsigned int)(uc_dstart);			\
-	_g = (Gfx *)(pkt);						\
-	_g->words.w0 = (_SHIFTL(G_LOAD_UCODE,24,8)|			\
-			_SHIFTL((int)(uc_dsize)-1,0,16));		\
-	_g->words.w1 = (unsigned int)(uc_start);			\
-}
-
-#define	gsSPLoadUcodeEx(uc_start, uc_dstart, uc_dsize)			\
-{{	_SHIFTL(G_RDPHALF_1,24,8),					\
-	(unsigned int)(uc_dstart),				}},	\
-{{	_SHIFTL(G_LOAD_UCODE,24,8)|					\
-	  _SHIFTL((int)(uc_dsize)-1,0,16),				\
-	(unsigned int)(uc_start),				}}
-
-#define	gSPLoadUcode(pkt, uc_start, uc_dstart)				\
-        gSPLoadUcodeEx((pkt), (uc_start), (uc_dstart), SP_UCODE_DATA_SIZE)
-#define	gsSPLoadUcode(uc_start, uc_dstart)				\
-        gsSPLoadUcodeEx((uc_start), (uc_dstart), SP_UCODE_DATA_SIZE)
-
-#define	gSPLoadUcodeL(pkt, ucode)					\
-        gSPLoadUcode((pkt), OS_K0_TO_PHYSICAL(&##ucode##TextStart),	\
-		            OS_K0_TO_PHYSICAL(&##ucode##DataStart))
-#define	gsSPLoadUcodeL(ucode)						\
-        gsSPLoadUcode(OS_K0_TO_PHYSICAL(&##ucode##TextStart),		\
-		      OS_K0_TO_PHYSICAL(&##ucode##DataStart))
-#endif
-
-#ifdef	F3DEX_GBI_2
-/*
- * gSPDma_io  DMA to/from DMEM/IMEM for DEBUG.
- */
-#define	gSPDma_io(pkt, flag, dmem, dram, size)				\
-{									\
-	Gfx *_g = (Gfx *)(pkt);						\
-	_g->words.w0 = _SHIFTL(G_DMA_IO,24,8)|_SHIFTL((flag),23,1)|	\
-	  _SHIFTL((dmem)/8,13,10)|_SHIFTL((size)-1,0,12);		\
-	_g->words.w1 = (unsigned int)(dram);				\
-}
-
-#define	gsSPDma_io(flag, dmem, dram, size)				\
-{{									\
-	_SHIFTL(G_DMA_IO,24,8)|_SHIFTL((flag),23,1)|			\
-	_SHIFTL((dmem)/8,13,10)|_SHIFTL((size)-1,0,12),			\
-	(unsigned int)(dram)						\
-}}
-
-#define	gSPDmaRead(pkt,dmem,dram,size)	gSPDma_io((pkt),0,(dmem),(dram),(size))
-#define	gsSPDmaRead(dmem,dram,size)	gsSPDma_io(0,(dmem),(dram),(size))
-#define	gSPDmaWrite(pkt,dmem,dram,size)	gSPDma_io((pkt),1,(dmem),(dram),(size))
-#define	gsSPDmaWrite(dmem,dram,size)	gsSPDma_io(1,(dmem),(dram),(size))
-#endif
 
 /*
  * Lighting Macros
  */
-#ifdef	F3DEX_GBI_2
-# define NUML(n)	((n)*24)
-#else
-# define NUML(n)	(((n)+1)*32 + 0x80000000)
-#endif
+#define NUML(n)		(((n)+1)*32 + 0x80000000)
+
 #define NUMLIGHTS_0	1
 #define NUMLIGHTS_1	1
 #define NUMLIGHTS_2	2
@@ -2487,17 +1845,8 @@ typedef union {
  *       LIGHT_1 through LIGHT_3 will be the directional lights and light
  *       LIGHT_4 will be the ambient light.
  */
-#ifdef	F3DEX_GBI_2
-# define gSPLight(pkt, l, n)	\
-	  gDma2p((pkt),G_MOVEMEM,(l),sizeof(Light),G_MV_LIGHT,(n)*24+24)
-# define gsSPLight(l, n)	\
-	 gsDma2p(      G_MOVEMEM,(l),sizeof(Light),G_MV_LIGHT,(n)*24+24)
-#else	/* F3DEX_GBI_2 */
-# define gSPLight(pkt, l, n)	\
-	 gDma1p(pkt, G_MOVEMEM, l, sizeof(Light),((n)-1)*2+G_MV_L0)
-# define gsSPLight(l, n)	\
-	 gsDma1p(    G_MOVEMEM, l, sizeof(Light),((n)-1)*2+G_MV_L0)
-#endif	/* F3DEX_GBI_2 */
+#define	gSPLight(pkt, l, n)	gDma1p(pkt, G_MOVEMEM, l, sizeof(Light),((n)-1)*2+G_MV_L0)
+#define	gsSPLight(l, n)		gsDma1p(    G_MOVEMEM, l, sizeof(Light),((n)-1)*2+G_MV_L0)
 
 /*
  * gSPLightColor changes color of light without recalculating light direction
@@ -2651,25 +2000,11 @@ typedef union {
 /*
  * Reflection/Hiliting Macros
  */
-#ifdef	F3DEX_GBI_2
-# define gSPLookAtX(pkt, l)	\
-	 gDma2p((pkt),G_MOVEMEM,(l),sizeof(Light),G_MV_LIGHT,G_MVO_LOOKATX)
-# define gsSPLookAtX(l)		\
-	 gsDma2p(     G_MOVEMEM,(l),sizeof(Light),G_MV_LIGHT,G_MVO_LOOKATX)
-# define gSPLookAtY(pkt, l)	\
-	 gDma2p((pkt),G_MOVEMEM,(l),sizeof(Light),G_MV_LIGHT,G_MVO_LOOKATY)
-# define gsSPLookAtY(l)		\
-	 gsDma2p(     G_MOVEMEM,(l),sizeof(Light),G_MV_LIGHT,G_MVO_LOOKATY)
-#else	/* F3DEX_GBI_2 */
-# define gSPLookAtX(pkt, l)	\
-	 gDma1p(pkt, G_MOVEMEM, l, sizeof(Light),G_MV_LOOKATX)
-# define gsSPLookAtX(l)		\
-	 gsDma1p(    G_MOVEMEM, l, sizeof(Light),G_MV_LOOKATX)
-# define gSPLookAtY(pkt, l)	\
-	 gDma1p(pkt, G_MOVEMEM, l, sizeof(Light),G_MV_LOOKATY)
-# define gsSPLookAtY(l)		\
-	 gsDma1p(    G_MOVEMEM, l, sizeof(Light),G_MV_LOOKATY)
-#endif	/* F3DEX_GBI_2 */
+#define	gSPLookAtX(pkt, l)	gDma1p(pkt, G_MOVEMEM, l, sizeof(Light),G_MV_LOOKATX)
+#define	gsSPLookAtX(l)		gsDma1p(    G_MOVEMEM, l, sizeof(Light),G_MV_LOOKATX)
+
+#define	gSPLookAtY(pkt, l)	gDma1p(pkt, G_MOVEMEM, l, sizeof(Light),G_MV_LOOKATY)
+#define	gsSPLookAtY(l)		gsDma1p(    G_MOVEMEM, l, sizeof(Light),G_MV_LOOKATY)
 
 #define gSPLookAt(pkt, la)						\
 {									\
@@ -2683,11 +2018,16 @@ typedef union {
 #define gDPSetHilite1Tile(pkt, tile, hilite, width, height)		\
 	gDPSetTileSize(pkt, tile, (hilite)->h.x1 & 0xfff, (hilite)->h.y1 & 0xfff, 	\
 		((((width)-1)*4)+(hilite)->h.x1) & 0xfff, ((((height)-1)*4)+(hilite)->h.y1) & 0xfff)
+#define gsDPSetHilite1Tile(tile, hilite, width, height)			\
+	gsDPSetTileSize(tile, (hilite)->h.x1 & 0xfff, (hilite)->h.y1 & 0xfff, 		\
+		((((width)-1)*4)+(hilite)->h.x1) & 0xfff, ((((height)-1)*4)+(hilite)->h.y1) & 0xfff)
 
 #define gDPSetHilite2Tile(pkt, tile, hilite, width, height)		\
 	gDPSetTileSize(pkt, tile, (hilite)->h.x2 & 0xfff, (hilite)->h.y2 & 0xfff, 	\
 		((((width)-1)*4)+(hilite)->h.x2) & 0xfff, ((((height)-1)*4)+(hilite)->h.y2) & 0xfff)
-
+#define gsDPSetHilite2Tile(tile, hilite, width, height)			\
+	gsDPSetTileSize(tile, (hilite)->h.x2 & 0xfff, (hilite)->h.y2 & 0xfff, 		\
+		((((width)-1)*4)+(hilite)->h.x2) & 0xfff, ((((height)-1)*4)+(hilite)->h.y2) & 0xfff)
 
 /*
  * FOG macros
@@ -2720,113 +2060,55 @@ typedef union {
 		(_SHIFTL((128000/((max)-(min))),16,16) |		\
 		_SHIFTL(((500-(min))*256/((max)-(min))),0,16)))
 
-#ifdef	F3DEX_GBI_2
 /*
  * Macros to turn texture on/off
  */
-# define gSPTexture(pkt, s, t, level, tile, on)				\
+#define	gSPTexture(pkt, s, t, level, tile, on)				\
 {									\
 	Gfx *_g = (Gfx *)(pkt);						\
 									\
-	_g->words.w0 = (_SHIFTL(G_TEXTURE,24,8) | 			\
-			_SHIFTL(BOWTIE_VAL,16,8) |			\
-			_SHIFTL((level),11,3) | _SHIFTL((tile),8,3) |	\
-			_SHIFTL((on),1,7));				\
-	_g->words.w1 = (_SHIFTL((s),16,16) | _SHIFTL((t),0,16));	\
+	_g->words.w0 = (_SHIFTL(G_TEXTURE, 24, 8) | 			\
+			_SHIFTL(BOWTIE_VAL, 16, 8) |			\
+			_SHIFTL((level), 11, 3) | _SHIFTL((tile), 8, 3) |	\
+			_SHIFTL((on), 0, 8));				\
+	_g->words.w1 = (_SHIFTL((s), 16, 16) | _SHIFTL((t), 0, 16));	\
 }
-# define gsSPTexture(s, t, level, tile, on)				\
+
+#define	gsSPTexture(s, t, level, tile, on)				\
 {{									\
-	(_SHIFTL(G_TEXTURE,24,8) | _SHIFTL(BOWTIE_VAL,16,8) |		\
-	 _SHIFTL((level),11,3) | _SHIFTL((tile),8,3) | _SHIFTL((on),1,7)),\
-        (_SHIFTL((s),16,16) | _SHIFTL((t),0,16))			\
+	(_SHIFTL(G_TEXTURE, 24, 8) |  _SHIFTL(BOWTIE_VAL, 16, 8) |	\
+	 _SHIFTL((level), 11, 3) | _SHIFTL((tile), 8, 3) | _SHIFTL((on), 0, 8)),\
+        (_SHIFTL((s), 16, 16) | _SHIFTL((t), 0, 16))			\
 }}
+
 /* 
  * Different version of SPTexture macro, has an additional parameter
  * which is currently reserved in the microcode.
  */
-# define gSPTextureL(pkt, s, t, level, xparam, tile, on)		\
+#define	gSPTextureL(pkt, s, t, level, xparam, tile, on)			\
 {									\
 	Gfx *_g = (Gfx *)(pkt);						\
 									\
-	_g->words.w0 = (_SHIFTL(G_TEXTURE,24,8) | 			\
-			_SHIFTL((xparam),16,8) | 			\
-			_SHIFTL((level),11,3) | _SHIFTL((tile),8,3) |	\
-			_SHIFTL((on),1,7));				\
-	_g->words.w1 = (_SHIFTL((s),16,16) | _SHIFTL((t),0,16));	\
+	_g->words.w0 = (_SHIFTL(G_TEXTURE, 24, 8) | 			\
+			_SHIFTL((xparam), 16, 8) | 			\
+			_SHIFTL((level), 11, 3) | _SHIFTL((tile), 8, 3) |	\
+			_SHIFTL((on), 0, 8));				\
+	_g->words.w1 = (_SHIFTL((s), 16, 16) | _SHIFTL((t), 0, 16));	\
 }
-# define gsSPTextureL(s, t, level, xparam, tile, on)			\
-{{									\
-	(_SHIFTL(G_TEXTURE,24,8) | _SHIFTL((xparam),16,8) |		\
-	 _SHIFTL((level),11,3) | _SHIFTL((tile),8,3) | _SHIFTL((on),1,7)),\
-        (_SHIFTL((s),16,16) | _SHIFTL((t),0,16))			\
-}}
-#else
-/*
- * Macros to turn texture on/off
- */
-# define gSPTexture(pkt, s, t, level, tile, on)				\
-{									\
-	Gfx *_g = (Gfx *)(pkt);						\
-									\
-	_g->words.w0 = (_SHIFTL(G_TEXTURE,24,8)|_SHIFTL(BOWTIE_VAL,16,8)|\
-			_SHIFTL((level),11,3)|_SHIFTL((tile),8,3)|	\
-			_SHIFTL((on),0,8));				\
-	_g->words.w1 = (_SHIFTL((s),16,16)|_SHIFTL((t),0,16));		\
-}
-# define gsSPTexture(s, t, level, tile, on)				\
-{{									\
-	(_SHIFTL(G_TEXTURE,24,8)|_SHIFTL(BOWTIE_VAL,16,8)|		\
-	 _SHIFTL((level),11,3)|_SHIFTL((tile),8,3)|_SHIFTL((on),0,8)),	\
-        (_SHIFTL((s),16,16)|_SHIFTL((t),0,16))				\
-}}
-/* 
- * Different version of SPTexture macro, has an additional parameter
- * which is currently reserved in the microcode.
- */
-# define gSPTextureL(pkt, s, t, level, xparam, tile, on)		\
-{									\
-	Gfx *_g = (Gfx *)(pkt);						\
-									\
-	_g->words.w0 = (_SHIFTL(G_TEXTURE,24,8)|_SHIFTL((xparam),16,8)|	\
-			_SHIFTL((level),11,3)|_SHIFTL((tile),8,3)|	\
-			_SHIFTL((on),0,8));				\
-	_g->words.w1 = (_SHIFTL((s),16,16)|_SHIFTL((t),0,16));		\
-}
-# define gsSPTextureL(s, t, level, xparam, tile, on)			\
-{{									\
-	(_SHIFTL(G_TEXTURE,24,8)|_SHIFTL((xparam),16,8)|		\
-	 _SHIFTL((level),11,3)|_SHIFTL((tile),8,3)|_SHIFTL((on),0,8)),	\
-        (_SHIFTL((s),16,16)|_SHIFTL((t),0,16))				\
-}}
-#endif
 
-#ifdef F3D_OLD
-#define gSPPerspNormalize(pkt, s)					\
-{									\
-	Gfx *_g = (Gfx *)(pkt);						\
-									\
-	_g->words.w0 = _SHIFTL(G_PERSPNORM, 24, 8);			\
-	_g->words.w1 = (s);						\
-}
-#define gsSPPerspNormalize(s)						\
+#define	gsSPTextureL(s, t, level, xparam, tile, on)			\
 {{									\
-	_SHIFTL(G_PERSPNORM, 24, 8),					\
-	(s)								\
+	(_SHIFTL(G_TEXTURE, 24, 8) |  _SHIFTL((xparam), 16, 8) |		\
+	 _SHIFTL((level), 11, 3) | _SHIFTL((tile), 8, 3) | _SHIFTL((on), 0, 8)),\
+        (_SHIFTL((s), 16, 16) | _SHIFTL((t), 0, 16))			\
 }}
-#else
-#define gSPPerspNormalize(pkt, s)	gMoveWd(pkt, G_MW_PERSPNORM, 0, (s))
-#define gsSPPerspNormalize(s)		gsMoveWd(    G_MW_PERSPNORM, 0, (s))
-#endif
 
-#ifdef	F3DEX_GBI_2
-# define gSPPopMatrixN(pkt, n, num)	gDma2p((pkt),G_POPMTX,(num)*64,64,2,0)
-# define gsSPPopMatrixN(n, num)		gsDma2p(     G_POPMTX,(num)*64,64,2,0)
-# define gSPPopMatrix(pkt, n)		gSPPopMatrixN((pkt), (n), 1)
-# define gsSPPopMatrix(n)		gsSPPopMatrixN(      (n), 1)
-#else	/* F3DEX_GBI_2 */
-# define gSPPopMatrix(pkt, n)		gImmp1(pkt, G_POPMTX, n)
-# define gsSPPopMatrix(n)		gsImmp1(    G_POPMTX, n)
-#endif	/* F3DEX_GBI_2 */
+
+#define	gSPPerspNormalize(pkt, s)	gImmp1(pkt, G_PERSPNORMALIZE, s)
+#define	gsSPPerspNormalize(s)		gsImmp1(G_PERSPNORMALIZE, s)
+
+#define	gSPPopMatrix(pkt, n)			gImmp1(pkt, G_POPMTX, n)
+#define	gsSPPopMatrix(n)			gsImmp1(G_POPMTX, n)
 
 #define gSPEndDisplayList(pkt)						\
 {									\
@@ -2841,34 +2123,6 @@ typedef union {
 	_SHIFTL(G_ENDDL, 24, 8), 0					\
 }}
 
-#ifdef	F3DEX_GBI_2
-/*
- *	One gSPGeometryMode(pkt,c,s) GBI is equal to these two GBIs.
- *
- *		gSPClearGeometryMode(pkt,c)
- *		gSPSetGeometryMode(pkt,s)
- *
- *	gSPLoadGeometryMode(pkt, word) sets GeometryMode directly.
- */
-#define	gSPGeometryMode(pkt, c, s)					\
-{									\
-	Gfx *_g = (Gfx *)(pkt);						\
-	_g->words.w0 = _SHIFTL(G_GEOMETRYMODE,24,8)|_SHIFTL(~(u32)(c),0,24);\
-	_g->words.w1 = (u32)(s);					\
-}
-
-#define	gsSPGeometryMode(c, s)						\
-{{									\
-	(_SHIFTL(G_GEOMETRYMODE,24,8)|_SHIFTL(~(u32)(c),0,24)),(u32)(s)	\
-}}
-#define	gSPSetGeometryMode(pkt, word)	gSPGeometryMode((pkt),0,(word))
-#define	gsSPSetGeometryMode(word)	gsSPGeometryMode(0,(word))
-#define	gSPClearGeometryMode(pkt, word)	gSPGeometryMode((pkt),(word),0)
-#define	gsSPClearGeometryMode(word)	gsSPGeometryMode((word),0)
-#define	gSPLoadGeometryMode(pkt, word)	gSPGeometryMode((pkt),-1,(word))
-#define	gsSPLoadGeometryMode(word)	gsSPGeometryMode(-1,(word))
-
-#else	/* F3DEX_GBI_2 */
 #define	gSPSetGeometryMode(pkt, word)					\
 {									\
 	Gfx *_g = (Gfx *)(pkt);						\
@@ -2894,23 +2148,7 @@ typedef union {
 {{									\
 	_SHIFTL(G_CLEARGEOMETRYMODE, 24, 8), (unsigned int)(word)	\
 }}
-#endif	/* F3DEX_GBI_2 */
 
-#ifdef	F3DEX_GBI_2
-#define	gSPSetOtherMode(pkt, cmd, sft, len, data)			\
-{									\
-	Gfx *_g = (Gfx *)(pkt);						\
-	_g->words.w0 = (_SHIFTL(cmd,24,8)|_SHIFTL(32-(sft)-(len),8,8)|	\
-			_SHIFTL((len)-1,0,8));				\
-	_g->words.w1 = (unsigned int)(data);				\
-}
-
-#define	gsSPSetOtherMode(cmd, sft, len, data)				\
-{{									\
-	_SHIFTL(cmd,24,8)|_SHIFTL(32-(sft)-(len),8,8)|_SHIFTL((len)-1,0,8), \
-	(unsigned int)(data)						\
-}}
-#else
 #define	gSPSetOtherMode(pkt, cmd, sft, len, data)			\
 {									\
 	Gfx *_g = (Gfx *)(pkt);						\
@@ -2925,7 +2163,6 @@ typedef union {
 	_SHIFTL(cmd, 24, 8) | _SHIFTL(sft, 8, 8) | _SHIFTL(len, 0, 8),	\
 	(unsigned int)(data)						\
 }}
-#endif
 
 /*
  * RDP setothermode register commands - register shadowed in RSP
@@ -3195,53 +2432,10 @@ typedef union {
 	 _SHIFTL(a, 0, 8))						\
 }}
 
-/*
- * gDPSetOtherMode (This is for expert user.)
- *
- * This command makes all othermode parameters set.
- * Do not use this command in the same DL with another g*SPSetOtherMode DLs.
- * 
- * [Usage]
- *	gDPSetOtherMode(pkt, modeA, modeB)
- *
- *      'modeA' is described all parameters of GroupA GBI command.
- *      'modeB' is also described all parameters of GroupB GBI command.
- *
- *	GroupA:
- *	  gDPPipelineMode, gDPSetCycleType, gSPSetTexturePersp,
- *	  gDPSetTextureDetail, gDPSetTextureLOD, gDPSetTextureLUT,
- *	  gDPSetTextureFilter, gDPSetTextureConvert, gDPSetCombineKey,
- *	  gDPSetColorDither, gDPSetAlphaDither
- *
- *	GroupB:
- *	  gDPSetAlphaCompare, gDPSetDepthSource, gDPSetRenderMode
- *
- *	Use 'OR' operation to get modeA and modeB.
- *
- *	modeA = G_PM_* | G_CYC_* | G_TP_* | G_TD_* | G_TL_* | G_TT_* | G_TF_*
- *		G_TC_* | G_CK_*  | G_CD_* | G_AD_*;
- *
- *	modeB = G_AC_* | G_ZS_*  | G_RM_* | G_RM_*2;
- */
-#define	gDPSetOtherMode(pkt, mode0, mode1)				\
-{									\
-	Gfx *_g = (Gfx *)(pkt);						\
-									\
-	_g->words.w0 = _SHIFTL(G_RDPSETOTHERMODE,24,8)|_SHIFTL(mode0,0,24);\
-	_g->words.w1 = (unsigned int)(mode1);				\
-}
-
-#define	gsDPSetOtherMode(mode0, mode1)					\
-{{									\
-	_SHIFTL(G_RDPSETOTHERMODE,24,8)|_SHIFTL(mode0,0,24),		\
-	(unsigned int)(mode1)						\
-}}
 
 /*
  * Texturing macros
  */
-
-/* These are also defined defined above for Sprite Microcode */
 
 #define	G_TX_LOADTILE	7
 #define	G_TX_RENDERTILE	0
@@ -3292,7 +2486,7 @@ typedef union {
 		(((1 << G_TX_DXT_FRAC) + TXL2WORDS(width, b_txl) - 1) / \
 					TXL2WORDS(width, b_txl))
 
-#define TXL2WORDS_4b(txls)	MAX(1, ((txls)/16))
+#define TXL2WORDS_4b(txls)	((txls)/16)
 #define CALC_DXT_4b(width)	\
 		(((1 << G_TX_DXT_FRAC) + TXL2WORDS_4b(width) - 1) / \
 					TXL2WORDS_4b(width))
@@ -4383,7 +3577,7 @@ typedef union {
 #define gsDPSetConvert(k0, k1, k2, k3, k4, k5)				\
 {{									\
 	(_SHIFTL(G_SETCONVERT, 24, 8) |					\
-	 _SHIFTL(k0, 13, 9) | _SHIFTL(k1, 4, 9) | _SHIFTR(k2, 5, 4)),	\
+	 _SHIFTL(k0, 13, 9) | _SHIFTL(k1, 4, 9) | _SHIFTL(k2, 5, 4)),	\
 	(_SHIFTL(k2, 27, 5) | _SHIFTL(k3, 18, 9) | _SHIFTL(k4, 9, 9) | 	\
 	 _SHIFTL(k5, 0, 9))						\
 }}
@@ -4463,19 +3657,6 @@ typedef union {
     _SHIFTL(dsdx, 16, 16) | _SHIFTL(dtdy, 0, 16)			\
 }}
 
-#define gDPTextureRectangle(pkt, xl, yl, xh, yh, tile, s, t, dsdx, dtdy)\
-{									\
-    Gfx *_g = (Gfx *)(pkt);						\
-    if (pkt);								\
-    _g->words.w0 = (_SHIFTL(G_TEXRECT, 24, 8) | _SHIFTL(xh, 12, 12) |	\
-		    _SHIFTL(yh, 0, 12));    				\
-    _g->words.w1 = (_SHIFTL(tile, 24, 3) | _SHIFTL(xl, 12, 12) |	\
-		    _SHIFTL(yl, 0, 12));				\
-    _g ++;								\
-    _g->words.w0 = (_SHIFTL(s, 16, 16) | _SHIFTL(t, 0, 16));		\
-    _g->words.w1 = (_SHIFTL(dsdx, 16, 16) | _SHIFTL(dtdy, 0, 16));	\
-}
-
 #define gsDPTextureRectangleFlip(xl, yl, xh, yh, tile, s, t, dsdx, dtdy) \
 {{									\
     (_SHIFTL(G_TEXRECTFLIP, 24, 8) | _SHIFTL(xh, 12, 12) |		\
@@ -4487,18 +3668,6 @@ typedef union {
     _SHIFTL(dsdx, 16, 16) | _SHIFTL(dtdy, 0, 16)			\
 }}
 
-#define gDPTextureRectangleFlip(pkt, xl, yl, xh, yh, tile, s, t, dsdx, dtdy)\
-{									\
-    Gfx *_g = (Gfx *)(pkt);						\
-    if (pkt);								\
-    _g->words.w0 = (_SHIFTL(G_TEXRECTFLIP, 24, 8) | _SHIFTL(xh, 12, 12) | \
-		    _SHIFTL(yh, 0, 12));    				\
-    _g->words.w1 = (_SHIFTL(tile, 24, 3) | _SHIFTL(xl, 12, 12) |	\
-		    _SHIFTL(yl, 0, 12));				\
-    _g ++;								\
-    _g->words.w0 = (_SHIFTL(s, 16, 16) | _SHIFTL(t, 0, 16));		\
-    _g->words.w1 = (_SHIFTL(dsdx, 16, 16) | _SHIFTL(dtdy, 0, 16));	\
-}
 
 #define gsSPTextureRectangle(xl, yl, xh, yh, tile, s, t, dsdx, dtdy)	\
     {{(_SHIFTL(G_TEXRECT, 24, 8) | _SHIFTL(xh, 12, 12) | _SHIFTL(yh, 0, 12)),\
@@ -4519,31 +3688,19 @@ typedef union {
 }
 
 /* like gSPTextureRectangle but accepts negative position arguments */
-#define gSPScisTextureRectangle(pkt, xl, yl, xh, yh, tile, s, t, dsdx, dtdy) \
-{                                                                            \
-    Gfx *_g = (Gfx *)(pkt);                                                  \
-                                                                             \
-    _g->words.w0 = (_SHIFTL(G_TEXRECT, 24, 8) |                              \
-                    _SHIFTL(MAX((s16)(xh),0), 12, 12) |                      \
-                    _SHIFTL(MAX((s16)(yh),0), 0, 12));                       \
-    _g->words.w1 = (_SHIFTL((tile), 24, 3) |                                 \
-                    _SHIFTL(MAX((s16)(xl),0), 12, 12) |                      \
-                    _SHIFTL(MAX((s16)(yl),0), 0, 12));                       \
-    gImmp1(pkt, G_RDPHALF_1,                                                 \
-                (_SHIFTL(((s) -                                              \
-                          (((s16)(xl) < 0) ?                                 \
-                           (((s16)(dsdx) < 0) ?                              \
-                            (MAX((((s16)(xl)*(s16)(dsdx))>>7),0)) :          \
-			    (MIN((((s16)(xl)*(s16)(dsdx))>>7),0))) : 0)),    \
-			 16, 16) |                                           \
-                 _SHIFTL(((t) -                                              \
-                          (((yl) < 0) ?                                      \
-                           (((s16)(dtdy) < 0) ?                              \
-                            (MAX((((s16)(yl)*(s16)(dtdy))>>7),0)) :          \
-                            (MIN((((s16)(yl)*(s16)(dtdy))>>7),0))) : 0)),    \
-			 0, 16)));                                           \
-    gImmp1(pkt, G_RDPHALF_2, (_SHIFTL((dsdx), 16, 16) |                      \
-                              _SHIFTL((dtdy), 0, 16)));                      \
+#define gSPScisTextureRectangle(pkt, xl, yl, xh, yh, tile, s, t, dsdx, dtdy)  \
+{									\
+    Gfx *_g = (Gfx *)(pkt);						\
+									\
+    _g->words.w0 = (_SHIFTL(G_TEXRECT, 24, 8) | 			\
+		    _SHIFTL(MAX((xh),0), 12, 12) | _SHIFTL(MAX((yh),0), 0, 12)); \
+    _g->words.w1 = (_SHIFTL((tile), 24, 3) |				     \
+		    _SHIFTL(MAX((xl),0), 12, 12) | _SHIFTL(MAX((yl),0), 0, 12)); \
+    gImmp1(pkt, G_RDPHALF_1, 						     \
+		(_SHIFTL(((s) - (MIN((((xl)*(dsdx))>>7),0))), 16, 16) |	     \
+		_SHIFTL(((t) - (MIN((((yl)*(dtdy))>>7),0))), 0, 16)));	     \
+    gImmp1(pkt, G_RDPHALF_2, 						     \
+		(_SHIFTL((dsdx), 16, 16) |	_SHIFTL((dtdy), 0, 16)));	     \
 }
 
 #define gsSPTextureRectangleFlip(xl, yl, xh, yh, tile, s, t, dsdx, dtdy) \

--- a/include/PR/gu.h
+++ b/include/PR/gu.h
@@ -256,15 +256,4 @@ typedef struct {
     u32    paddr;
 } guDLPrintCB;
 
-void guSprite2DInit(uSprite *SpritePointer,   
-		    void *SourceImagePointer,
-		    void *TlutPointer,
-		    int Stride,
-		    int SubImageWidth,
-		    int SubImageHeight,
-		    int SourceImageType,
-		    int SourceImageBitSize,
-		    int SourceImageOffsetS,
-		    int SourceImageOffsetT);
-
 #endif /* !_GU_H_ */

--- a/include/f3ddkr.h
+++ b/include/f3ddkr.h
@@ -200,10 +200,19 @@
     _g->words.w1 = rgba;                          \
 }
 
-#if defined(F3DDKR_GBI)
- // ?????? - Needed to modify this to work with matching material_init
-#undef TXL2WORDS_4b
-#define TXL2WORDS_4b(txls) ((txls)/16)
-#endif
+// DKR Uses these macros, from later gbi.h files
+#define	gDPSetOtherMode(pkt, mode0, mode1)				\
+{									\
+	Gfx *_g = (Gfx *)(pkt);						\
+									\
+	_g->words.w0 = _SHIFTL(G_RDPSETOTHERMODE,24,8)|_SHIFTL(mode0,0,24);\
+	_g->words.w1 = (unsigned int)(mode1);				\
+}
+
+#define	gsDPSetOtherMode(mode0, mode1)					\
+{{									\
+	_SHIFTL(G_RDPSETOTHERMODE,24,8)|_SHIFTL(mode0,0,24),		\
+	(unsigned int)(mode1)						\
+}}
 
 #endif

--- a/src/hasm/entrypoint.s
+++ b/src/hasm/entrypoint.s
@@ -7,9 +7,10 @@
 
 .section .bss
 
+.equ entrypointThreadStackSize, 0x1000
 glabel entrypointThreadStack
-.space 0x1000
-glabel entrypointThreadStackEnd
+.space entrypointThreadStackSize
+.size entrypointThreadStack, entrypointThreadStackSize
 
 .section .text, "ax"
 
@@ -25,10 +26,10 @@ sw         $zero, 0x4($t0)
 bnez       $t1, .clear_bytes
  addi      $t0, $t0, 0x8
 lui        $t2, %hi(mainproc)
-lui        $sp, %hi(entrypointThreadStackEnd)
+lui        $sp, %hi(entrypointThreadStack + entrypointThreadStackSize)
 addiu      $t2, $t2, %lo(mainproc)
 jr         $t2
- addiu     $sp, $sp, %lo(entrypointThreadStackEnd)
+ addiu     $sp, $sp, %lo(entrypointThreadStack + entrypointThreadStackSize)
 nop
 nop
 nop

--- a/src/hasm/math_util.s
+++ b/src/hasm/math_util.s
@@ -1576,6 +1576,7 @@ negu       $v0, $v0
 jr         $ra
 nop
 .end coss_s16
+.size sins_s16, . - sins_s16
 
 /* Official Name: mathCos */
 leaf coss_2
@@ -1603,6 +1604,7 @@ negu       $v0, $v0
 jr         $ra
 nop
 .end coss_2
+.size sins_2, . - sins_2
 
 leaf calc_dyn_lighting_for_level_segment
 lw         $t1, 0x0($a1)

--- a/src/lights.c
+++ b/src/lights.c
@@ -57,7 +57,8 @@ void lights_init(s32 count) {
     lights_free();
     gMaxLights = count;
     buffer = (u8 *) mempool_alloc_safe(
-        gMaxLights * (sizeof(s32 *) + sizeof(ObjectLight) + sizeof(ObjectLightShadeProperties) + sizeof(Vec3f)), COLOUR_TAG_MAGENTA);
+        gMaxLights * (sizeof(s32 *) + sizeof(ObjectLight) + sizeof(ObjectLightShadeProperties) + sizeof(Vec3f)),
+        COLOUR_TAG_MAGENTA);
 
     temp = gMaxLights;
     gActiveLights = (ObjectLight **) buffer;
@@ -239,7 +240,8 @@ UNUSED void light_toggle(ObjectLight *light) {
 /**
  * Initialises a gradual change of colour for a light source.
  */
-UNUSED void light_setup_colour_change(ObjectLight *light, s32 targetR, s32 diffR, s32 targetG, s32 diffG, s32 targetB, s32 diffB) {
+UNUSED void light_setup_colour_change(ObjectLight *light, s32 targetR, s32 diffR, s32 targetG, s32 diffG, s32 targetB,
+                                      s32 diffB) {
     if (diffR > 0) {
         light->targetColourDiffR = diffR;
         light->targetColourChangeRateR = ((targetR << 0x10) - light->colourR) / diffR;
@@ -484,8 +486,9 @@ void light_update_shading(Object *object) {
 
         for (i = 0; i < gNumActiveLights; i++) {
             light = gActiveLights[i];
-            if ((light->unk2 & objTypeMask) && (light->enabled == TRUE) && (objX >= light->minX) && (light->maxX >= objX) &&
-                (objY >= light->minY) && (light->maxY >= objY) && (objZ >= light->minZ) && (light->maxZ >= objZ)) {
+            if ((light->unk2 & objTypeMask) && (light->enabled == TRUE) && (objX >= light->minX) &&
+                (light->maxX >= objX) && (objY >= light->minY) && (light->maxY >= objY) && (objZ >= light->minZ) &&
+                (light->maxZ >= objZ)) {
                 if (light->unk0 == 0) {
                     if (light->intensity >= 0x10000) {
                         gShadeBuffer[numLights].lightObj = light;

--- a/src/object_functions.c
+++ b/src/object_functions.c
@@ -5443,10 +5443,12 @@ void obj_init_audio(Object *obj, LevelObjectEntry_Audio *entry) {
     audio->soundMask = NULL;
     if (sound_is_looped(audio->soundId)) {
         audspat_point_create(audio->soundId, entry->common.x, entry->common.y, entry->common.z, 9, audio->minVolume,
-                             audio->volume, audio->range, audio->fastFalloff, audio->pitch, audio->priority, &audio->soundMask);
+                             audio->volume, audio->range, audio->fastFalloff, audio->pitch, audio->priority,
+                             &audio->soundMask);
     } else {
         audspat_point_create(audio->soundId, entry->common.x, entry->common.y, entry->common.z, 10, audio->minVolume,
-                             audio->volume, audio->range, audio->fastFalloff, audio->pitch, audio->priority, &audio->soundMask);
+                             audio->volume, audio->range, audio->fastFalloff, audio->pitch, audio->priority,
+                             &audio->soundMask);
     }
     free_object(obj);
 }

--- a/src/objects.h
+++ b/src/objects.h
@@ -352,7 +352,7 @@ u8 has_ghost_to_save(void);
 void set_ghost_none(void);
 f32 racer_calc_distance_to_opponent(Object_Racer *racer1, Object_Racer *racer2);
 CheckpointNode *get_checkpoint_node(s32 checkpointID);
-CheckpointNode *find_next_checkpoint_node(s32 splinePos, s32 arg1);
+CheckpointNode *find_next_checkpoint_node(s32 splinePos, s32 isAlternate);
 s32 get_checkpoint_count(void);
 Object **get_racer_objects(s32 *numRacers);
 Object **get_racer_objects_by_port(s32 *numRacers);
@@ -368,8 +368,8 @@ void set_world_shading(f32 ambient, f32 diffuse, s16 angleX, s16 angleY, s16 ang
 void set_shading_properties(ShadeProperties *arg0, f32 ambient, f32 diffuse, s16 angleX, s16 angleY, s16 angleZ);
 void obj_shade_fancy(ObjectModel *model, Object *object, s32 arg2, f32 intensity);
 s32 *get_misc_asset(s32 index);
-s32 is_bridge_raised(s32 arg0);
-void start_bridge_timer(s32 arg0);
+s32 is_bridge_raised(s32 index);
+void start_bridge_timer(s32 index);
 void obj_bridge_pos(s32 timing, f32 *x, f32 *y, f32 *z);
 s16 cutscene_id(void);
 void cutscene_id_set(s32 cutsceneID);
@@ -437,8 +437,8 @@ void obj_init_animobject(Object *, Object *);
 Object *obj_butterfly_node(f32 x, f32 y, f32 z, f32 maxDistCheck, s32 dontCheckYAxis);
 void func_8002125C(Object *obj, LevelObjectEntry_Animation *entry, Object_AnimatedObject *animObj, UNUSED s32 index);
 void func_80021104(Object *obj, Object_AnimatedObject *animObj, LevelObjectEntry_Animation *entry);
-s32 homing_rocket_get_next_direction(Object *obj, s32 checkpoint, u8 arg2, s32 arg3, s32 arg4, f32 checkpointDist, f32 *outX, f32 *outY,
-                  f32 *outZ);
+s32 homing_rocket_get_next_direction(Object *obj, s32 checkpoint, u8 isOnAlternateRoute, s32 arg3, s32 arg4,
+                                     f32 checkpointDist, f32 *outX, f32 *outY, f32 *outZ);
 void func_80016500(Object *obj, Object_Racer *racer);
 void track_spawn_objects(s32, s32);
 u8 timetrial_init_staff_ghost(s32 trackId);
@@ -487,7 +487,8 @@ Object *spawn_object(LevelObjectEntryCommon *entry, s32);
 s32 func_8001F460(Object *, s32, Object *);
 void func_8000B750(Object *racerObj, s32 racerIndex, s32 vehicleIDPrev, s32 boostType, s32 arg4);
 void func_80018CE0(Object *racerObj, f32 xPos, f32 yPos, f32 zPos, s32 updateRate);
-s32 checkpoint_is_passed(s32 checkpointIndex, Object *obj, f32 objX, f32 objY, f32 objZ, f32 *arg5, u8 *arg6);
+s32 checkpoint_is_passed(s32 checkpointIndex, Object *obj, f32 objX, f32 objY, f32 objZ, f32 *checkpointDistance,
+                         u8 *isOnAlternateRoute);
 void obj_tex_animate(Object *, s32);
 Object *find_furthest_telepoint(f32 x, f32 z);
 void model_init_collision(ObjectModel *);

--- a/src/set_rsp_segment.c
+++ b/src/set_rsp_segment.c
@@ -2,6 +2,7 @@
 #include "PR/gbi.h"
 #include "PR/mbi.h"
 #include "PR/R4300.h"
+#include <PR/ultratypes.h>
 
 /**
  * Set the offset for the given address, so the RSP can get the correct physical address.

--- a/src/set_rsp_segment.h
+++ b/src/set_rsp_segment.h
@@ -2,6 +2,7 @@
 #define _SET_RSP_SEGMENT_H_
 
 #include "PR/gbi.h"
+#include <PR/ultratypes.h>
 
 /**
  * Normally, in F3D, RSP segments go up to 16.

--- a/src/tracks.c
+++ b/src/tracks.c
@@ -4344,7 +4344,7 @@ void update_fog(s32 viewportCount, s32 updateRate) {
 void apply_fog(s32 playerID) {
     gDPSetFogColor(gTrackDL++, gFogData[playerID].fog.r >> 0x10, gFogData[playerID].fog.g >> 0x10,
                    gFogData[playerID].fog.b >> 0x10, 0xFF);
-    gSPFogPosition(gTrackDL++, gFogData[playerID].fog.near >> 0x10, gFogData[playerID].fog.far >> 0x10);
+    gSPFogPosition(gTrackDL++, (gFogData[playerID].fog.near >> 0x10), (gFogData[playerID].fog.far >> 0x10));
 }
 
 /**


### PR DESCRIPTION
This PR will change the gbi.h to match one found in an older version of libultra, specifically version E. This is done because it turns out we know they based their gbi.h on that version due to a specific change done to the `TXL2WORDS_4b` macro. That macro was updated in all later versions of this file, and we require the older version without the MAX.

This also cleans up our gbi.h to remove references to F3DEX2 which we don't use anyway.

