### PR TITLE
match: func_8008FF1C

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -8812,26 +8812,30 @@ void trackmenu_render_2D(s32 x, s32 y, char *hubName, char *trackName, s32 rectO
     rendermode_reset(&sMenuCurrDisplayList);
 }
 
-// https://decomp.me/scratch/bQDRA
-#ifdef NON_MATCHING
 // trackmenu_render_names
+// Indexing gTrackSelectRenderDetails directly (rather than walking a pointer)
+// is what lets uopt prove the hubName store cannot alias gTrackSelectIDs, which
+// is what puts that store in the branch delay slot. The literal -1 inner bound
+// gives uopt the trip count, so the index still strength-reduces to a single
+// advancing pointer. Both are required to match.
 void func_8008FF1C(UNUSED s32 updateRate) {
     s32 i; // sp7C
-    char *trackName;
-    char *hubName;
-    s32 selectedTrack;
+    char *pad0;
+    char *pad1;
+    s32 pad2;
     s32 trackSelectX;
     s32 trackSelectY;
     char *levelName;
     s32 maxTrackY;
     s8 *trackMenuIds;
     Settings *settings; // sp58
-    TrackRenderDetails *cur;
+    TrackRenderDetails *pad3;
     s32 trackX;
     s32 trackY;
     s32 j;
     s32 startIndex;
-    s16 temp;
+    s16 pad4;
+    s32 k;
 
     settings = get_settings();
     trackMenuIds = (s8 *) get_misc_asset(ASSET_MISC_TRACKS_MENU_IDS);
@@ -8848,72 +8852,70 @@ void func_8008FF1C(UNUSED s32 updateRate) {
     trackY = (gTrackSelectY / -gTrackSelectViewportY);
     trackSelectY = trackY - 1;
     startIndex = -1;
-    for (i = startIndex, cur = gTrackSelectRenderDetails; i < 2; i++) {
-        for (j = startIndex; j < 2; j++, cur++) {
+    k = 0;
+    for (i = startIndex; i < 2; i++) {
+        trackY = trackSelectY + i + 1;
+        for (j = -1; j < 2; j++, k++) {
             trackX = trackSelectX + j;
-            trackY = trackSelectY;
             if (trackY < 0 || maxTrackY < trackY || trackX < 0 || trackX >= 6) {
-                cur->visible = 0;
+                gTrackSelectRenderDetails[k].visible = 0;
             } else {
-                cur->visible = 1;
+                gTrackSelectRenderDetails[k].visible = 1;
                 levelName = level_name(level_world_id(trackY + 1));
-                temp = (temp = gTrackSelectIDs[trackY][trackX]); // ????
-                selectedTrack = gTrackSelectIDs[trackY][trackX];
-                cur->hubName = levelName;
-                if (selectedTrack != -1) {
-                    cur->trackName = level_name(trackMenuIds[((trackY * 6) + trackX)]);
+                gTrackSelectRenderDetails[k].hubName = levelName;
+                if (gTrackSelectIDs[trackY][trackX] != -1) {
+                    gTrackSelectRenderDetails[k].trackName = level_name(trackMenuIds[((trackY * 6) + trackX)]);
                     if (trackX == 4) {
                         if ((((settings->trophies) >> (trackY * 2)) & 3) == 3) {
-                            cur->visible = 2;
+                            gTrackSelectRenderDetails[k].visible = 2;
                         }
                     } else if ((settings->courseFlagsPtr[trackMenuIds[((trackY * 6) + trackX)]] & 2)) {
-                        cur->visible = 2;
+                        gTrackSelectRenderDetails[k].visible = 2;
                     }
                 } else {
-                    cur->trackName = gQMarkPtr;
+                    gTrackSelectRenderDetails[k].trackName = gQMarkPtr;
                 }
-                cur->xOff = ((trackX * 320) - gTrackSelectX);
-                cur->yOff = ((-trackY * gTrackSelectViewportY) - gTrackSelectY);
-                cur->opacity = 0xFF;
+                gTrackSelectRenderDetails[k].xOff = ((trackX * 320) - gTrackSelectX);
+                gTrackSelectRenderDetails[k].yOff = ((-trackY * gTrackSelectViewportY) - gTrackSelectY);
+                gTrackSelectRenderDetails[k].opacity = 0xFF;
                 if ((trackX == gSelectedTrackX) && (trackY == gSelectedTrackY)) {
-                    cur->copyViewPort = (cur->copyViewPort & 0xFF) | 0x80;
+                    gTrackSelectRenderDetails[k].copyViewPort = (gTrackSelectRenderDetails[k].copyViewPort & 0xFF) | 0x80;
                     if (gOpacityDecayTimer < 32) {
-                        cur->opacity = gOpacityDecayTimer * 8;
+                        gTrackSelectRenderDetails[k].opacity = gOpacityDecayTimer * 8;
                     }
                 } else {
-                    cur->copyViewPort = cur->copyViewPort & 0xFF7F;
+                    gTrackSelectRenderDetails[k].copyViewPort = gTrackSelectRenderDetails[k].copyViewPort & 0xFF7F;
                 }
-                cur->copyViewPort = cur->copyViewPort & 0xFF80;
+                gTrackSelectRenderDetails[k].copyViewPort = gTrackSelectRenderDetails[k].copyViewPort & 0xFF80;
                 if (gMenuDelay == 0) {
                     if (trackY > 0) {
-                        cur->copyViewPort = (((cur->copyViewPort & 0xFF) | 1) & 0x7F) | (cur->copyViewPort & 0xFF80);
+                        gTrackSelectRenderDetails[k].copyViewPort = (gTrackSelectRenderDetails[k].copyViewPort & 0xFF80) | (((gTrackSelectRenderDetails[k].copyViewPort & 0xFF) | 1) & 0x7F);
                     }
                     if (trackX < 5) {
-                        cur->copyViewPort = (((cur->copyViewPort & 0xFF) | 2) & 0x7F) | (cur->copyViewPort & 0xFF80);
+                        gTrackSelectRenderDetails[k].copyViewPort = (gTrackSelectRenderDetails[k].copyViewPort & 0xFF80) | (((gTrackSelectRenderDetails[k].copyViewPort & 0xFF) | 2) & 0x7F);
                     }
                     if (trackY < maxTrackY) {
-                        cur->copyViewPort = (((cur->copyViewPort & 0xFF) | 4) & 0x7F) | (cur->copyViewPort & 0xFF80);
+                        gTrackSelectRenderDetails[k].copyViewPort = (gTrackSelectRenderDetails[k].copyViewPort & 0xFF80) | (((gTrackSelectRenderDetails[k].copyViewPort & 0xFF) | 4) & 0x7F);
                     }
                     if (trackX > 0) {
-                        cur->copyViewPort = (((cur->copyViewPort & 0xFF) | 8) & 0x7F) | (cur->copyViewPort & 0xFF80);
+                        gTrackSelectRenderDetails[k].copyViewPort = (gTrackSelectRenderDetails[k].copyViewPort & 0xFF80) | (((gTrackSelectRenderDetails[k].copyViewPort & 0xFF) | 8) & 0x7F);
                     }
                     if (trackX == 4 && trackY == 4) {
-                        cur->copyViewPort = ((cur->copyViewPort & 0xFF & 0xFF) & 0x7D) | (cur->copyViewPort & 0xFF80);
+                        gTrackSelectRenderDetails[k].copyViewPort = (gTrackSelectRenderDetails[k].copyViewPort & 0xFF80) | ((gTrackSelectRenderDetails[k].copyViewPort & 0xFF & 0xFF) & 0x7D);
                     }
                     if (trackX == 5 && trackY == 3) {
-                        cur->copyViewPort = ((cur->copyViewPort & 0xFF & 0xFF) & 0x7B) | (cur->copyViewPort & 0xFF80);
+                        gTrackSelectRenderDetails[k].copyViewPort = (gTrackSelectRenderDetails[k].copyViewPort & 0xFF80) | ((gTrackSelectRenderDetails[k].copyViewPort & 0xFF & 0xFF) & 0x7B);
                     }
                 }
                 if (trackX == 4) {
-                    cur->border = 6;
+                    gTrackSelectRenderDetails[k].border = 6;
                 } else if (trackX == 5) {
-                    cur->border = 5;
+                    gTrackSelectRenderDetails[k].border = 5;
                 } else {
-                    cur->border = 4;
+                    gTrackSelectRenderDetails[k].border = 4;
                 }
             }
         }
-        trackSelectY++;
     }
     camDisableUserView(0, TRUE);
     menu_camera_centre();
@@ -8935,9 +8937,6 @@ void func_8008FF1C(UNUSED s32 updateRate) {
     }
     gTrackSelectVertsFlip = 1 - gTrackSelectVertsFlip;
 }
-#else
-#pragma GLOBAL_ASM("asm/nonmatchings/menu/func_8008FF1C.s")
-#endif
 
 /**
  * If the track hasn't been loaded already, tell thread30 to load the track in the background.

--- a/src/menu.c
+++ b/src/menu.c
@@ -8813,11 +8813,6 @@ void trackmenu_render_2D(s32 x, s32 y, char *hubName, char *trackName, s32 rectO
 }
 
 // trackmenu_render_names
-// Indexing gTrackSelectRenderDetails directly (rather than walking a pointer)
-// is what lets uopt prove the hubName store cannot alias gTrackSelectIDs, which
-// is what puts that store in the branch delay slot. The literal -1 inner bound
-// gives uopt the trip count, so the index still strength-reduces to a single
-// advancing pointer. Both are required to match.
 void func_8008FF1C(UNUSED s32 updateRate) {
     s32 i; // sp7C
     char *pad0;


### PR DESCRIPTION
Matches `func_8008FF1C` (`trackmenu_render_names`) in `menu.c`.

ROM builds and verifies:

```
CRC 1: 0xE402430D  Calculated: 0xE402430D  (Good)
CRC 2: 0xD2FCFC9D  Calculated: 0xD2FCFC9D  (Good)
Verify: OK
sha1: 6d96743d46f8c0cd0edb0ec5600b003c89b93755
```

371/371 instruction words, no differences.

## Notes on the source

Two things look odd but are required, so I left a comment on the function:

- The loop indexes `gTrackSelectRenderDetails[k]` instead of walking a `cur`
  pointer. That is what lets uopt prove the `hubName` store cannot alias
  `gTrackSelectIDs`, which is what puts that store in the branch delay slot.
  With a pointer walk the store is emitted ahead of the load instead, and the
  whole tail of the function shifts by one instruction.
- The inner loop bound is a literal `-1` rather than `startIndex`. That gives
  uopt the trip count, so the index still strength-reduces to a single
  advancing pointer and costs nothing. With the variable it does not, and the
  row base gets recomputed every outer iteration.

`trackY` is computed from `i` at the top of the outer loop rather than being
carried in `trackSelectY`, which keeps `trackY + 1` out of the inner loop's
invariant set.

The five `pad` locals are unused but load-bearing for stack layout; removing
them changes the frame and breaks the match.