### PR TITLE
Document vsprintf

### DIFF
--- a/src/printf.c
+++ b/src/printf.c
@@ -232,7 +232,11 @@ UNUSED int sprintf(char *s, const char *format, ...) {
 
 #define isdigit(c) ((c >= '0') && (c <= '9'))
 
-// Returns the total number of characters written.
+/**
+ * Formats a variable argument list into a null-terminated string.
+ * Inserts debug text control codes around numeric values when fixed-width spacing is enabled.
+ * Returns the number of characters written, excluding the null terminator.
+ */
 int vsprintf(char *s, const char *fmt, va_list args) {
     /* Pointer into the format string.  */
     const char *f;


### PR DESCRIPTION
## Summary

Document `vsprintf`, including its fixed-width debug text control codes and return value.

## Testing

- `clang-format --dry-run --Werror -style=file src/printf.c`
- `gmake -j8 REGION=us VERSION=v80` (`Verify: OK`)
- `./score.sh -a 2 -v us.v80` (67.20%)
