### PR TITLE
Fix undefined behaviour in non-matching builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,14 @@ As of July 25, 2026, this is our current score:
 
 <summary> Ubuntu / Debian based Linux distros </summary>
 
-`sudo apt install build-essential pkg-config git python3 python3-pip binutils-mips-linux-gnu python3-venv libpcre2-dev libpcre2-8-0`
+`sudo apt install build-essential libssl-dev pkg-config git curl python3 python3-pip binutils-mips-linux-gnu gcc-mips-linux-gnu python3-venv libpcre2-dev libpcre2-8-0`
 
 - `build-essential` / `pkg-config` are helper packages needed for make.
 - `git` is used for version control.
+- `curl` downloads the IDO recomp during setup.
 - `python3` is needed to run python scripts
 - `libpcre2-dev` and `libpcre2-8-0` are not technically required, but will speedup extracting/building some assets significantly.
-- `gcc-mips-linux-gnu` is optionally used if compiling NON_MATCHING with COMPILER=gcc
+- `gcc-mips-linux-gnu` is used when compiling a non-matching build with `COMPILER=gcc`.
 
 </details>
 
@@ -97,27 +98,45 @@ Windows is not natively supported. We recommend using a linux distro under the W
 6. Run `make` in the main directory.  
    **a.** Use the `-jN` argument to use `N` number of threads to speed up building. For example, if you have a system with 4 cores / 4 threads, you should do `make -j4`.
 
+The resulting ROM is written to `build/dkr.<region>.<version>.z64`. Run that ROM in a compatible Nintendo 64 emulator or on supported hardware; this repository does not produce a native desktop executable.
+
 Note: If you are on MacOS, remember to use `gmake` instead of `make`!
 
 ---
 
 ### Building other versions
 
-To build other versions of the ROM, just specifcy the region and version in the make command. All examples are below:
-Baserom|REGION|VERSION|Command
----|--|---|-
-US 1.0 | US | v77 | `make REGION=us VERSION=v77`
-PAL 1.0 | PAL | v77 | `make REGION=pal VERSION=v77`
-JPN 1.0 | JPN | v79 | `make REGION=jpn VERSION=v79`
-US 1.1 | US | v80 | `make REGION=us VERSION=v80`
-PAL 1.1 | PAL | v80 | `make REGION=pal VERSION=v80`
+To build another version of the ROM, pass the same region and version to both the extraction and build commands:
+
+Baserom|REGION|VERSION|Extraction|Build
+---|--|---|---|-
+US 1.0 | US | v77 | `make cleanextract REGION=us VERSION=v77` | `make REGION=us VERSION=v77`
+PAL 1.0 | PAL | v77 | `make cleanextract REGION=pal VERSION=v77` | `make REGION=pal VERSION=v77`
+JPN 1.0 | JPN | v79 | `make cleanextract REGION=jpn VERSION=v79` | `make REGION=jpn VERSION=v79`
+US 1.1 | US | v80 | `make cleanextract REGION=us VERSION=v80` | `make REGION=us VERSION=v80`
+PAL 1.1 | PAL | v80 | `make cleanextract REGION=pal VERSION=v80` | `make REGION=pal VERSION=v80`
 
 ## Modding
 
-If you are modifying the code in the repo, then you should add `NON_MATCHING=1` to the make command.  
-Example: `make NON_MATCHING=1 -j4`
+If you are modifying the code in the repo, then you should add `NON_MATCHING=1` to the make command:
+
+```sh
+make clean
+make NON_MATCHING=1 -j4
+```
 
 The `NON_MATCHING` define will include the functions that don't exactly match one-to-one, but should be no different functionality-wise. If you do notice any bugs that occur in a `NON_MATCHING` build that are not in the vanilla game, then please file an issue describing the bug. It would be helpful if you can track down which function is causing the bug, but that is not required.
+
+To compile the game code with GCC instead of IDO, use a MIPS cross-compiler:
+
+```sh
+make clean
+make COMPILER=gcc -j4
+```
+
+`COMPILER=gcc` automatically enables `NON_MATCHING`. It requires a compatible MIPS GCC in your `PATH`; the host GCC or Clang compiler is only used for syntax checks. There is no Clang target compiler option.
+
+Always run `make clean` when switching between matching, `NON_MATCHING`, and GCC builds because they share the `build` directory.
 
 ## Style Guide
 

--- a/src/camera.c
+++ b/src/camera.c
@@ -28,12 +28,19 @@ s8 gAntiPiracyViewport = FALSE;
 
 #define SCISSOR_INTERLACE G_SC_NON_INTERLACE
 
