### PR TITLE
Match trackbg_render_flashy

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -5410,7 +5410,9 @@ s32 func_80017A18(ObjectModel *arg0, s32 arg1, s32 *arg2, f32 *arg3, f32 *arg4, 
     s32 counter;
     s32 spF8; // f8
     s32 var_s6;
-    f32 A2, C2;
+    CollisionFacetPlanes *node;
+    s32 triIndex;
+    s32 closestTri;
     f32 A; // e4
     f32 B; // e0
     f32 C; // dc
@@ -5425,10 +5427,6 @@ s32 func_80017A18(ObjectModel *arg0, s32 arg1, s32 *arg2, f32 *arg3, f32 *arg4, 
     f32 x2; // a4
     f32 y2; // a0
     f32 z2; // 9c
-    CollisionNode *node;
-    f32 dx, dy, dz;
-    s32 triIndex;
-    s32 closestTri;
 
     spF8 = 0;
     planes = arg0->collisionPlanes;
@@ -5438,38 +5436,34 @@ s32 func_80017A18(ObjectModel *arg0, s32 arg1, s32 *arg2, f32 *arg3, f32 *arg4, 
         x1 = arg6[i];
         y1 = arg7[i];
         z1 = arg8[i];
+        y3 = arg3[i];
+        z3 = arg4[i];
+        sum2 = arg5[i];
         spC0 = arg9[i] * argB;
 
         counter = 0;
         do {
             redoLoop = FALSE;
-            x2 = arg3[i];
-            y2 = arg4[i];
-            z2 = arg5[i];
+            x2 = y3;
+            y2 = z3;
+            z2 = sum2;
 
             for (j = 0; j < arg0->collisionFacetCount; j++) {
-                node = (CollisionNode *) &arg0->collisionFacets[j];
-                triIndex = node->colPlaneIndex;
+                node = &arg0->collisionFacets[j];
+                triIndex = node->basePlaneIndex;
 
                 A = planes[4 * triIndex + 0];
                 B = planes[4 * triIndex + 1];
                 C = planes[4 * triIndex + 2];
                 D = planes[4 * triIndex + 3];
 
-                A2 = A * x2;
-                sum1 = A2;
-                sum1 += B * y2;
-                C2 = C * z2;
-                sum1 += C2;
-                sum1 = D + sum1;
-                sum1 -= spC0;
-
-                sum2 = planes[4 * triIndex + 0] * x1;
-                sum2 += planes[4 * triIndex + 1] * y1;
-                sum2 += planes[4 * triIndex + 2] * z1;
+                sum2 = A * x2 + B * y2;
+                sum1 = sum2 + C * z2 + D - spC0;
+                sum2 = A * x1 + B * y1 + C * z1;
                 sum2 += D;
                 sum2 -= spC0;
                 if (sum1 >= -0.1 && sum2 < -0.1) {
+                    var_a2 = TRUE;
                     if (sum1 != sum2) {
                         t = sum1 / (sum1 - sum2);
                     } else {
@@ -5478,17 +5472,17 @@ s32 func_80017A18(ObjectModel *arg0, s32 arg1, s32 *arg2, f32 *arg3, f32 *arg4, 
                     x3 = (x1 - x2) * t + x2;
                     y3 = (y1 - y2) * t + y2;
                     z3 = (z1 - z2) * t + z2;
-                    var_a2 = TRUE;
 
                     for (k = 0; k < 3 && var_a2 == TRUE; k++) {
-                        closestTri = node->closestTri[k];
+                        closestTri = node->edgeBisectorPlane[k];
 
-                        A1 = planes[4 * closestTri + 0] * x3;
-                        B1 = planes[4 * closestTri + 1] * y3;
-                        C1 = planes[4 * closestTri + 2] * z3;
+                        A1 = planes[4 * closestTri + 0];
+                        B1 = planes[4 * closestTri + 1];
+                        C1 = planes[4 * closestTri + 2];
                         D1 = planes[4 * closestTri + 3];
 
-                        if (A1 + B1 + C1 + D1 > 4.0f) {
+                        t = A1 * x3 + B1 * y3 + C1 * z3 + D1;
+                        if (t > 4.0f) {
                             var_a2 = FALSE;
                         }
                     }
@@ -5496,7 +5490,7 @@ s32 func_80017A18(ObjectModel *arg0, s32 arg1, s32 *arg2, f32 *arg3, f32 *arg4, 
                     if (var_a2) {
                         redoLoop = TRUE;
                         if (B > 0.707) {
-                            y1 = (spC0 - (A2 + C2 + D)) / B;
+                            y1 = (spC0 - (A * x1 + C * z1 + D)) / B;
                         } else {
                             x1 -= sum2 * A;
                             y1 -= sum2 * B;
@@ -5517,6 +5511,9 @@ s32 func_80017A18(ObjectModel *arg0, s32 arg1, s32 *arg2, f32 *arg3, f32 *arg4, 
                     }
                 }
             }
+            sum2 = z2;
+            z3 = y2;
+            y3 = x2;
         } while (redoLoop);
 
         if (counter > 0) {

--- a/src/tracks.c
+++ b/src/tracks.c
@@ -1351,8 +1351,6 @@ void set_skydome_visbility(s32 renderSky) {
     gSceneRenderSkyDome = renderSky;
 }
 
-// https://decomp.me/scratch/E1DFy
-#ifdef NON_MATCHING
 // This function creates the flashy sky effect in the wizpig 2 race.
 void trackbg_render_flashy(void) {
     Triangle *tris;
@@ -1383,10 +1381,10 @@ void trackbg_render_flashy(void) {
     s16 vertY;
     s16 vTempCoord;
     s16 uTempCoord;
-    LevelHeader_70 *levelHeader;
-    LevelHeader_70 *var_t2; // sp7C
-    LevelHeader_70 *sp78;
-    TextureHeader *texHeader; // sp74
+    LevelHeader_70 *pad2;
+    LevelHeader_70 *var_t2;      // sp7C
+    LevelHeader_70 *levelHeader; // sp78
+    TextureHeader *texHeader;    // sp74
     s32 pad[4];
 
     verts = gTrackVtxPtr;
@@ -1401,47 +1399,51 @@ void trackbg_render_flashy(void) {
 
     scaledXSin = xSin * 1280.0f;
     scaledXCos = xCos * 1280.0f;
+    pad_sp100 = 2.0f * scaledXSin;
     xPositions[0] = -scaledXCos - (xSin * 1280.0f);
     zPositions[0] = -scaledXCos + (xSin * 1280.0f);
     xPositions[1] = scaledXCos - (xSin * 1280.0f);
     zPositions[1] = -scaledXCos - (xSin * 1280.0f);
-    xPositions[2] = scaledXCos + (xSin * 1280.0f);
+    xPositions[2] = scaledXCos + scaledXSin;
     zPositions[2] = scaledXCos - (xSin * 1280.0f);
     xPositions[3] = -scaledXCos + (xSin * 1280.0f);
-    zPositions[3] = scaledXCos + scaledXSin;
+    zPositions[3] = scaledXCos + (xSin * 1280.0f);
     xPositions[4] = 0.0f;
     zPositions[4] = 0.0f;
 
-    zPositions[5] = scaledXSin - (2.0f * scaledXCos);
-    xPositions[6] = scaledXCos - (2.0f * scaledXSin);
-    zPositions[6] = -(2.0f * scaledXCos) - scaledXSin;
-    xPositions[5] = -scaledXCos - (2.0f * scaledXSin);
-    xPositions[7] = scaledXCos + (2.0f * scaledXSin);
-    zPositions[7] = (2.0f * scaledXCos) - scaledXSin;
-    xPositions[8] = -scaledXCos + (2.0f * scaledXSin);
-    zPositions[8] = (2.0f * scaledXCos) + scaledXSin;
+    xPositions[5] = -(xCos * 1280.0f) - (2.0f * scaledXSin);
+    zPositions[5] = scaledXSin + -(2.0f * (xCos * 1280.0f));
+    xPositions[6] = (xCos * 1280.0f) - (2.0f * scaledXSin);
+    zPositions[6] = -(2.0f * (xCos * 1280.0f)) - scaledXSin;
+    xPositions[7] = (xCos * 1280.0f) + (2.0f * scaledXSin);
+    zPositions[7] = (2.0f * (xCos * 1280.0f)) - scaledXSin;
+    xPositions[8] = -(xCos * 1280.0f) + (2.0f * scaledXSin);
+    zPositions[8] = (2.0f * (xCos * 1280.0f)) + scaledXSin;
 
-    var_f14 = 1280.0f;
-    var_f14 *= 0.25f;
+    scaledXCos = 1280.0f;
+    var_f14 = scaledXCos * 0.25f;
 
     var_a1 = texHeader->width * 16 * gCurrentLevelHeader2->unkA0;
     var_a2 = texHeader->height * 16 * gCurrentLevelHeader2->unkA1;
 
-    var_v0 = ((s32) (camera->trans.x_position * (var_f14 / var_a1)) + (gCurrentLevelHeader2->unkA8 >> 4)) & uCoordMask;
-    var_v1 = ((s32) (camera->trans.z_position * (var_f14 / var_a2)) + (gCurrentLevelHeader2->unkAA >> 4)) & vCoordMask;
+    var_v0 = ((s32) (camera->trans.x_position * ((scaledXCos * 0.25f) / var_a1)) + (gCurrentLevelHeader2->unkA8 >> 4)) &
+             uCoordMask;
+    var_v1 = ((s32) (camera->trans.z_position * ((scaledXCos * 0.25f) / var_a2)) + (gCurrentLevelHeader2->unkAA >> 4)) &
+             vCoordMask;
 
     var_f14 = var_a1 * xCos;
     pos.z = var_a1 * xCos;
     pos.x = var_a1 * xCos;
     var_f16 = var_a2 * xSin;
     xCos = var_f16;
+    pad_sp108 = var_f16;
 
     // @fake
     var_a2 = texHeader->height * 16 * gCurrentLevelHeader2->unkA1;
 
-    uCoords[0] = (s16) (-var_f14 - xCos) + var_v0;
+    uCoords[0] = (s16) (-var_f14 - pad_sp108) + var_v0;
     vCoords[0] = (s16) (var_f16 - var_f14) + var_v1;
-    uCoords[1] = (s16) (var_f14 - xCos) + var_v0;
+    uCoords[1] = (s16) (var_f14 - pad_sp108) + var_v0;
     vCoords[1] = (s16) (-var_f14 - var_f16) + var_v1;
     uCoords[2] = (s16) (var_f14 + var_f16) + var_v0;
     vCoords[2] = (s16) (var_f14 - var_f16) + var_v1;
@@ -1455,7 +1457,7 @@ void trackbg_render_flashy(void) {
     vCoords[5] = (s16) (var_f16 - (2.0f * var_f14)) + var_v1;
     uCoords[6] = (s16) (var_f14 - (2.0f * xCos)) + var_v0;
     vCoords[6] = (s16) ((-(2.0f * var_f14)) - var_f16) + var_v1;
-    uCoords[7] = (s16) ((2.0f * xCos) + pos.z) + var_v0;
+    uCoords[7] = (s16) (pos.f[2] + (2.0f * xCos)) + var_v0;
     vCoords[7] = (s16) ((2.0f * pos.x) - var_f16) + var_v1;
     uCoords[8] = (s16) ((2.0f * xCos) - pos.z) + var_v0;
     vCoords[8] = (s16) ((2.0f * pos.x) + var_f16) + var_v1;
@@ -1471,7 +1473,6 @@ void trackbg_render_flashy(void) {
             levelHeader = var_t2;
         }
     } else {
-        levelHeader = sp78; // @bug? sp78 is never set
         var_t2 = NULL;
     }
 
@@ -1526,9 +1527,6 @@ void trackbg_render_flashy(void) {
     gTrackVtxPtr = verts;
     gTrackTriPtr = tris;
 }
-#else
-#pragma GLOBAL_ASM("asm/nonmatchings/tracks/trackbg_render_flashy.s")
-#endif
 
 /**
  * Instead of drawing the skydome with textures, draw a solid coloured background.


### PR DESCRIPTION
Matches `trackbg_render_flashy` (byte-identical on us.v80, full ROM Verify: OK, GLOBAL_ASM removed), and reworks the `func_80017A18` WIP — asm-differ 8591 -> 4651, with the frame, k-loop, and all named-variable registers now exact.

The tracks match came from tracing uopt's register allocator (ido-static-recomp with two libc shims added unlocks the `-zdbug` dumps while keeping output byte-identical): allocation ties break by expression-table creation order, so the dead `pad_sp100`/`pad_sp108` defs emit no code but flip the f16/f18 tie that blocked this function. The other changes pin down operand order and constant folding the same way. Bonus: the old `@bug? sp78` comment is resolved — that's the compiler reloading a genuinely-uninitialized variable slot, not a game bug.

Heads up on CI: the red checks die at the checkout step — GitHub now blocks fork checkouts in `pull_request_target` workflows by default (needs `allow-unsafe-pr-checkout: true` or a workflow restructure). Nothing was compiled; locally the matching build, NM=1, and NON_EQUIVALENT=1 are all clean.

One measurement note that bit us: enable only one WIP function at a time when scoring — multiple enabled WIPs shift ROM addresses and inflate everyone's asm-differ numbers.
