### PR TITLE
Add allow-unsafe-pr-checkout to workflows.

### DIFF
--- a/.github/workflows/UpdateScore.yml
+++ b/.github/workflows/UpdateScore.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+        allow-unsafe-pr-checkout: true
 
       - name: Install packages
         run: |

--- a/.github/workflows/VerifyAllVersions.yml
+++ b/.github/workflows/VerifyAllVersions.yml
@@ -17,6 +17,7 @@ jobs:
           submodules: recursive
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+        allow-unsafe-pr-checkout: true
 
       - name: Install packages
         run: |

--- a/.github/workflows/VerifyBuild.yml
+++ b/.github/workflows/VerifyBuild.yml
@@ -17,6 +17,7 @@ jobs:
           submodules: recursive
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+        allow-unsafe-pr-checkout: true
 
       - name: Install packages
         run: |

--- a/.github/workflows/VerifyNonEquivalent.yml
+++ b/.github/workflows/VerifyNonEquivalent.yml
@@ -17,6 +17,7 @@ jobs:
           submodules: recursive
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+        allow-unsafe-pr-checkout: true
 
       - name: Install packages
         run: |

--- a/.github/workflows/VerifyNonMatching.yml
+++ b/.github/workflows/VerifyNonMatching.yml
@@ -17,6 +17,7 @@ jobs:
           submodules: recursive
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+        allow-unsafe-pr-checkout: true
 
       - name: Install packages
         run: |

--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ As of July 24, 2026, this is our current score:
 
 <details>
 
+<summary> Fedora based Linux distros </summary>
+
+Most dependencies should already be installed by default (in fedora 44). Only thing needed was pcre2.
+
+`sudo dnf install pcre2 pcre2-devel`
+
+</details>
+
+
+<details>
+
 <summary> Arch based Linux distros </summary>
 
 `sudo pacman -Syu --needed base-devel pkgconf git python python-pip python-virtualenv pcre2 yay`

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -8,10 +8,10 @@ endif
 
 CC := gcc
 CXX := g++
-CFLAGS := -I . -Wall -Wextra -Wno-unused-parameter -pedantic -std=c99 $(OPT) -s
+CFLAGS := -I . -Wall -Wextra -Wno-unused-parameter -Wno-sfinae-incomplete -pedantic -std=c99 $(OPT) -s
 # List of specific errors to ignore
 IGNORE_W_ERRORS := -Wno-unused-parameter -Wno-misleading-indentation -Wno-extra
-CXXFLAGS := -I . -I dkr_assets_tool_src/ -std=c++17 $(OPT)
+CXXFLAGS := -I . -I dkr_assets_tool_src/ -Wno-sfinae-incomplete -std=c++17 $(OPT)
 LDFLAGS := -lm
 PROGRAMS := n64crc dkr_assets_tool
 


### PR DESCRIPTION
Should be the easiest way to get ci stuff working again. Also added `-Wno-sfinae-incomplete` flag to dkr_assets_tool build flags to fix a build error.