+#ifdef AVOID_UB
+// viewport_reset uses index 4 for the full-screen viewport.
+ScreenViewport gScreenViewports[5] = {
+    { DEFAULT_VIEWPORT }, { DEFAULT_VIEWPORT }, { DEFAULT_VIEWPORT }, { DEFAULT_VIEWPORT }, { DEFAULT_VIEWPORT },
+};
+#else
 ScreenViewport gScreenViewports[4] = {
     { DEFAULT_VIEWPORT },
     { DEFAULT_VIEWPORT },
     { DEFAULT_VIEWPORT },
     { DEFAULT_VIEWPORT },
 };
+#endif
 
 u32 gViewportWithBG = FALSE;
 

--- a/src/game.c
+++ b/src/game.c
@@ -427,10 +427,10 @@ void level_load(s32 levelId, s32 numberOfPlayers, s32 entranceId, Vehicle vehicl
             if (gCurrentLevelHeader->world > WORLD_CENTRAL_AREA && gCurrentLevelHeader->world < WORLD_FUTURE_FUN_LAND) {
                 var_s0 = gCurrentLevelHeader->world;
                 if (settings->keys & (1 << var_s0) &&
-                    !(settings->cutsceneFlags & (CUTSCENE_DINO_DOMAIN_KEY << (var_s0 + 31)))) {
+                    !(settings->cutsceneFlags & (CUTSCENE_DINO_DOMAIN_KEY << (var_s0 - 1)))) {
                     // Trigger World Key unlocking Challenge Door cutscene.
                     level_properties_push(levelId, entranceId, vehicleId, cutsceneId);
-                    settings->cutsceneFlags |= CUTSCENE_DINO_DOMAIN_KEY << (var_s0 + 31);
+                    settings->cutsceneFlags |= CUTSCENE_DINO_DOMAIN_KEY << (var_s0 - 1);
                     someAsset = (s8 *) get_misc_asset(ASSET_MISC_68);
                     levelId = someAsset[var_s0 - 1];
                     entranceId = 0;
@@ -509,7 +509,11 @@ void level_load(s32 levelId, s32 numberOfPlayers, s32 entranceId, Vehicle vehicl
     set_vehicle_id_for_menu(vehicleId);
     if (gCurrentLevelHeader->race_type == RACETYPE_HUBWORLD) {
         if (settings->worldId - 1 >= 0) {
+#ifdef AVOID_UB
+            var_s0 = 8 << (settings->worldId - 1);
+#else
             var_s0 = 8 << (settings->worldId + 31);
+#endif
             if (settings->worldId == 5) {
                 if (settings->balloonsPtr[0] >= 47) {
                     if (settings->ttAmulet >= 4) {

--- a/src/menu.c
+++ b/src/menu.c
@@ -44,6 +44,10 @@
 // The bss section needs to stay above the data section!
 // Otherwise the bss variables will get reordered, which is bad.
 
+#ifdef AVOID_UB
+#define TRACK_SELECT_ROWS 5
+#endif
+
 // A huge unfortunate issue has occurred which seems to have reordered the BSS for JP... Not sure why.
 #if REGION == REGION_JP
 // START OF JPN BSS ORDER
@@ -183,10 +187,16 @@ unk80126878 D_80126878[8];
 f32 D_801268D8;
 UNUSED s32 D_801268DC; // Set to 0 during the title screen, never read.
 s32 gOpeningNameID;
+#ifdef AVOID_UB
+// The fifth row overlaps gFFLUnlocked and the two words after it in the matching BSS.
+s16 gTrackSelectIDs[TRACK_SELECT_ROWS][6];
+#define gFFLUnlocked gTrackSelectIDs[4][0]
+#else
 s16 gTrackSelectIDs[4][6]; // Track Select values?
 s16 gFFLUnlocked;
 UNUSED s32 D_80128464;
 UNUSED s32 D_80128468;
+#endif
 s32 gTrackSelectVertsFlip;
 UNUSED s32 D_80126928; // Set to 64, but never used.
 UNUSED s32 D_8012692C; // Set to 32, but never used.
@@ -397,10 +407,16 @@ f32 D_801268D8;
 UNUSED s32 D_801268DC; // Set to 0 during the title screen, never read.
 s32 gOpeningNameID;
 UNUSED s32 D_801268E4;
+#ifdef AVOID_UB
+// The fifth row overlaps gFFLUnlocked and the two words after it in the matching BSS.
+s16 gTrackSelectIDs[TRACK_SELECT_ROWS][6];
+#define gFFLUnlocked gTrackSelectIDs[4][0]
+#else
 s16 gTrackSelectIDs[4][6]; // Track Select values?
 s16 gFFLUnlocked;
 UNUSED s32 D_8012691C;
 UNUSED s32 D_80126920;
+#endif
 s32 gTrackSelectVertsFlip;
 UNUSED s32 D_80126928; // Set to 64, but never used.
 UNUSED s32 D_8012692C; // Set to 32, but never used.

--- a/src/objects.c
+++ b/src/objects.c
@@ -1512,7 +1512,7 @@ void track_setup_racers(Vehicle vehicle, u32 entranceID, s32 playerCount) {
             // Taj will teleport straight to the player to initiate a challenge.
             if (j) {
                 set_taj_voice_line(SOUND_VOICE_TAJ_CHALLENGE_RACE);
-                settings->tajFlags |= 1 << (j + 31);
+                settings->tajFlags |= 1 << (j - 1);
                 set_taj_status(TAJ_TELEPORT);
                 set_next_taj_challenge_menu(j);
                 safe_mark_write_save_file(get_save_file_index());

--- a/src/waves.c
+++ b/src/waves.c
@@ -101,8 +101,18 @@ s32 gWaveTileCountZ;    // used in mempool_alloc_safe size calculation
 s32 gNumberOfLevelSegments;
 s32 D_8012A0E8[64];
 s16 gWaveBlockIDs[512]; // used to index gWaveModel and as arg0 for func_800B92F4 and func_800B97A8
+#ifdef AVOID_UB
+// D_8012A5E8 and D_8012A600 are adjacent parts of one table in the matching BSS.
+// Code indexes D_8012A5E8 across that boundary.
+#define WAVE_VISIBILITY_HEAD_COUNT 2
+#define WAVE_VISIBILITY_TAIL_COUNT 24
+unk8012A5E8 D_8012A5E8[WAVE_VISIBILITY_HEAD_COUNT + WAVE_VISIBILITY_TAIL_COUNT];
+#define D_8012A600 (&D_8012A5E8[WAVE_VISIBILITY_HEAD_COUNT])
+#else
 unk8012A5E8 D_8012A5E8[2];
 unk8012A5E8 D_8012A600[24];
+#define WAVE_VISIBILITY_TAIL_COUNT ARRAY_COUNT(D_8012A600)
+#endif
 f32 gWavePowerBase;
 f32 gWaveMagnitude;
 s32 gWavePowerDivisor;
@@ -426,7 +436,7 @@ void waves_visibility(s32 xPosition, s32 yPosition, s32 zPosition, s32 currentVi
 
     if (0) {}
 
-    for (var_v1 = 0; var_v1 != ARRAY_COUNT(D_8012A600); var_v1 += 4) {
+    for (var_v1 = 0; var_v1 != WAVE_VISIBILITY_TAIL_COUNT; var_v1 += 4) {
         D_8012A5E8[0].blockID = -1;
         D_8012A5E8[1].blockID = -1;
         D_8012A600[var_v1].blockID = -1;


### PR DESCRIPTION
## Summary

- use defined shift counts for progression flags, directly where IDO still produces matching code
- keep the track-select and wave-visibility tables contiguous when compiled by optimising C compilers
- keep the full-screen viewport used by `viewport_reset` inside `gScreenViewports`
- document clean build-mode switching, MIPS GCC setup, required packages, and version-specific extraction

## Why

The original MIPS shifts rely on the CPU masking variable shift counts. In C, those same counts are undefined behaviour, so an optimising compiler can remove progression-state writes.

Two tables also rely on separately declared BSS objects being adjacent. C does not guarantee that layout, which can corrupt track-select and wave-visibility indexing in non-matching builds.

`viewport_reset` also selects viewport 4 from a four-element array. The matching layout happens to provide usable data after that array, but this is an out-of-bounds read in C.

IDO produces matching code with `- 1` for the key and Taj flag shifts across all five versions, so those expressions do not need conditional code. The `8 << (worldId - 1)` expression changes code generation in all five versions, so that one retains its original matching expression behind `AVOID_UB`.

The table and viewport fixes remain limited to `AVOID_UB`.

## Verification

- [x] matching `Verify: OK`: US v77, PAL v77, JPN v79, US v80, PAL v80
- [x] tested each direct `- 1` cleanup separately; `8 << (worldId - 1)` grows `level_load` by one instruction and fails to match all five versions
- [x] Linux x86 `-m32` host syntax checks for the changed C sources (US and JPN)
- [x] `make NON_MATCHING=1 -j8`
- [x] Ubuntu 24.04 / MIPS GCC 12: `make COMPILER=gcc -j4`
- [x] inspected optimised MIPS objects: progression writes remain; table sizes are 60 and 312 bytes; the viewport array is 260 bytes
- [x] ares smoke test: retail, IDO non-matching, and GCC ROMs followed the same scripted route through title, game select, and track select; GCC also reached an in-game race
- [x] `clang-format --dry-run --Werror src/camera.c src/game.c src/menu.c src/objects.c src/waves.c`
- [x] `git diff --check origin/master...HEAD`
